### PR TITLE
fix: pre-flight model availability check before benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pre-flight model availability check (#19)** — when a server lists a model
+  in `/v1/models` but fails to actually serve it (e.g. vLLM returns 400
+  "Model not found" on inference), the benchmark previously produced
+  misleading scores (1 passed, 11 partial, 72 failed) because 4xx responses
+  were treated as "model returned no tool calls" by the adapter.  A new
+  `_preflight_model_check()` sends a trivial 1-token chat completion after
+  model detection and before warm-up.  If the server returns 4xx/5xx, the
+  benchmark aborts with a clear error (exit code 3) instead of running
+  84 scenarios against a broken endpoint.  New `MODEL_NOT_AVAILABLE` error
+  code added to `domain/errors.py` for structured `--json` output.
+
 ### Changed
 
 - **TC-48 evaluator tightened** — models that merge CC correctly but skip

--- a/src/tool_eval_bench/cli/bench.py
+++ b/src/tool_eval_bench/cli/bench.py
@@ -95,6 +95,7 @@ from tool_eval_bench.domain.errors import (
     DETECTION_FAILED,
     HTTP_ERROR,
     INVALID_RESPONSE,
+    MODEL_NOT_AVAILABLE,
     NO_MODELS,
     NO_SERVER,
 )
@@ -386,6 +387,96 @@ async def _plain_on_result(
 ) -> None:
     style = STATUS_STYLE.get(result.status, "?")
     print(f"{style}  ({result.points}/2) {DIM}{result.summary}{RESET}")
+
+
+# ---------------------------------------------------------------------------
+# Pre-flight model availability check (issue #19)
+# ---------------------------------------------------------------------------
+
+
+def _preflight_model_check(
+    console: Console,
+    base_url: str,
+    model: str,
+    api_key: str | None,
+    *,
+    headless: bool = False,
+) -> None:
+    """Send a trivial chat completion to verify the model is actually usable.
+
+    Some servers (vLLM, LiteLLM) list models in ``/v1/models`` even when they
+    fail to load — returning HTTP 400 "Model not found" on the first real
+    request.  Without this check, the benchmark silently produces misleading
+    pass/partial/fail scores because 4xx responses are treated as "model
+    returned no tool calls" by the adapter.
+
+    This function sends a minimal 1-token completion request.  If the server
+    returns 4xx/5xx, we abort with a clear error before any scenarios run.
+
+    Exits with code 3 (model error) on failure.
+    """
+    import httpx
+
+    from tool_eval_bench.utils.urls import chat_completions_url as _chat_url
+
+    url = _chat_url(base_url)
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Say hello."},
+        ],
+        "max_tokens": 1,
+        "temperature": 0.0,
+    }
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    async def _check() -> httpx.Response:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            return await client.post(url, json=payload, headers=headers)
+
+    try:
+        resp = asyncio.run(_check())
+        if resp.status_code >= 400:
+            body = resp.text[:300].strip()
+            if headless:
+                _headless_error(
+                    MODEL_NOT_AVAILABLE,
+                    f"Model '{model}' is listed in /v1/models but returned "
+                    f"HTTP {resp.status_code} on a test request: {body}",
+                    exit_code=3,
+                )
+            console.print("[bold red]✗ Model not available[/]")
+            console.print(
+                f"[red]Model '{model}' is listed in /v1/models but returned "
+                f"HTTP {resp.status_code} on a test request.[/]"
+            )
+            console.print(f"[dim]  {body}[/]")
+            console.print(
+                "\n[yellow]The server lists this model but cannot serve it. "
+                "Check server logs for model loading errors.[/]"
+            )
+            sys.exit(3)
+    except httpx.ConnectError:
+        if headless:
+            _headless_error(
+                CONNECTION_FAILED,
+                f"Could not connect to {base_url} for pre-flight check.",
+                exit_code=2,
+            )
+        console.print(f"[bold red]✗ Cannot connect to {base_url}[/]")
+        sys.exit(2)
+    except Exception as exc:
+        if headless:
+            _headless_error(
+                MODEL_NOT_AVAILABLE,
+                f"Pre-flight check failed with unexpected error: {exc}",
+                exit_code=3,
+            )
+        console.print(f"[bold red]✗ Pre-flight check failed:[/] {exc}")
+        sys.exit(3)
 
 
 # ---------------------------------------------------------------------------
@@ -2134,6 +2225,11 @@ def main() -> None:
         except KeyboardInterrupt:
             pass
         return
+
+    # -- Pre-flight: verify the model actually works (issue #19) --
+    # Some servers list models in /v1/models but fail on real requests.
+    # Without this check, the benchmark produces misleading scores.
+    _preflight_model_check(console, base_url, model, api_key, headless=args.json)
 
     # -- Warm-up --
     if not args.no_warmup and not args.json:

--- a/src/tool_eval_bench/domain/errors.py
+++ b/src/tool_eval_bench/domain/errors.py
@@ -32,6 +32,12 @@ INVALID_RESPONSE = "invalid_response"
 NO_MODELS = "no_models"
 """Server responded but the model list is empty — no models loaded."""
 
+MODEL_NOT_AVAILABLE = "model_not_available"
+"""Model is listed in /v1/models but returns an error (4xx/5xx) when actually
+used for inference.  This catches the case where a model appears loaded but
+fails on real requests — without this check the benchmark silently produces
+misleading pass/partial/fail scores (issue #19)."""
+
 # -- Discovery errors (exit code 1) -----------------------------------------
 NO_SERVER = "no_server"
 """Auto-discovery found no responsive inference server on localhost."""


### PR DESCRIPTION
## Problem (Closes #19)

When a server lists a model in `/v1/models` but fails to actually serve it (e.g. vLLM returns `400 "Model not found"` on inference), the benchmark silently produced misleading scores — `1 passed, 11 partial, 72 failed` — because 4xx responses were treated as "model returned no tool calls" by the adapter.

This made it impossible to distinguish between:
- A genuinely bad model
- A model that didn't load at all

## Fix

Adds `_preflight_model_check()` — a trivial 1-token chat completion sent **after** model detection and **before** warm-up/scenarios. If the server returns 4xx/5xx, the benchmark aborts immediately.

### Behavior

| Mode | Output | Exit Code |
|------|--------|-----------|
| Interactive | Clear error message with HTTP status + body | 3 |
| `--json` | Structured `{"error": "model_not_available", ...}` event on stderr | 3 |

### Changes

- **`domain/errors.py`**: New `MODEL_NOT_AVAILABLE` error constant
- **`cli/bench.py`**: New `_preflight_model_check()` function, called between model detection and warm-up

### Testing

Tested against vLLM 0.23.1 with DeepSeek-V4-Flash-DSpark on GB10 Spark cluster:

- ✅ Valid model (`DeepSeek-V4-Flash`): pre-flight passes, benchmark runs normally (15/15 pass in `--short` mode)
- ✅ Invalid model (`nonexistent-model-xyz`): pre-flight catches 404, exits with code 3 in both interactive and JSON modes
- ✅ `ruff check .` passes
- ✅ `pytest tests/ --ignore=tests/test_llama_benchy.py` — 1895 passed