### PR TITLE
fix: repair truncated streamed tool-call arguments for --stream-interval > 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ All notable changes to `tool-eval-bench` are documented here.
   benchmark aborts with a clear error (exit code 3) instead of running
   84 scenarios against a broken endpoint.  New `MODEL_NOT_AVAILABLE` error
   code added to `domain/errors.py` for structured `--json` output.
+- **Streamed tool-call arguments repair for `--stream-interval > 1` (#18)**
+  — when vLLM is launched with `--stream-interval` set to a value higher
+  than 1, tool-call argument tokens are batched into larger SSE chunks.
+  In some cases the server's own tool-call parser does not detect the
+  closing brace within a batch, causing the accumulated arguments string
+  to be missing its final `}` or have unbalanced quotes.  The streaming
+  adapter now applies a `_repair_streamed_tool_args()` function that
+  closes unterminated strings and unbalanced braces/brackets before
+  building `ProviderToolCall` objects, ensuring arguments are parseable
+  regardless of the server's stream-interval setting.
 
 ### Changed
 

--- a/src/tool_eval_bench/adapters/openai_compat.py
+++ b/src/tool_eval_bench/adapters/openai_compat.py
@@ -21,6 +21,51 @@ from tool_eval_bench.utils.urls import chat_completions_url as _chat_completions
 logger = logging.getLogger(__name__)
 
 
+def _repair_streamed_tool_args(s: str) -> str:
+    """Repair truncated JSON from streamed tool-call arguments.
+
+    When a server uses ``--stream-interval > 1``, tool-call argument tokens
+    are batched into larger SSE chunks.  In some cases the server's own
+    tool-call parser may not detect the closing brace within a batch,
+    causing the accumulated arguments string to be missing its final ``}``
+    or have unbalanced quotes.
+
+    This function applies minimal repairs:
+      1. Close unterminated strings (odd number of unescaped quotes).
+      2. Close unbalanced braces and brackets.
+
+    If the string is already valid JSON, it is returned unchanged.
+    """
+    if not s or not s.strip():
+        return "{}"
+    try:
+        json.loads(s)
+        return s  # already valid
+    except json.JSONDecodeError:
+        pass
+
+    import re
+
+    repaired = s
+    # Close unterminated strings
+    n_quotes = len(re.findall(r'(?<!\\)"', repaired))
+    if n_quotes % 2 != 0:
+        repaired += '"'
+
+    # Close unbalanced braces and brackets
+    opens_brace = repaired.count("{") - repaired.count("}")
+    repaired += "}" * max(0, opens_brace)
+    opens_bracket = repaired.count("[") - repaired.count("]")
+    repaired += "]" * max(0, opens_bracket)
+
+    try:
+        json.loads(repaired)
+        return repaired
+    except json.JSONDecodeError:
+        logger.warning("Could not repair streamed tool-call arguments: %.80s", s)
+        return s  # return original; let downstream parsing handle it
+
+
 def _normalize_tool_calls(raw_calls: list[dict] | None) -> list[ProviderToolCall]:
     if not raw_calls:
         return []
@@ -271,11 +316,26 @@ class OpenAICompatibleAdapter(BackendAdapter):
         tool_calls: list[ProviderToolCall] = []
         for idx in sorted(tool_calls_map.keys()):
             tc = tool_calls_map[idx]
+            # Repair truncated JSON arguments.  When the server uses
+            # --stream-interval > 1, tool-call arguments may arrive in
+            # larger batches where the closing brace is split across
+            # chunks or missing entirely (vLLM issue with batched token
+            # streaming).  Apply the same repair logic used for the
+            # round-trip message to ensure arguments are parseable.
+            raw_args = tc["arguments"]
+            repaired_args = _repair_streamed_tool_args(raw_args)
+            if repaired_args != raw_args:
+                logger.debug(
+                    "Repaired streamed tool-call arguments for index %d: %.80s → %.80s",
+                    idx,
+                    raw_args,
+                    repaired_args,
+                )
             tool_calls.append(
                 ProviderToolCall(
                     id=tc["id"],
                     name=tc["name"],
-                    arguments_str=tc["arguments"],
+                    arguments_str=repaired_args,
                 )
             )
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -881,3 +881,128 @@ async def test_stream_null_function_in_tool_call_delta() -> None:
     assert result.tool_calls[0].name == "search"
     assert result.tool_calls[0].id == "tc_1"
     await adapter.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Stream-interval > 1: truncated tool-call arguments (GH-18)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_truncated_tool_args_missing_brace() -> None:
+    """Tool-call arguments with missing closing brace should be repaired (GH-18).
+
+    When --stream-interval > 1, vLLM may batch tokens such that the closing
+    brace of a tool-call's JSON arguments is missing from the final stream
+    chunk.  The adapter should repair the truncated JSON.
+    """
+    chunks = [
+        json.dumps(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "tc_1",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": '{"location": "NYC"',
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ),
+    ]
+    body = _sse_lines(*chunks)
+
+    adapter = OpenAICompatibleAdapter()
+    adapter._client = httpx.AsyncClient(transport=_mock_stream_transport(body))
+
+    result = await adapter.chat_completion(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        base_url="http://localhost:8000",
+        stream=True,
+    )
+
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "get_weather"
+    # The missing closing brace should have been repaired
+    assert result.tool_calls[0].arguments_str == '{"location": "NYC"}'
+    assert result.tool_calls[0].arguments == {"location": "NYC"}
+    await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_truncated_tool_args_unbalanced_quotes() -> None:
+    """Tool-call arguments with unbalanced quotes should be repaired (GH-18)."""
+    chunks = [
+        json.dumps(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "tc_1",
+                                    "function": {
+                                        "name": "search",
+                                        "arguments": '{"query": "test',
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ),
+    ]
+    body = _sse_lines(*chunks)
+
+    adapter = OpenAICompatibleAdapter()
+    adapter._client = httpx.AsyncClient(transport=_mock_stream_transport(body))
+
+    result = await adapter.chat_completion(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        base_url="http://localhost:8000",
+        stream=True,
+    )
+
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "search"
+    # Repair should close the quote and brace
+    parsed = json.loads(result.tool_calls[0].arguments_str)
+    assert parsed == {"query": "test"}
+    await adapter.aclose()
+
+
+def test_repair_streamed_tool_args_valid_json() -> None:
+    """Already-valid JSON should be returned unchanged."""
+    from tool_eval_bench.adapters.openai_compat import _repair_streamed_tool_args
+
+    assert _repair_streamed_tool_args('{"a": 1}') == '{"a": 1}'
+    assert _repair_streamed_tool_args("") == "{}"
+    assert _repair_streamed_tool_args("  ") == "{}"
+
+
+def test_repair_streamed_tool_args_missing_brace() -> None:
+    """Missing closing brace should be repaired."""
+    from tool_eval_bench.adapters.openai_compat import _repair_streamed_tool_args
+
+    result = _repair_streamed_tool_args('{"key": "value"')
+    assert json.loads(result) == {"key": "value"}
+
+
+def test_repair_streamed_tool_args_nested() -> None:
+    """Nested JSON with missing braces should be repaired."""
+    from tool_eval_bench.adapters.openai_compat import _repair_streamed_tool_args
+
+    result = _repair_streamed_tool_args('{"outer": {"inner": 1')
+    assert json.loads(result) == {"outer": {"inner": 1}}


### PR DESCRIPTION
## Problem (Closes #18)

When vLLM is launched with `--stream-interval` set to a value higher than 1, tool-call argument tokens are batched into larger SSE chunks. In some cases the server's own tool-call parser does not detect the closing brace within a batch, causing the accumulated arguments string to be missing its final `}` or have unbalanced quotes.

This caused many low-numbered tool-eval-bench test cases to fail with "missing closing brace" errors.

## Fix

Adds `_repair_streamed_tool_args()` in the streaming adapter (`openai_compat.py`) that:
1. Closes unterminated strings (odd number of unescaped quotes)
2. Closes unbalanced braces and brackets

The repair is applied **after** accumulating all SSE chunks and **before** building `ProviderToolCall` objects, ensuring arguments are parseable regardless of the server's stream-interval setting.

The existing `_repair_json_str` in `orchestrator.py` only runs when building the assistant message for the round-trip back to the server. The new function catches the problem earlier — at parse time — so that scenario evaluators also see correct arguments.

### Changes

- **`adapters/openai_compat.py`**: New `_repair_streamed_tool_args()` function + applied in `_stream_request()`
- **`tests/test_adapter.py`**: 5 new tests covering truncated/missing-brace/unbalanced-quotes/nested cases
- **`CHANGELOG.md`**: Updated

### Testing

- ✅ `ruff check .` passes
- ✅ `ruff format --check .` passes
- ✅ `pytest tests/ --ignore=tests/test_llama_benchy.py` — 1900 passed (5 new)

### Notes

This is a client-side fix. The root cause is in vLLM's tool-call parser not detecting the closing brace within a batched stream-interval chunk. The benchmark adapter now gracefully handles this case by repairing the truncated JSON.