### PR TITLE
Add Docker support for running tool-eval-bench in a container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ __pycache__
 .ruff_cache
 .coverage
 reports/
+runs/
 tests/
 docs/
 compare/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+.venv
+venv
+__pycache__
+*.pyc
+.pytest_cache
+.ruff_cache
+.coverage
+reports/
+tests/
+docs/
+compare/
+*.md
+!README.md
+.env

--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,11 @@
 # Copy to .env and adjust for your setup.
 
 # Option A: full URL (preferred)
-TOOL_EVAL_BASE_URL=http://your-server:8080
+# TOOL_EVAL_BASE_URL=http://your-server:8080
 
 # Option B: host + port separately (used when BASE_URL is empty)
-# TOOL_EVAL_HOST=your-server
-# TOOL_EVAL_PORT=8080
+TOOL_EVAL_HOST=your-server
+TOOL_EVAL_PORT=8080
 
 # Backend label for reports (optional, default: vllm)
 # All backends use the same OpenAI-compatible adapter — this is just a label.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,15 @@ jobs:
           --ignore=tests/test_llama_benchy.py
           --cov=tool_eval_bench --cov-report=term-missing
           --cov-fail-under=55
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build -t tool-eval-bench:ci .
+
+      - name: Smoke test — CLI entrypoint
+        run: docker run --rm tool-eval-bench:ci --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to `tool-eval-bench` are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **Docker support** — a `Dockerfile` and `docker-compose.yaml` for running
+  the benchmark in a container against a remote OpenAI-compatible endpoint,
+  useful when testing a server by IP/port without a local Python setup.
+  Reuses the existing `.env.example` / `TOOL_EVAL_*` config surface unchanged
+  — no separate Docker-specific env schema. `docker-compose.yaml` mounts
+  `./runs` directly (the CLI's own default report path, see `AGENTS.md`), so
+  `--output-dir` never needs to be passed and results survive `--rm`
+  cleaning up the container. CI now builds the image on every push/PR to
+  catch breakage. See the "Run with Docker" section in the README.
+
 ## [2.1.0] — 2026-07-06
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# git is needed by tool-eval-bench's `compare` git helper; kept minimal otherwise.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md ./
+COPY src ./src
+
+# Build with `--build-arg EXTRAS=perf,hf` to bundle the throughput/HF-dataset extras.
+ARG EXTRAS=""
+RUN pip install --no-cache-dir .$( [ -n "$EXTRAS" ] && echo "[$EXTRAS]" )
+
+RUN mkdir -p /app/runs
+VOLUME ["/app/runs"]
+
+ENTRYPOINT ["tool-eval-bench"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -97,12 +97,14 @@ OpenAI-compatible endpoint reachable from the container:
 git clone https://github.com/SeraphimSerapis/tool-eval-bench.git
 cd tool-eval-bench
 
-docker compose build
-
 # Point it at your server: copy the config template and fill in the target
 # (same TOOL_EVAL_* variables as the Configuration section below)
 cp .env.example .env
-# edit .env: TOOL_EVAL_HOST=<ip>, TOOL_EVAL_PORT=<port>, TOOL_EVAL_API_KEY=<token>
+# edit .env: set TOOL_EVAL_BASE_URL, or set TOOL_EVAL_HOST/TOOL_EVAL_PORT;
+# also set TOOL_EVAL_API_KEY when the endpoint requires authentication
+
+# Compose validates env_file entries before any command, so .env must exist first
+docker compose build
 
 # Check the endpoint is reachable (default command)
 docker compose run --rm tool-eval-bench --probe

--- a/README.md
+++ b/README.md
@@ -88,6 +88,36 @@ source .venv/bin/activate
 pip install -e '.[dev,perf,hf]'
 ```
 
+### Run with Docker
+
+No local Python setup required — build once, then run against any
+OpenAI-compatible endpoint reachable from the container:
+
+```bash
+git clone https://github.com/SeraphimSerapis/tool-eval-bench.git
+cd tool-eval-bench
+
+docker compose build
+
+# Point it at your server: copy the config template and fill in the target
+# (same TOOL_EVAL_* variables as the Configuration section below)
+cp .env.example .env
+# edit .env: TOOL_EVAL_HOST=<ip>, TOOL_EVAL_PORT=<port>, TOOL_EVAL_API_KEY=<token>
+
+# Check the endpoint is reachable (default command)
+docker compose run --rm tool-eval-bench --probe
+
+# Run the benchmark — any CLI flag works here too
+docker compose run --rm tool-eval-bench --short --seed 42
+```
+
+Reports land in `./runs/` on the host, matching the CLI's own default output
+path (`./runs/YYYY/MM/`) — `docker-compose.yaml` mounts that directory
+directly, so `--output-dir` never needs to be passed explicitly and results
+survive `--rm` cleaning up the container.
+
+Build with the throughput/HF-dataset extras via `docker compose build --build-arg EXTRAS=perf,hf`.
+
 ### Updating
 
 ```bash

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,22 @@
+services:
+  tool-eval-bench:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: tool-eval-bench:local
+    container_name: tool-eval-bench
+    # Copy .env.example to .env and set TOOL_EVAL_HOST/TOOL_EVAL_PORT (or
+    # TOOL_EVAL_BASE_URL) and TOOL_EVAL_API_KEY to the target endpoint's
+    # IP/port and access token.
+    env_file:
+      - .env
+    # tool-eval-bench's own default report location is ./runs (relative to
+    # its CWD, which is /app here per WORKDIR) — mount that path directly so
+    # reports land on the host even if a run overrides the command without
+    # passing --output-dir.
+    volumes:
+      - ./runs:/app/runs
+    # Default: verify the endpoint is reachable and exit (0 = ready, 1 = not found).
+    # Override with `docker compose run --rm tool-eval-bench <args>` for a real benchmark run, e.g.:
+    #   docker compose run --rm tool-eval-bench --short --seed 42
+    command: ["--probe"]


### PR DESCRIPTION
## Summary
- Add a `Dockerfile` and `docker-compose.yaml` for running the benchmark in a container against a remote OpenAI-compatible endpoint (vLLM, LiteLLM, llama.cpp, ...) by IP/port and access token, without a local Python setup.
- Reuses the existing `.env.example` / `TOOL_EVAL_*` config surface unchanged — no separate Docker-specific env schema to keep in sync.
- `docker-compose.yaml` mounts `./runs:/app/runs`, matching the CLI's own default report path (per `AGENTS.md`: "every completed run MUST produce a Markdown artifact under `runs/YYYY/MM/`"), so results land on the host whether or not `--output-dir` is passed, and survive `--rm` cleaning up the container.
- Adds a `docker-build` CI job (build + `--help` smoke test) so the image doesn't silently rot as the CLI evolves.
- Documents the new workflow in a "Run with Docker" README subsection and a `CHANGELOG.md` `[Unreleased]` entry.

## Test plan
- [x] `docker build .` succeeds
- [x] `docker run --rm <image> --help` smoke test passes
- [x] Verified `--probe` and a real scenario run against a local mock OpenAI-compatible server, including the `Authorization: Bearer <token>` header round-trip
- [x] Confirmed report files land in `./runs/YYYY/MM/*.md` on the host after `docker compose run --rm ...` even without passing `--output-dir`, and persist after `--rm` removes the container
- [x] `ruff check .` / `pytest` unaffected (no Python source changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)