### PR TITLE
docs: add Cursor Cloud environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,37 @@ When changing architecture or API behavior, update:
 - `CHANGELOG.md`
 
 Keep `CHANGELOG.md` up to date with notable changes.
+
+## Cursor Cloud specific instructions
+
+The VM comes with the project venv at `.venv` (created by the startup update
+script, which runs `pip install -e '.[dev,perf]'`). Always use `.venv/bin/...`
+as documented in the Quality bar section. Lint/type/test/run commands are
+unchanged from the Quality bar and `SKILL.md`; the notes below only cover
+non-obvious environment caveats.
+
+- **`pytest` needs `FORCE_COLOR` unset.** This VM's shell exports
+  `FORCE_COLOR=0` and `TERM=dumb`. `rich` treats the *presence* of
+  `FORCE_COLOR` (even `0`) as "force terminal", so its `StringIO`-based
+  rendering tests emit ANSI codes and hardcode width 80, breaking ~6 tests in
+  `tests/test_history.py`, `tests/test_leaderboard_display.py`, and
+  `tests/test_spec_live.py`. Run the suite with `FORCE_COLOR` removed, e.g.
+  `env -u FORCE_COLOR .venv/bin/python -m pytest ...`. `ruff` and `mypy` are
+  unaffected. This is purely an env quirk (not a `rich` version issue) — the
+  tests pass in CI where `FORCE_COLOR` is unset.
+- **Do NOT install the `[hf]` extra for the quality bar.** Installing
+  `datasets` (via `.[hf]`) makes `mypy` fail with 3 `import-untyped` errors in
+  `plugins/hf_utils.py` and `cli/plugin_runners.py` (the code's
+  `type: ignore[import-not-found]` comments only match when `datasets` is
+  absent, as in CI). Only add `[hf]` when actively working on GSM8K/MMLU/IFEval
+  plugins, and expect that mypy noise while it is installed.
+- **No live LLM server runs in this environment.** Commands that hit the model
+  (`run`, `probe`, `plugin`, `resume`, `bench` with scenarios/perf/spec) need a
+  reachable OpenAI-compatible `/v1/chat/completions` endpoint. Without one, use
+  `tool-eval-bench run --dry-run` (no server) or point `--base-url` at a local
+  mock server that implements `GET /v1/models` and `POST /v1/chat/completions`
+  (the first turn is streamed, so a mock MUST support `stream: true` SSE or the
+  adapter parses zero tool calls).
+- **Run artifacts are gitignored:** `data/benchmarks.sqlite` (SQLite) and
+  `runs/YYYY/MM/*.md` (Markdown reports) are written on every completed run and
+  read back by `history`/`leaderboard`/`compare`/`export`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for `tool-eval-bench` in Cursor Cloud, and records the non-obvious environment caveats in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section.

No application/source code was changed — only `AGENTS.md`.

## Environment setup

- Python 3.12 venv at `.venv`, installed with `pip install -e '.[dev,perf]'` (the startup update script).
- `[hf]` is intentionally excluded from the default install because `datasets` breaks the `mypy` quality bar.

## Verification (all green)

| Check | Command | Result |
|---|---|---|
| Lint | `ruff check .` | pass |
| Format | `ruff format --check .` | 168 files formatted |
| Types | `mypy` | no issues (95 files) |
| Tests | `pytest ... -m "not live"` (seeds 104729/130363/155921) | 2107 passed |
| Perf tests | `pytest tests/test_llama_benchy.py` | 61 passed |

## Hello-world (core functionality)

Ran the tool-call benchmark end-to-end against a local mock OpenAI-compatible server:

```
tool-eval-bench run --short --base-url http://127.0.0.1:8000 --model mock-model --seed 42
→ Score 17/100 (2 pass / 1 partial / 12 fail)
```

This exercised server discovery, the streaming adapter, multi-turn orchestration, in-process mock tool handlers, pass/partial/fail evaluators, scoring, SQLite persistence (`data/benchmarks.sqlite`, read back by `history`/`leaderboard`), and Markdown report generation (`runs/2026/07/*.md`).

## Key caveats captured in AGENTS.md

- `pytest` must be run with `FORCE_COLOR` unset (this VM sets `FORCE_COLOR=0` + `TERM=dumb`, which makes `rich` break ~6 rendering tests). Not a `rich` version issue.
- `[hf]` extra breaks the `mypy` quality bar; install only for plugin work.
- No live LLM server exists here — use `--dry-run` or a mock server that supports `stream: true` SSE (turn 1 is streamed).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d455adbf-f5df-4d4e-affd-f4d2751fa674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d455adbf-f5df-4d4e-affd-f4d2751fa674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

