### PR TITLE
docs: hyphenate llama-bench-style in README.md throughput section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Inspired by [ToolCall-15](https://github.com/stevibe/ToolCall-15), this tool run
 
 ### Throughput Performance (optional)
 
-llama-bench style prefill (pp) and token generation (tg) measurement via streaming, with configurable context depth and concurrency sweeps.
+llama-bench-style prefill (pp) and token generation (tg) measurement via streaming, with configurable context depth and concurrency sweeps.
 
 ### Pluggable Accuracy Benchmarks
 


### PR DESCRIPTION
## Description
This PR fixes compound adjective hyphenation in `README.md` under the Throughput Performance section.

## Details
Hyphenated `llama-bench style` -> `llama-bench-style`.