### PR TITLE
fix: restore CI under Ruff 0.16 and improve llama-benchy progress

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 repos:
   # ── Ruff: lint + format ─────────────────────────────────────
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.15
+    rev: v0.16.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to `tool-eval-bench` are documented here.
 
+## [Unreleased]
+
+### Changed
+
+- **llama-benchy dependency bumped to `>=0.4.0`** — the `[perf]` optional
+  dependency now requires llama-benchy 0.4.0+, which replaces the heavy
+  `transformers`-based tokenizer with a lightweight `tokenizers`-based
+  fallback (fixing the subprocess OOM risk from #14) and fixes the context
+  prefill probe for vLLM's Rust frontend. The JSON output schema and all CLI
+  flags consumed by the integration are unchanged.
+
 ## [2.2.0] — 2026-07-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,21 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI format check under Ruff 0.16** — Ruff 0.16 formats Python fenced code
+  blocks in Markdown by default. Exclude `*.md` from Ruff so docs examples keep
+  intentional layout and CI no longer fails when the unbound `ruff>=0.12` pin
+  floats to a new major formatter release.
+
 ### Changed
 
+- **llama-benchy progress via `--emit-progress`** — the perf CLI drives its
+  progress bar from structured JSONL events (`request_start` / `request_end` /
+  `bench_complete`) instead of scraping human-readable log lines. The runner
+  always passes `--emit-progress -`, reads progress from stdout and logs from
+  stderr concurrently, and still accepts a caller-supplied `--emit-progress` in
+  `extra_args`.
 - **llama-benchy dependency bumped to `>=0.4.0`** — the `[perf]` optional
   dependency now requires llama-benchy 0.4.0+, which replaces the heavy
   `transformers`-based tokenizer with a lightweight `tokenizers`-based

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 perf = [
-  "llama-benchy>=0.3.5",
+  "llama-benchy>=0.4.0",
 ]
 hf = [
   "datasets>=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,10 @@ where = ["src"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+# Ruff 0.16+ formats Python fenced blocks in Markdown by default. Keep docs
+# examples human-edited (aligned comments, intentional layout) and avoid CI
+# breakage when the unbound `ruff>=0.12` pin floats across major formatter changes.
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "B", "S"]

--- a/src/tool_eval_bench/cli/perf.py
+++ b/src/tool_eval_bench/cli/perf.py
@@ -10,7 +10,6 @@ display conventions.
 from __future__ import annotations
 
 import asyncio
-import re
 import sys
 from typing import Any
 
@@ -224,24 +223,22 @@ def run_llama_benchy(
             current_test = ""
             completed_runs = 0
 
-            def on_output(line: str) -> None:
+            def on_progress(event: dict[str, Any]) -> None:
                 nonlocal current_test, completed_runs
-                stripped = line.strip()
-                if not stripped:
-                    return
-
-                if stripped.startswith("Running test:"):
-                    current_test = stripped.replace("Running test: ", "")
+                event_type = event.get("type", "")
+                if event_type == "request_start":
+                    pp = event.get("prompt_size", "?")
+                    tg = event.get("response_size", "?")
+                    depth = event.get("context_size", 0)
+                    conc = event.get("concurrency", 1)
+                    run_idx = event.get("run_index", 0)
+                    current_test = f"pp{pp} tg{tg} @ d{depth} c{conc} run {run_idx}"
                     progress.update(task, description=current_test)
-                elif re.match(r"\s*Run \d+/\d+", stripped):
+                elif event_type == "request_end":
                     completed_runs += 1
                     progress.update(task, completed=completed_runs)
-                elif "Warming up" in stripped and "complete" not in stripped.lower():
-                    progress.update(task, description="Warming up…")
-                elif "Measuring latency" in stripped:
-                    progress.update(task, description="Measuring latency…")
-                elif "Average latency" in stripped:
-                    progress.update(task, description="Running benchmarks…")
+                elif event_type == "bench_complete":
+                    progress.update(task, completed=total_runs, description="[green]✓ Complete")
 
             benchy_result = await run_llama_benchy(
                 base_url,
@@ -256,7 +253,7 @@ def run_llama_benchy(
                 skip_coherence=skip_coherence,
                 skip_warmup=skip_warmup,
                 extra_args=extra_args,
-                on_output=on_output,
+                on_progress=on_progress,
             )
 
             progress.update(task, completed=total_runs, description="[green]✓ Complete")

--- a/src/tool_eval_bench/runner/llama_benchy.py
+++ b/src/tool_eval_bench/runner/llama_benchy.py
@@ -162,6 +162,12 @@ def _build_command(
     if output_file:
         cmd.extend(["--save-result", output_file])
 
+    # Structured progress events (JSONL on stdout).  Requires llama-benchy >=0.4.0,
+    # which is the current minimum.  If the user already specified --emit-progress
+    # in extra_args, respect their choice.
+    if not (extra_args and "--emit-progress" in extra_args):
+        cmd.extend(["--emit-progress", "-"])
+
     # Pass-through extra args
     if extra_args:
         cmd.extend(extra_args)
@@ -272,14 +278,20 @@ async def run_llama_benchy(
     skip_warmup: bool = False,
     extra_args: list[str] | None = None,
     on_output: Callable[[str], None] | None = None,
+    on_progress: Callable[[dict[str, Any]], None] | None = None,
 ) -> LlamaBenchyResult:
     """Run llama-benchy as a subprocess and parse the results.
 
     Parameters
     ----------
     on_output : callable, optional
-        Called with each line of stdout for real-time progress display.
-        Signature: ``(line: str) -> None``
+        Called with each line of stderr (regular llama-benchy output) for
+        real-time display.  Signature: ``(line: str) -> None``
+    on_progress : callable, optional
+        Called with each structured progress event (JSONL) from llama-benchy's
+        ``--emit-progress`` stream.  Each event is a dict with a ``"type"`` key
+        (e.g. ``"request_start"``, ``"request_end"``, ``"bench_complete"``).
+        Signature: ``(event: dict[str, Any]) -> None``
 
     Returns
     -------
@@ -293,8 +305,8 @@ async def run_llama_benchy(
     FileNotFoundError
         If llama-benchy is not installed and uvx is not available.
     """
-    # Write JSON output to a temp file for reliable parsing
-    # (stdout may contain progress/debug output mixed with JSON)
+    # Write JSON results to a temp file.  Progress JSONL goes to stdout when
+    # --emit-progress - is set; human-readable logs go to stderr.
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
         output_file = f.name
 
@@ -346,11 +358,13 @@ async def run_llama_benchy(
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+            stderr=asyncio.subprocess.PIPE,
             env=env,
         )
 
-        # Stream stdout for real-time display
+        # With --emit-progress -, llama-benchy writes JSONL progress events to
+        # stdout and regular output to stderr.  Read both concurrently to avoid
+        # pipe-buffer deadlock.
         output_lines: list[str] = []
         # Known noisy lines from transformers/HF Hub we suppress from display
         _SUPPRESS = (
@@ -358,13 +372,29 @@ async def run_llama_benchy(
             "Models won't be available",
             "unauthenticated requests to the HF Hub",
         )
-        if proc.stdout is None:
-            raise RuntimeError("Subprocess stdout unexpectedly None")
-        async for raw_line in proc.stdout:
-            line = raw_line.decode("utf-8", errors="replace").rstrip()
-            output_lines.append(line)
-            if on_output and not any(s in line for s in _SUPPRESS):
-                on_output(line)
+
+        async def _read_stderr() -> None:
+            if proc.stderr is None:
+                return
+            async for raw_line in proc.stderr:
+                line = raw_line.decode("utf-8", errors="replace").rstrip()
+                output_lines.append(line)
+                if on_output and not any(s in line for s in _SUPPRESS):
+                    on_output(line)
+
+        async def _read_stdout() -> None:
+            if proc.stdout is None:
+                return
+            async for raw_line in proc.stdout:
+                line = raw_line.decode("utf-8", errors="replace").rstrip()
+                if on_progress:
+                    try:
+                        event = json.loads(line)
+                        on_progress(event)
+                    except json.JSONDecodeError:
+                        pass  # Non-JSON line on stdout, skip
+
+        await asyncio.gather(_read_stderr(), _read_stdout())
 
         returncode = await proc.wait()
 

--- a/tests/test_llama_benchy.py
+++ b/tests/test_llama_benchy.py
@@ -184,6 +184,9 @@ class TestBuildCommand:
         assert "--skip-coherence" not in cmd
         # adapt-prompt is always disabled (tool-eval-bench does its own calibration)
         assert "--no-adapt-prompt" in cmd
+        # Structured progress events on stdout (llama-benchy >=0.4.0)
+        assert "--emit-progress" in cmd
+        assert cmd[cmd.index("--emit-progress") + 1] == "-"
 
     def test_api_key_not_on_command_line(self, monkeypatch):
         """API key must NOT appear on the command line (security: visible in ps aux).
@@ -282,6 +285,20 @@ class TestBuildCommand:
             extra_args=["--no-warmup"],
         )
         assert "--no-warmup" in cmd
+
+    def test_emit_progress_not_duplicated_when_in_extra_args(self, monkeypatch):
+        """Respect a user-supplied --emit-progress instead of adding a second one."""
+        monkeypatch.setattr(
+            "tool_eval_bench.runner.llama_benchy.shutil.which",
+            lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
+        )
+        cmd = _build_command(
+            "http://localhost:8888/v1",
+            "test-model",
+            extra_args=["--emit-progress", "/tmp/progress.jsonl"],
+        )
+        assert cmd.count("--emit-progress") == 1
+        assert cmd[cmd.index("--emit-progress") + 1] == "/tmp/progress.jsonl"
 
     def test_url_with_trailing_slash(self, monkeypatch):
         monkeypatch.setattr(
@@ -524,64 +541,85 @@ class TestParserEdgeCases:
         assert result.latency_ms == 0.0
 
 
+class _MockStream:
+    """Async iterable standing in for subprocess stdout/stderr pipes."""
+
+    def __init__(self, lines: list[str | bytes] | None = None) -> None:
+        self._lines: list[str | bytes] = list(lines or [])
+        self._idx = 0
+
+    def __aiter__(self) -> _MockStream:
+        return self
+
+    async def __anext__(self) -> bytes:
+        if self._idx >= len(self._lines):
+            raise StopAsyncIteration
+        line = self._lines[self._idx]
+        self._idx += 1
+        return line if isinstance(line, bytes) else line.encode("utf-8")
+
+
+class _MockProcess:
+    """Minimal asyncio subprocess mock with separate stdout/stderr streams."""
+
+    def __init__(
+        self,
+        *,
+        stderr_lines: list[str | bytes] | None = None,
+        stdout_lines: list[str | bytes] | None = None,
+        returncode: int = 0,
+        output_file: str | None = None,
+        write_json: dict | None = None,
+    ) -> None:
+        self.stdout = _MockStream(stdout_lines)
+        self.stderr = _MockStream(stderr_lines)
+        self._returncode = returncode
+        self._output_file = output_file
+        self._write_json = write_json
+
+    async def wait(self) -> int:
+        if self._write_json is not None and self._output_file:
+            Path(self._output_file).write_text(json.dumps(self._write_json), encoding="utf-8")
+        return self._returncode
+
+
+def _capture_output_file(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Wrap ``_build_command`` so tests can learn the temp ``--save-result`` path."""
+    output_file_ref: list[str] = []
+    original_build = _build_command
+
+    def mock_build(*args: object, **kwargs: object) -> list[str]:
+        cmd = original_build(*args, **kwargs)
+        if "--save-result" in cmd:
+            output_file_ref.append(cmd[cmd.index("--save-result") + 1])
+        return cmd
+
+    monkeypatch.setattr("tool_eval_bench.runner.llama_benchy._build_command", mock_build)
+    return output_file_ref
+
+
 class TestRunLlamaBenchy:
     """Tests for the async subprocess runner using mocked subprocess."""
 
-    async def test_happy_path(self, tmp_path, monkeypatch):
+    async def test_happy_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Successful run should parse JSON output and return results."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
-        # Mock shutil.which to find llama-benchy
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.shutil.which",
             lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
         )
 
         captured_lines: list[str] = []
+        output_file_ref = _capture_output_file(monkeypatch)
 
-        # Mock asyncio.create_subprocess_exec
-        class MockStdout:
-            def __init__(self, lines):
-                self._lines = lines
-                self._idx = 0
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if self._idx >= len(self._lines):
-                    raise StopAsyncIteration
-                line = self._lines[self._idx]
-                self._idx += 1
-                return line.encode("utf-8")
-
-        class MockProcess:
-            def __init__(self, output_file):
-                self.stdout = MockStdout(["Running benchmark...\n", "Done\n"])
-                self._output_file = output_file
-
-            async def wait(self):
-                # Write valid JSON to the output file
-                Path(self._output_file).write_text(json.dumps(SAMPLE_JSON_OUTPUT), encoding="utf-8")
-                return 0
-
-        output_file_ref: list[str] = []
-
-        original_build = _build_command
-
-        def mock_build(*args, **kwargs):
-            cmd = original_build(*args, **kwargs)
-            # Capture the output file from the command
-            if "--save-result" in cmd:
-                idx = cmd.index("--save-result") + 1
-                output_file_ref.append(cmd[idx])
-            return cmd
-
-        monkeypatch.setattr("tool_eval_bench.runner.llama_benchy._build_command", mock_build)
-
-        async def mock_create_subprocess_exec(*args, **kwargs):
+        async def mock_create_subprocess_exec(*args: object, **kwargs: object) -> _MockProcess:
             assert output_file_ref, "output file should be set by _build_command"
-            return MockProcess(output_file_ref[0])
+            return _MockProcess(
+                stderr_lines=["Running benchmark...\n", "Done\n"],
+                output_file=output_file_ref[0],
+                write_json=SAMPLE_JSON_OUTPUT,
+            )
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -600,7 +638,7 @@ class TestRunLlamaBenchy:
         assert len(captured_lines) == 2
         assert "Running benchmark..." in captured_lines[0]
 
-    async def test_nonzero_exit_raises(self, monkeypatch):
+    async def test_nonzero_exit_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Non-zero exit code should raise RuntimeError."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
@@ -609,21 +647,8 @@ class TestRunLlamaBenchy:
             lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
         )
 
-        class MockStdout:
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                raise StopAsyncIteration
-
-        class MockProcess:
-            stdout = MockStdout()
-
-            async def wait(self):
-                return 1
-
-        async def mock_create(*args, **kwargs):
-            return MockProcess()
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(returncode=1)
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -633,7 +658,7 @@ class TestRunLlamaBenchy:
         with pytest.raises(RuntimeError, match="exited with code 1"):
             await run_llama_benchy("http://localhost:8888/v1", "test-model")
 
-    async def test_empty_output_file_raises(self, monkeypatch):
+    async def test_empty_output_file_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Empty output file should raise RuntimeError."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
@@ -642,22 +667,8 @@ class TestRunLlamaBenchy:
             lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
         )
 
-        class MockStdout:
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                raise StopAsyncIteration
-
-        class MockProcess:
-            stdout = MockStdout()
-
-            async def wait(self):
-                # Don't write anything to the output file
-                return 0
-
-        async def mock_create(*args, **kwargs):
-            return MockProcess()
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(returncode=0)
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -667,8 +678,8 @@ class TestRunLlamaBenchy:
         with pytest.raises(RuntimeError, match="did not produce JSON output"):
             await run_llama_benchy("http://localhost:8888/v1", "test-model")
 
-    async def test_on_output_receives_all_lines(self, monkeypatch):
-        """on_output callback should receive every stdout line."""
+    async def test_on_output_receives_stderr_lines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """on_output callback should receive every stderr line."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
         monkeypatch.setattr(
@@ -682,45 +693,14 @@ class TestRunLlamaBenchy:
             "pp2048 tg32 @ d4096 c2: 1968 pp/s, 99 tg/s\n",
             "Complete!\n",
         ]
+        output_file_ref = _capture_output_file(monkeypatch)
 
-        class MockStdout:
-            def __init__(self):
-                self._idx = 0
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if self._idx >= len(expected_lines):
-                    raise StopAsyncIteration
-                line = expected_lines[self._idx]
-                self._idx += 1
-                return line.encode("utf-8")
-
-        output_file_ref: list[str] = []
-        original_build = _build_command
-
-        def mock_build(*args, **kwargs):
-            cmd = original_build(*args, **kwargs)
-            if "--save-result" in cmd:
-                idx = cmd.index("--save-result") + 1
-                output_file_ref.append(cmd[idx])
-            return cmd
-
-        monkeypatch.setattr("tool_eval_bench.runner.llama_benchy._build_command", mock_build)
-
-        class MockProcess:
-            def __init__(self):
-                self.stdout = MockStdout()
-
-            async def wait(self):
-                Path(output_file_ref[0]).write_text(
-                    json.dumps(SAMPLE_JSON_OUTPUT), encoding="utf-8"
-                )
-                return 0
-
-        async def mock_create(*args, **kwargs):
-            return MockProcess()
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(
+                stderr_lines=expected_lines,
+                output_file=output_file_ref[0],
+                write_json=SAMPLE_JSON_OUTPUT,
+            )
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -738,7 +718,61 @@ class TestRunLlamaBenchy:
         assert "Warming up" in captured[0]
         assert "Complete" in captured[3]
 
-    async def test_noisy_lines_suppressed(self, monkeypatch):
+    async def test_on_progress_receives_jsonl_events(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """on_progress should parse JSONL events from stdout."""
+        from tool_eval_bench.runner.llama_benchy import run_llama_benchy
+
+        monkeypatch.setattr(
+            "tool_eval_bench.runner.llama_benchy.shutil.which",
+            lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
+        )
+
+        progress_lines = [
+            json.dumps(
+                {
+                    "type": "request_start",
+                    "prompt_size": 2048,
+                    "response_size": 32,
+                    "context_size": 0,
+                    "concurrency": 1,
+                    "run_index": 1,
+                }
+            )
+            + "\n",
+            "not-json\n",
+            json.dumps({"type": "request_end"}) + "\n",
+            json.dumps({"type": "bench_complete"}) + "\n",
+        ]
+        output_file_ref = _capture_output_file(monkeypatch)
+
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(
+                stdout_lines=progress_lines,
+                stderr_lines=["status\n"],
+                output_file=output_file_ref[0],
+                write_json=SAMPLE_JSON_OUTPUT,
+            )
+
+        monkeypatch.setattr(
+            "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
+            mock_create,
+        )
+
+        events: list[dict] = []
+        await run_llama_benchy(
+            "http://localhost:8888/v1",
+            "test-model",
+            on_progress=lambda event: events.append(event),
+        )
+
+        assert [e["type"] for e in events] == [
+            "request_start",
+            "request_end",
+            "bench_complete",
+        ]
+        assert events[0]["prompt_size"] == 2048
+
+    async def test_noisy_lines_suppressed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """PyTorch/HF Hub warnings should be filtered from on_output."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
@@ -754,45 +788,14 @@ class TestRunLlamaBenchy:
             "Running test: pp=2048, tg=128\n",
             "Done\n",
         ]
+        output_file_ref = _capture_output_file(monkeypatch)
 
-        class MockStdout:
-            def __init__(self):
-                self._idx = 0
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if self._idx >= len(noisy_lines):
-                    raise StopAsyncIteration
-                line = noisy_lines[self._idx]
-                self._idx += 1
-                return line.encode("utf-8")
-
-        output_file_ref: list[str] = []
-        original_build = _build_command
-
-        def mock_build(*args, **kwargs):
-            cmd = original_build(*args, **kwargs)
-            if "--save-result" in cmd:
-                idx = cmd.index("--save-result") + 1
-                output_file_ref.append(cmd[idx])
-            return cmd
-
-        monkeypatch.setattr("tool_eval_bench.runner.llama_benchy._build_command", mock_build)
-
-        class MockProcess:
-            def __init__(self):
-                self.stdout = MockStdout()
-
-            async def wait(self):
-                Path(output_file_ref[0]).write_text(
-                    json.dumps(SAMPLE_JSON_OUTPUT), encoding="utf-8"
-                )
-                return 0
-
-        async def mock_create(*args, **kwargs):
-            return MockProcess()
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(
+                stderr_lines=noisy_lines,
+                output_file=output_file_ref[0],
+                write_json=SAMPLE_JSON_OUTPUT,
+            )
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -806,15 +809,16 @@ class TestRunLlamaBenchy:
             on_output=lambda line: captured.append(line),
         )
 
-        # 3 of 5 lines are noisy — only 2 should pass through
+        # 2 of 5 lines are noisy — 3 should pass through
         assert len(captured) == 3
         assert any("llama-benchy" in c for c in captured)
         assert any("Running test" in c for c in captured)
-        # Noisy lines must not appear
         assert not any("PyTorch" in c for c in captured)
         assert not any("unauthenticated" in c for c in captured)
 
-    async def test_subprocess_env_suppresses_warnings(self, monkeypatch):
+    async def test_subprocess_env_suppresses_warnings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Subprocess should receive env vars that suppress HF warnings."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
@@ -825,23 +829,9 @@ class TestRunLlamaBenchy:
 
         captured_env: dict[str, str] = {}
 
-        class MockStdout:
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                raise StopAsyncIteration
-
-        class MockProcess:
-            stdout = MockStdout()
-
-            async def wait(self):
-                return 1  # Will raise RuntimeError, that's fine
-
-        async def mock_create(*args, **kwargs):
-            # Capture the env passed to the subprocess
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
             captured_env.update(kwargs.get("env", {}))
-            return MockProcess()
+            return _MockProcess(returncode=1)
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -857,7 +847,7 @@ class TestRunLlamaBenchy:
         assert captured_env.get("HF_HUB_OFFLINE") == "1"
         assert captured_env.get("TRANSFORMERS_OFFLINE") == "1"
 
-    async def test_oom_detected_sigkill(self, monkeypatch):
+    async def test_oom_detected_sigkill(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SIGKILL (-9) should be detected as OOM with a clear message."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
@@ -866,21 +856,8 @@ class TestRunLlamaBenchy:
             lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
         )
 
-        class MockStdout:
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                raise StopAsyncIteration
-
-        class MockProcess:
-            stdout = MockStdout()
-
-            async def wait(self):
-                return -9  # SIGKILL
-
-        async def mock_create(*args, **kwargs):
-            return MockProcess()
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(returncode=-9)
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -890,7 +867,7 @@ class TestRunLlamaBenchy:
         with pytest.raises(RuntimeError, match="out of memory"):
             await run_llama_benchy("http://localhost:8888/v1", "test-model")
 
-    async def test_oom_detected_exit_137(self, monkeypatch):
+    async def test_oom_detected_exit_137(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Exit code 137 (128 + SIGKILL) should also be detected as OOM."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
@@ -899,21 +876,8 @@ class TestRunLlamaBenchy:
             lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
         )
 
-        class MockStdout:
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                raise StopAsyncIteration
-
-        class MockProcess:
-            stdout = MockStdout()
-
-            async def wait(self):
-                return 137  # 128 + SIGKILL
-
-        async def mock_create(*args, **kwargs):
-            return MockProcess()
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(returncode=137)
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -923,8 +887,10 @@ class TestRunLlamaBenchy:
         with pytest.raises(RuntimeError, match="out of memory"):
             await run_llama_benchy("http://localhost:8888/v1", "test-model")
 
-    async def test_oom_detected_memory_error_in_output(self, monkeypatch):
-        """MemoryError in subprocess output should be detected as OOM."""
+    async def test_oom_detected_memory_error_in_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """MemoryError in subprocess stderr should be detected as OOM."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
         monkeypatch.setattr(
@@ -932,33 +898,14 @@ class TestRunLlamaBenchy:
             lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
         )
 
-        class MockStdout:
-            def __init__(self):
-                self._lines = [
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(
+                stderr_lines=[
                     b"Traceback (most recent call last):\n",
                     b"MemoryError\n",
-                ]
-                self._idx = 0
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if self._idx >= len(self._lines):
-                    raise StopAsyncIteration
-                line = self._lines[self._idx]
-                self._idx += 1
-                return line
-
-        class MockProcess:
-            def __init__(self):
-                self.stdout = MockStdout()
-
-            async def wait(self):
-                return 1  # generic failure
-
-        async def mock_create(*args, **kwargs):
-            return MockProcess()
+                ],
+                returncode=1,
+            )
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -968,7 +915,9 @@ class TestRunLlamaBenchy:
         with pytest.raises(RuntimeError, match="out of memory"):
             await run_llama_benchy("http://localhost:8888/v1", "test-model")
 
-    async def test_non_oom_exit_preserves_original_error(self, monkeypatch):
+    async def test_non_oom_exit_preserves_original_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Non-OOM failures should still report the exit code and output."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
@@ -977,30 +926,8 @@ class TestRunLlamaBenchy:
             lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
         )
 
-        class MockStdout:
-            def __init__(self):
-                self._lines = [b"Some error occurred\n"]
-                self._idx = 0
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if self._idx >= len(self._lines):
-                    raise StopAsyncIteration
-                line = self._lines[self._idx]
-                self._idx += 1
-                return line
-
-        class MockProcess:
-            def __init__(self):
-                self.stdout = MockStdout()
-
-            async def wait(self):
-                return 2
-
-        async def mock_create(*args, **kwargs):
-            return MockProcess()
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(stderr_lines=[b"Some error occurred\n"], returncode=2)
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
@@ -1010,8 +937,8 @@ class TestRunLlamaBenchy:
         with pytest.raises(RuntimeError, match="exited with code 2"):
             await run_llama_benchy("http://localhost:8888/v1", "test-model")
 
-    async def test_oom_detected_cannot_allocate(self, monkeypatch):
-        """'Cannot allocate memory' in output should be detected as OOM."""
+    async def test_oom_detected_cannot_allocate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """'Cannot allocate memory' in stderr should be detected as OOM."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy
 
         monkeypatch.setattr(
@@ -1019,32 +946,11 @@ class TestRunLlamaBenchy:
             lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
         )
 
-        class MockStdout:
-            def __init__(self):
-                self._lines = [
-                    b"OSError: [Errno 12] Cannot allocate memory\n",
-                ]
-                self._idx = 0
-
-            def __aiter__(self):
-                return self
-
-            async def __anext__(self):
-                if self._idx >= len(self._lines):
-                    raise StopAsyncIteration
-                line = self._lines[self._idx]
-                self._idx += 1
-                return line
-
-        class MockProcess:
-            def __init__(self):
-                self.stdout = MockStdout()
-
-            async def wait(self):
-                return 1
-
-        async def mock_create(*args, **kwargs):
-            return MockProcess()
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(
+                stderr_lines=[b"OSError: [Errno 12] Cannot allocate memory\n"],
+                returncode=1,
+            )
 
         monkeypatch.setattr(
             "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",

--- a/tests/test_reporting_and_perf_coverage.py
+++ b/tests/test_reporting_and_perf_coverage.py
@@ -239,16 +239,20 @@ def test_llama_benchy_cli_success_and_unavailable(monkeypatch: pytest.MonkeyPatc
     ok = _sample(calibration_confidence="llama-benchy")
     failed = _sample(error="failed")
 
-    async def fake_run(*args: object, on_output=None, **kwargs: object):
-        for line in (
-            "",
-            "Running test: pp100",
-            "Run 1/1",
-            "Warming up",
-            "Measuring latency",
-            "Average latency 2ms",
-        ):
-            on_output(line)
+    async def fake_run(*args: object, on_progress=None, **kwargs: object):
+        if on_progress is not None:
+            on_progress(
+                {
+                    "type": "request_start",
+                    "prompt_size": 100,
+                    "response_size": 20,
+                    "context_size": 0,
+                    "concurrency": 1,
+                    "run_index": 1,
+                }
+            )
+            on_progress({"type": "request_end"})
+            on_progress({"type": "bench_complete"})
         return benchy.LlamaBenchyResult(version="1.2.3", latency_ms=2.0, samples=[ok, failed])
 
     monkeypatch.setattr(benchy, "is_available", lambda: True)


### PR DESCRIPTION
## Summary
- Exclude `*.md` from Ruff formatting and bump the pre-commit hook to v0.16.0 so CI stops failing when the unbound `ruff>=0.12` pin floats to 0.16 (Markdown code-block formatting).
- Bump the optional llama-benchy dependency to `>=0.4.0`.
- Drive the perf CLI progress bar from structured `--emit-progress` JSONL events (`request_start` / `request_end` / `bench_complete`) instead of scraping human-readable log lines; read stdout/stderr concurrently.

## Test plan
- [x] `ruff check .` / `ruff format --check .` / `mypy`
- [x] Required pytest suite (`2107` passed, seed `104729`)
- [x] `tests/test_llama_benchy.py` + reporting coverage (`68` passed)
- [x] Live probe + `--perf-only` (pp128/tg32) against `192.168.10.221:8080` (llama-benchy 0.4.0)
- [x] Live `run --scenarios TC-01` against the same endpoint (PASS)


Made with [Cursor](https://cursor.com)