### PR TITLE
docs: fix project name code formatting and trailing period in RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,4 @@
-# Releasing tool-eval-bench
+# Releasing `tool-eval-bench`
 
 Checklist for publishing a new release.
 
@@ -67,7 +67,7 @@ git push origin main --tags
 
 ## Post-release
 
-- Add a new `## [Unreleased]` section at the top of `CHANGELOG.md`
+- Add a new `## [Unreleased]` section at the top of `CHANGELOG.md`.
 
 ## Live Certification (required before major releases)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ user-specified LLM endpoints. It does not expose any network services itself.
 
 The primary security considerations are:
 
-- **API keys** stored in `.env` files (never committed to git)
+- **API keys** stored in `.env` files (never committed to Git)
 - **Dataset downloads** — benchmark plugins (GSM8K, MMLU, IFEval) download
   datasets from HuggingFace on first use.  Two download methods are supported:
   - **`datasets` library** (`pip install tool-eval-bench[hf]`): downloads
@@ -17,7 +17,7 @@ The primary security considerations are:
     `datasets-server.huggingface.co`.  No authentication tokens are sent.
   Downloaded data is cached locally under `data/` as JSONL files.
 - **Prompt injection scenarios** (Category K) — these are intentionally
-  adversarial test cases, not vulnerabilities
+  adversarial test cases, not vulnerabilities.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Description
This PR adds backticks to the document title and fixes trailing period punctuation in `RELEASING.md`.

## Details
1. Formatted project name in H1 header (`# Releasing tool-eval-bench` $\to$ `# Releasing `tool-eval-bench``).
2. Added missing trailing period to post-release checklist bullet point.