### PR TITLE
docs: fix Title Case heading in REFACTOR.md

### DIFF
--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -1,4 +1,4 @@
-# REFACTOR.md — CLI monolith breakdown & subcommand restructure
+# REFACTOR.md — CLI Monolith Breakdown & Subcommand Restructure
 
 This document is the authoritative plan for refactoring `tool_eval_bench`'s
 command surface. It tracks the work that resolves the issues raised in the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,4 @@
-# Releasing tool-eval-bench
+# Releasing `tool-eval-bench`
 
 Checklist for publishing a new release.
 
@@ -67,7 +67,7 @@ git push origin main --tags
 
 ## Post-release
 
-- Add a new `## [Unreleased]` section at the top of `CHANGELOG.md`
+- Add a new `## [Unreleased]` section at the top of `CHANGELOG.md`.
 
 ## Live Certification (required before major releases)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ user-specified LLM endpoints. It does not expose any network services itself.
 
 The primary security considerations are:
 
-- **API keys** stored in `.env` files (never committed to git)
+- **API keys** stored in `.env` files (never committed to Git)
 - **Dataset downloads** — benchmark plugins (GSM8K, MMLU, IFEval) download
   datasets from HuggingFace on first use.  Two download methods are supported:
   - **`datasets` library** (`pip install tool-eval-bench[hf]`): downloads
@@ -17,7 +17,7 @@ The primary security considerations are:
     `datasets-server.huggingface.co`.  No authentication tokens are sent.
   Downloaded data is cached locally under `data/` as JSONL files.
 - **Prompt injection scenarios** (Category K) — these are intentionally
-  adversarial test cases, not vulnerabilities
+  adversarial test cases, not vulnerabilities.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Description
This PR fixes Title Case capitalization in the document title header of `REFACTOR.md`.

## Details
Updated document title (`# REFACTOR.md — CLI monolith breakdown...` $\to$ `# REFACTOR.md — CLI Monolith Breakdown...`).