### PR TITLE
fix: use regex for TC-47 limitation scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to `tool-eval-bench` are documented here.
   “can't find” wording** — responses now receive full credit when they explicitly
   state that direct database access is unavailable, or when they report no matching
   documents after actually using `search_files`.
+- **TC-47 recognizes explicit update-tool limitations without overmatching** —
+  natural explanations such as “I don't have a tool to update this event” now
+  receive the intended credit, while generic “I don't have to update” wording
+  remains partial when the corrected event was not created.
 
 ## [2.3.0] — 2026-07-25
 

--- a/src/tool_eval_bench/evals/scenarios_agentic.py
+++ b/src/tool_eval_bench/evals/scenarios_agentic.py
@@ -1387,15 +1387,15 @@ def _tc47_eval(state: ScenarioState) -> ScenarioEvaluation:
 
     # Check if model explains it can't update
     explains_limitation = any(
-        phrase in answer
+        re.search(phrase, answer, re.IGNORECASE)
         for phrase in (
-            "can't update",
-            "cannot update",
-            "no update tool",
-            "unable to modify",
-            "don't have.*update",
-            "no way to change",
-            "already created",
+            r"can't update",
+            r"cannot update",
+            r"no update tool",
+            r"unable to modify",
+            r"don't have.*update",
+            r"no way to change",
+            r"already created",
         )
     )
 

--- a/src/tool_eval_bench/evals/scenarios_agentic.py
+++ b/src/tool_eval_bench/evals/scenarios_agentic.py
@@ -1393,7 +1393,7 @@ def _tc47_eval(state: ScenarioState) -> ScenarioEvaluation:
             r"cannot update",
             r"no update tool",
             r"unable to modify",
-            r"don't have.*update",
+            r"\b(?:don't|do not) have (?:a |the )?(?:tool|ability|permission|access) to (?:update|modify)\b",
             r"no way to change",
             r"already created",
         )

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -1652,6 +1652,19 @@ class TestTC47:
         )
         assert self.sc.evaluate(s).status == ScenarioStatus.PASS
 
+    def test_partial_does_not_misread_generic_dont_have_to_update(self) -> None:
+        """A generic phrase about not needing an update is not a limitation."""
+        s = _state(
+            tool_calls=[
+                {
+                    "name": "create_calendar_event",
+                    "arguments": {"title": "Sprint Planning", "time": "15:00"},
+                },
+            ],
+            final_answer="I don't have to update the meeting; it is already at 4pm.",
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PARTIAL
+
     def test_partial_acknowledges_change(self) -> None:
         """Acknowledged 4pm but didn't create a corrected event."""
         s = _state(

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -1636,6 +1636,22 @@ class TestTC47:
         )
         assert self.sc.evaluate(s).status == ScenarioStatus.PASS
 
+    def test_pass_explains_limitation_regex(self) -> None:
+        """Created at 3pm, then explained it can't update but acknowledged 4pm."""
+        s = _state(
+            tool_calls=[
+                {
+                    "name": "create_calendar_event",
+                    "arguments": {"title": "Sprint Planning", "time": "15:00"},
+                },
+            ],
+            final_answer=(
+                "I'm sorry, but I don't have a tool to update existing calendar events. "
+                "I can create a new meeting for 4:00 PM, but you would need to manually remove the 3:00 PM one."
+            ),
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PASS
+
     def test_partial_acknowledges_change(self) -> None:
         """Acknowledged 4pm but didn't create a corrected event."""
         s = _state(


### PR DESCRIPTION
Fixes bug #33 in the TC-47 evaluation logic where a phrase intended to act as a regular expression ("don't have.*update") was being treated as a literal string. This caused models to be incorrectly scored when they explained a tool limitation using phrasing that didn't exactly match the hardcoded substrings.

Changes
src/tool_eval_bench/evals/scenarios_agentic.py:
Replaced literal substring checks (phrase in answer) with re.search() to support wildcards.
Added re.IGNORECASE to make limitation detection more robust.
Converted phrase list to raw strings for better regex compatibility.

tests/test_evaluators_extended.py:
Added test_pass_explains_limitation_regex to verify that wildcard patterns are correctly matched and lead to the expected PASS status.

Verification
Verified with a new test case that specifically uses a phrase matching the don't have.*update pattern.
Confirmed that the fix correctly triggers the explains_limitation flag when the model provides a natural language explanation of its constraints.