### PR TITLE
feat: auto-detect the llama-benchy tokenizer from the local HuggingFace cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Tokenizer auto-detection for `--perf`** — `--tokenizer` is now rarely needed.
+  The served model id (including the vLLM `root` behind an alias) is matched
+  against the local HuggingFace cache (`HUGGINGFACE_HUB_CACHE`, `HF_HUB_CACHE`,
+  `TRANSFORMERS_CACHE`, `HF_HOME`, `~/.cache/huggingface/hub`), against local
+  model directories, and against llama.cpp's `/props.model_path`. An ambiguous
+  alias is never guessed at, since a wrong-family tokenizer silently skews token
+  counts. Detection is pure filesystem lookup — no network, no `huggingface_hub`
+  dependency. `--tokenizer` still overrides it.
+
+### Changed
+
+- **Offline-tokenizer failures list what's actually cached** — when no tokenizer
+  can be resolved, the error now names the tokenizers present in the HuggingFace
+  cache and shows the `hf download … --include "tokenizer*"` one-liner.
+
 ## [2.4.0] — 2026-07-31
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ## [Unreleased]
 
+## [2.4.0] — 2026-07-31
+
 ### Fixed
 
-- **TC-06 prompt explicitly requires tool use** — the prompt now reads “Use the
-  translate_text tool…”, so a correct direct answer is no longer scored 0/2
+- **TC-06 prompt explicitly requires tool use** — the prompt now reads "Use the
+  translate_text tool…", so a correct direct answer is no longer scored 0/2
   against a hidden requirement. The one-to-many splitting test is unchanged.
 - **llama-benchy offline-tokenizer failure gives actionable guidance** — when
   `--perf` fails on an air-gapped host with an empty HuggingFace cache, the raw

--- a/README.md
+++ b/README.md
@@ -314,16 +314,24 @@ tool-eval-bench bench --perf --benchy-runs 5 --benchy-latency-mode generation
 # Pass arbitrary flags to llama-benchy
 tool-eval-bench bench --perf --benchy-args='--no-warmup --enable-prefix-caching'
 
-# Offline / air-gapped host: point llama-benchy at a local tokenizer
-# (without it, llama-benchy needs network access or a filled HF cache)
+# Override the auto-detected tokenizer
 tool-eval-bench bench --perf --tokenizer /models/Qwen3.6/tokenizer.json
 ```
 
-> **Offline hosts:** llama-benchy always needs a tokenizer to construct prompts.
-> tool-eval-bench runs it in offline mode, so on an air-gapped host with an empty
-> HuggingFace cache you must pass `--tokenizer /path/to/tokenizer.json` (a file or
-> a directory containing `tokenizer.json`). Alternatively use `--perf-legacy`,
-> which needs no tokenizer.
+> **Offline hosts:** llama-benchy always needs a tokenizer to construct prompts, and
+> tool-eval-bench runs it in offline mode. The tokenizer is now located automatically:
+> the served model id (including the vLLM `root` behind an alias) is matched against
+> your HuggingFace cache (`~/.cache/huggingface/hub`, or `HF_HOME`/`HF_HUB_CACHE`),
+> against local model directories, and against the llama.cpp `/props.model_path`.
+> Pass `--tokenizer /path/to/tokenizer.json` (a file or a directory containing one)
+> only to override that, or when nothing is found — the error then lists the
+> tokenizers your cache does have. To fetch just the tokenizer on a networked host:
+>
+> ```bash
+> hf download <org>/<model> --include "tokenizer*" "*config.json"
+> ```
+>
+> Alternatively use `--perf-legacy`, which needs no tokenizer.
 
 | Flag | Default | Purpose |
 |---|---|---|
@@ -336,7 +344,7 @@ tool-eval-bench bench --perf --tokenizer /models/Qwen3.6/tokenizer.json
 | `--benchy-runs` | 3 | Measurement iterations per test point |
 | `--benchy-latency-mode` | `generation` | Latency mode: `api`, `generation`, `none` |
 | `--benchy-args` | — | Pass-through for arbitrary llama-benchy flags |
-| `--tokenizer` | — | Local tokenizer.json path for offline hosts |
+| `--tokenizer` | auto | Local tokenizer.json path; overrides HF-cache auto-detection |
 
 ### Legacy built-in throughput
 

--- a/src/tool_eval_bench/cli/legacy_parser.py
+++ b/src/tool_eval_bench/cli/legacy_parser.py
@@ -273,8 +273,9 @@ def _make_parser() -> argparse.ArgumentParser:
         "--tokenizer",
         default=None,
         help="Path to a local tokenizer.json (or a directory containing it) used "
-        "for llama-benchy prompt construction. Needed on offline/air-gapped hosts "
-        "with an empty HuggingFace cache.",
+        "for llama-benchy prompt construction. Usually unnecessary: the HuggingFace "
+        "cache is searched automatically for the served model. Use this to override "
+        "that, or on offline hosts where auto-detection finds nothing.",
     )
     perf_grp.add_argument(
         "--skip-coherence",

--- a/src/tool_eval_bench/cli/perf.py
+++ b/src/tool_eval_bench/cli/perf.py
@@ -209,6 +209,60 @@ def run_throughput(
     return completed
 
 
+def _probe_llamacpp_model_path(base_url: str) -> str | None:
+    """Best-effort read of llama.cpp ``/props.model_path`` (the loaded GGUF)."""
+    import httpx
+
+    url = f"{base_url.rstrip('/').removesuffix('/v1')}/props"
+    try:
+        resp = httpx.get(url, timeout=3.0)
+        if resp.status_code != 200:
+            return None
+        body = resp.json()
+    except (httpx.HTTPError, OSError, ValueError):
+        return None
+    if not isinstance(body, dict):
+        return None
+    path = body.get("model_path")
+    if not path:
+        settings = body.get("default_generation_settings")
+        if isinstance(settings, dict):
+            path = settings.get("model")
+    return path if isinstance(path, str) and path else None
+
+
+def _resolve_benchy_tokenizer(
+    console: Console,
+    model: str,
+    display_name: str,
+    base_url: str,
+    explicit: str | None,
+) -> str | None:
+    """Find a local tokenizer for llama-benchy, reporting what was used.
+
+    llama-benchy runs offline (``HF_HUB_OFFLINE=1``), so an empty HuggingFace
+    cache makes it fail with a raw transformers traceback.  Resolving the path
+    ourselves means users rarely need to pass ``--tokenizer`` by hand.
+    """
+    from tool_eval_bench.utils.tokenizers import resolve_tokenizer
+
+    if explicit:
+        return explicit
+
+    resolution = resolve_tokenizer(model, model_root=display_name)
+    if not resolution:
+        model_path = _probe_llamacpp_model_path(base_url)
+        if model_path:
+            resolution = resolve_tokenizer(model, model_root=display_name, model_path=model_path)
+
+    if resolution.source in ("hf-cache", "hf-cache-alias"):
+        console.print(f"  [dim]🔤 Tokenizer: {resolution.detail} (HuggingFace cache)[/]")
+    elif resolution.source == "model-path":
+        console.print(f"  [dim]🔤 Tokenizer: {resolution.path}[/]")
+
+    return resolution.path
+
+
 def run_llama_benchy(
     console: Console,
     model: str,
@@ -247,6 +301,8 @@ def run_llama_benchy(
             "Or ensure [bold cyan]uvx[/] is on PATH for zero-install usage."
         )
         sys.exit(1)
+
+    tokenizer = _resolve_benchy_tokenizer(console, model, display_name, base_url, tokenizer)
 
     console.print()
     console.print(

--- a/src/tool_eval_bench/runner/llama_benchy.py
+++ b/src/tool_eval_bench/runner/llama_benchy.py
@@ -448,16 +448,29 @@ async def run_llama_benchy(
                 "couldn't find them in the cached files" in line for line in tail
             ) or any("Error loading tokenizer" in line for line in tail)
             if is_offline_tokenizer:
+                from tool_eval_bench.utils.tokenizers import (
+                    format_candidates,
+                    iter_cached_repos,
+                )
+
+                cached = format_candidates(sorted(iter_cached_repos()))
+                cache_hint = (
+                    f"\nTokenizers found in your HuggingFace cache:\n{cached}\n"
+                    "Pass one of these with --tokenizer if it matches the served model.\n"
+                    if cached
+                    else ""
+                )
                 raise RuntimeError(
                     "llama-benchy could not load a tokenizer.\n"
                     "llama-benchy needs a tokenizer to construct prompts, and this "
                     "host is running in offline mode with no tokenizer in the "
                     "HuggingFace cache.\n"
+                    f"{cache_hint}"
                     "Fixes:\n"
                     "  - Pass --tokenizer /path/to/tokenizer.json (or a directory "
                     "containing tokenizer.json) to use a local tokenizer.\n"
-                    "  - Or run once with network access so the gpt2 fallback "
-                    "tokenizer is cached.\n"
+                    "  - Or fetch just the tokenizer once with network access:\n"
+                    '      hf download <org>/<model> --include "tokenizer*" "*config.json"\n'
                     "  - Or use --perf-legacy for the built-in throughput benchmark, "
                     "which needs no tokenizer."
                 )

--- a/src/tool_eval_bench/utils/tokenizers.py
+++ b/src/tool_eval_bench/utils/tokenizers.py
@@ -1,0 +1,320 @@
+"""Locate a local HuggingFace tokenizer without touching the network.
+
+llama-benchy always needs a tokenizer to construct benchmark prompts.  We run
+it with ``HF_HUB_OFFLINE=1`` (see :mod:`tool_eval_bench.runner.llama_benchy`),
+so on hosts with an empty HuggingFace cache it fails unless the user passes
+``--tokenizer /path/to/tokenizer.json`` — which means hunting through
+``~/.cache/huggingface/hub`` by hand.
+
+This module does that hunt automatically.  It is deliberately dependency-free
+(stdlib ``pathlib`` only): ``huggingface_hub`` is not a runtime dependency, and
+shelling out to the ``hf`` CLI would mean parsing a human-readable table.
+
+The HF cache layout we rely on::
+
+    <cache_root>/models--Qwen--Qwen3.6-35B-A3B-FP8/
+        refs/main                      -> <sha>
+        snapshots/<sha>/tokenizer.json
+
+Resolution order (see :func:`resolve_tokenizer`):
+
+1. An explicit ``--tokenizer`` value always wins.
+2. The served model id / vLLM ``root`` is a local path → look there.
+3. The id looks like ``org/name`` → exact HF cache lookup.
+4. The id is an alias (``qwen3-coder``) → normalised match against cached
+   repos, accepted only when exactly one repo matches.
+5. llama.cpp ``/props.model_path`` → the GGUF's sibling directory.
+6. Nothing found → return the cached repo ids so the caller can show the user
+   what *is* available instead of making them go looking.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_TOKENIZER_FILE = "tokenizer.json"
+_REPO_PREFIX = "models--"
+
+
+@dataclass(frozen=True)
+class TokenizerResolution:
+    """Outcome of a tokenizer lookup.
+
+    ``path`` is None when nothing was found; ``candidates`` then holds the
+    repo ids present in the local HF cache, for a helpful error message.
+    """
+
+    path: str | None = None
+    source: str = "none"
+    detail: str = ""
+    candidates: list[str] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return self.path is not None
+
+
+# ---------------------------------------------------------------------------
+# HF cache discovery
+# ---------------------------------------------------------------------------
+
+
+def hf_cache_roots() -> list[Path]:
+    """Return existing HuggingFace hub cache directories, most specific first.
+
+    Honours ``HUGGINGFACE_HUB_CACHE``, ``HF_HUB_CACHE``, ``TRANSFORMERS_CACHE``
+    and ``HF_HOME`` before falling back to ``~/.cache/huggingface/hub``.
+    """
+    candidates: list[Path] = []
+
+    for var in ("HUGGINGFACE_HUB_CACHE", "HF_HUB_CACHE", "TRANSFORMERS_CACHE"):
+        value = os.environ.get(var)
+        if value:
+            candidates.append(Path(value).expanduser())
+
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        candidates.append(Path(hf_home).expanduser() / "hub")
+
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        candidates.append(Path(xdg).expanduser() / "huggingface" / "hub")
+
+    candidates.append(Path.home() / ".cache" / "huggingface" / "hub")
+
+    roots: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            if not candidate.is_dir():
+                continue
+            resolved = candidate.resolve()
+        except OSError:  # pragma: no cover - unreadable path
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        roots.append(candidate)
+    return roots
+
+
+def _repo_id_from_dir(name: str) -> str:
+    """``models--Qwen--Qwen3.6-35B`` → ``Qwen/Qwen3.6-35B``."""
+    return name[len(_REPO_PREFIX) :].replace("--", "/")
+
+
+def iter_cached_repos(roots: list[Path] | None = None) -> dict[str, Path]:
+    """Map ``repo_id`` → repo directory for every repo in the HF cache."""
+    repos: dict[str, Path] = {}
+    for root in roots if roots is not None else hf_cache_roots():
+        try:
+            entries = sorted(root.iterdir())
+        except OSError:  # pragma: no cover - unreadable cache root
+            continue
+        for entry in entries:
+            if not entry.is_dir() or not entry.name.startswith(_REPO_PREFIX):
+                continue
+            repos.setdefault(_repo_id_from_dir(entry.name), entry)
+    return repos
+
+
+def tokenizer_in_repo(repo_dir: Path) -> Path | None:
+    """Find ``tokenizer.json`` inside a cached repo directory.
+
+    Prefers the snapshot pinned by ``refs/main``; otherwise falls back to the
+    most recently modified snapshot that actually has the file.
+    """
+    ref = repo_dir / "refs" / "main"
+    try:
+        if ref.is_file():
+            sha = ref.read_text(encoding="utf-8").strip()
+            pinned = repo_dir / "snapshots" / sha / _TOKENIZER_FILE
+            if sha and pinned.is_file():
+                return pinned
+    except OSError:  # pragma: no cover - unreadable ref
+        pass
+
+    snapshots = repo_dir / "snapshots"
+    try:
+        found = [
+            snapshot / _TOKENIZER_FILE
+            for snapshot in snapshots.iterdir()
+            if (snapshot / _TOKENIZER_FILE).is_file()
+        ]
+    except OSError:
+        return None
+    if not found:
+        return None
+    return max(found, key=lambda p: p.stat().st_mtime)
+
+
+# ---------------------------------------------------------------------------
+# Local path handling
+# ---------------------------------------------------------------------------
+
+
+def tokenizer_near_path(raw: str) -> Path | None:
+    """Find a tokenizer for a local model path (a directory, or a weights file).
+
+    Accepts a ``tokenizer.json`` directly, a directory containing one, or a
+    model file (``.gguf``, ``.safetensors``) whose sibling directory has one.
+    """
+    if not raw:
+        return None
+    path = Path(raw).expanduser()
+    try:
+        if path.is_file():
+            if path.name == _TOKENIZER_FILE:
+                return path
+            sibling = path.parent / _TOKENIZER_FILE
+            return sibling if sibling.is_file() else None
+        if path.is_dir():
+            direct = path / _TOKENIZER_FILE
+            return direct if direct.is_file() else None
+    except OSError:  # pragma: no cover - permission errors
+        return None
+    return None
+
+
+def _looks_like_path(value: str) -> bool:
+    return value.startswith(("/", "~", "./", "../")) or (len(value) > 2 and value[1] == ":")
+
+
+# ---------------------------------------------------------------------------
+# Alias matching
+# ---------------------------------------------------------------------------
+
+
+def _normalise(value: str) -> str:
+    """Lowercase and strip separators so ``Qwen3.6-35B`` == ``qwen3_6_35b``."""
+    return "".join(ch for ch in value.lower() if ch.isalnum())
+
+
+def _fuzzy_match(alias: str, repos: dict[str, Path]) -> tuple[str, Path] | None:
+    """Match a served alias against cached repo ids.
+
+    Only an unambiguous match is accepted: a tokenizer from the wrong model
+    family silently changes real prompt token counts, which is worse than
+    asking the user for ``--tokenizer``.
+    """
+    target = _normalise(alias)
+    if not target:
+        return None
+
+    exact: list[tuple[str, Path]] = []
+    partial: list[tuple[str, Path]] = []
+    for repo_id, repo_dir in repos.items():
+        full = _normalise(repo_id)
+        name = _normalise(repo_id.split("/")[-1])
+        if target in (full, name):
+            exact.append((repo_id, repo_dir))
+        elif target in name or name in target:
+            partial.append((repo_id, repo_dir))
+
+    for bucket in (exact, partial):
+        if len(bucket) == 1:
+            return bucket[0]
+        if len(bucket) > 1:
+            logger.debug(
+                "tokenizer alias %r matched %d cached repos, refusing to guess",
+                alias,
+                len(bucket),
+            )
+            return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def resolve_tokenizer(
+    model: str,
+    *,
+    explicit: str | None = None,
+    model_root: str | None = None,
+    model_path: str | None = None,
+) -> TokenizerResolution:
+    """Resolve a local tokenizer for ``model``.
+
+    Parameters
+    ----------
+    model:
+        The model id used against the API (the served alias).
+    explicit:
+        A user-supplied ``--tokenizer`` value; returned unchanged if truthy.
+    model_root:
+        The ``root`` field from ``/v1/models`` — on vLLM this is the real HF
+        repo id or local path behind the alias.
+    model_path:
+        A backend-reported weights path, e.g. llama.cpp ``/props.model_path``.
+    """
+    if explicit:
+        return TokenizerResolution(path=explicit, source="explicit", detail="--tokenizer")
+
+    repos = iter_cached_repos()
+    candidates = sorted(repos)
+    ids = [value for value in (model_root, model) if value]
+
+    # 2. Local model directory / file (vLLM root is often an absolute path).
+    for value in ids:
+        if not _looks_like_path(value):
+            continue
+        found = tokenizer_near_path(value)
+        if found:
+            return TokenizerResolution(
+                path=str(found), source="model-path", detail=value, candidates=candidates
+            )
+
+    # 3. Exact HF repo id.
+    for value in ids:
+        repo_dir = repos.get(value)
+        if repo_dir is None:
+            continue
+        found = tokenizer_in_repo(repo_dir)
+        if found:
+            return TokenizerResolution(
+                path=str(found), source="hf-cache", detail=value, candidates=candidates
+            )
+
+    # 4. Alias → unique cached repo.
+    for value in ids:
+        match = _fuzzy_match(value, repos)
+        if match is None:
+            continue
+        repo_id, repo_dir = match
+        found = tokenizer_in_repo(repo_dir)
+        if found:
+            return TokenizerResolution(
+                path=str(found),
+                source="hf-cache-alias",
+                detail=repo_id,
+                candidates=candidates,
+            )
+
+    # 5. Backend-reported weights path (llama.cpp GGUF sibling).
+    if model_path:
+        found = tokenizer_near_path(model_path)
+        if found:
+            return TokenizerResolution(
+                path=str(found), source="model-path", detail=model_path, candidates=candidates
+            )
+
+    # 6. Nothing usable — report what the cache does hold.
+    return TokenizerResolution(candidates=candidates)
+
+
+def format_candidates(candidates: list[str], limit: int = 10) -> str:
+    """Render cached repo ids as an indented bullet list for error output."""
+    if not candidates:
+        return ""
+    shown = candidates[:limit]
+    lines = [f"  - {repo_id}" for repo_id in shown]
+    if len(candidates) > limit:
+        lines.append(f"  … and {len(candidates) - limit} more")
+    return "\n".join(lines)

--- a/tests/test_tokenizer_resolve.py
+++ b/tests/test_tokenizer_resolve.py
@@ -1,0 +1,383 @@
+"""Tests for utils.tokenizers — offline tokenizer auto-detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tool_eval_bench.utils.tokenizers import (
+    format_candidates,
+    hf_cache_roots,
+    iter_cached_repos,
+    resolve_tokenizer,
+    tokenizer_in_repo,
+    tokenizer_near_path,
+)
+
+_USE_SHA = "<use-sha>"
+
+
+def _make_repo(
+    cache: Path,
+    repo_id: str,
+    *,
+    sha: str = "abc123",
+    ref: str | None = _USE_SHA,
+    tokenizer: bool = True,
+) -> Path:
+    """Create a fake HF cache entry for ``repo_id``.
+
+    ``ref`` defaults to ``sha``; pass None for no refs/main, or another value
+    to simulate a dangling ref.
+    """
+    if ref is _USE_SHA:
+        ref = sha
+    repo_dir = cache / f"models--{repo_id.replace('/', '--')}"
+    snapshot = repo_dir / "snapshots" / sha
+    snapshot.mkdir(parents=True)
+    if tokenizer:
+        (snapshot / "tokenizer.json").write_text("{}", encoding="utf-8")
+    if ref is not None:
+        (repo_dir / "refs").mkdir(parents=True, exist_ok=True)
+        (repo_dir / "refs" / "main").write_text(ref, encoding="utf-8")
+    return repo_dir
+
+
+@pytest.fixture
+def hf_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An isolated HF hub cache, with all other cache locations neutralised.
+
+    HOME is redirected too, otherwise the developer's real
+    ``~/.cache/huggingface/hub`` leaks into the scan.
+    """
+    cache = tmp_path / "hub"
+    cache.mkdir()
+    for var in ("HF_HOME", "TRANSFORMERS_CACHE", "HF_HUB_CACHE", "XDG_CACHE_HOME"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(cache))
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+    return cache
+
+
+# -- cache discovery --------------------------------------------------------
+
+
+def test_hf_cache_roots_prefers_env(hf_cache: Path) -> None:
+    assert hf_cache_roots()[0] == hf_cache
+
+
+def test_hf_cache_roots_skips_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(tmp_path / "nope"))
+    assert all(root.is_dir() for root in hf_cache_roots())
+
+
+def test_hf_cache_roots_deduplicates(hf_cache: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HF_HUB_CACHE", str(hf_cache))
+    assert hf_cache_roots().count(hf_cache) == 1
+
+
+def test_iter_cached_repos_maps_repo_ids(hf_cache: Path) -> None:
+    _make_repo(hf_cache, "Qwen/Qwen3.6-35B-A3B-FP8")
+    _make_repo(hf_cache, "gpt2")
+    (hf_cache / "not-a-repo").mkdir()
+
+    repos = iter_cached_repos()
+
+    assert set(repos) == {"Qwen/Qwen3.6-35B-A3B-FP8", "gpt2"}
+
+
+# -- snapshot selection -----------------------------------------------------
+
+
+def test_tokenizer_in_repo_follows_refs_main(hf_cache: Path) -> None:
+    repo = _make_repo(hf_cache, "org/model", sha="pinned")
+    other = repo / "snapshots" / "stale"
+    other.mkdir()
+    (other / "tokenizer.json").write_text("{}", encoding="utf-8")
+
+    found = tokenizer_in_repo(repo)
+
+    assert found is not None
+    assert found.parent.name == "pinned"
+
+
+def test_tokenizer_in_repo_falls_back_when_ref_missing(hf_cache: Path) -> None:
+    repo = _make_repo(hf_cache, "org/model", sha="only", ref=None)
+    assert tokenizer_in_repo(repo) == repo / "snapshots" / "only" / "tokenizer.json"
+
+
+def test_tokenizer_in_repo_ignores_snapshot_without_tokenizer(hf_cache: Path) -> None:
+    repo = _make_repo(hf_cache, "org/model", tokenizer=False)
+    assert tokenizer_in_repo(repo) is None
+
+
+def test_tokenizer_in_repo_handles_dangling_ref(hf_cache: Path) -> None:
+    """A refs/main pointing at a snapshot without tokenizer.json still resolves."""
+    repo = _make_repo(hf_cache, "org/model", sha="good", ref="gone")
+    assert tokenizer_in_repo(repo) == repo / "snapshots" / "good" / "tokenizer.json"
+
+
+# -- local paths ------------------------------------------------------------
+
+
+def test_tokenizer_near_path_directory(tmp_path: Path) -> None:
+    (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+    assert tokenizer_near_path(str(tmp_path)) == tmp_path / "tokenizer.json"
+
+
+def test_tokenizer_near_path_file_itself(tmp_path: Path) -> None:
+    target = tmp_path / "tokenizer.json"
+    target.write_text("{}", encoding="utf-8")
+    assert tokenizer_near_path(str(target)) == target
+
+
+def test_tokenizer_near_path_gguf_sibling(tmp_path: Path) -> None:
+    (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+    gguf = tmp_path / "model-Q4_K_M.gguf"
+    gguf.write_bytes(b"GGUF")
+    assert tokenizer_near_path(str(gguf)) == tmp_path / "tokenizer.json"
+
+
+def test_tokenizer_near_path_missing(tmp_path: Path) -> None:
+    assert tokenizer_near_path(str(tmp_path)) is None
+    assert tokenizer_near_path("") is None
+
+
+# -- resolution order -------------------------------------------------------
+
+
+def test_explicit_wins(hf_cache: Path) -> None:
+    _make_repo(hf_cache, "org/model")
+    resolution = resolve_tokenizer("org/model", explicit="/custom/tokenizer.json")
+
+    assert resolution.path == "/custom/tokenizer.json"
+    assert resolution.source == "explicit"
+    assert bool(resolution) is True
+
+
+def test_exact_repo_id_from_hf_cache(hf_cache: Path) -> None:
+    _make_repo(hf_cache, "Qwen/Qwen3.6-35B-A3B-FP8")
+
+    resolution = resolve_tokenizer("Qwen/Qwen3.6-35B-A3B-FP8")
+
+    assert resolution.source == "hf-cache"
+    assert resolution.path is not None
+    assert resolution.path.endswith("tokenizer.json")
+
+
+def test_vllm_root_resolves_alias(hf_cache: Path) -> None:
+    """The served alias is meaningless; /v1/models root carries the real id."""
+    _make_repo(hf_cache, "Qwen/Qwen3.6-35B-A3B-FP8")
+
+    resolution = resolve_tokenizer("my-model", model_root="Qwen/Qwen3.6-35B-A3B-FP8")
+
+    assert resolution.source == "hf-cache"
+    assert resolution.detail == "Qwen/Qwen3.6-35B-A3B-FP8"
+
+
+def test_local_model_directory(tmp_path: Path, hf_cache: Path) -> None:
+    model_dir = tmp_path / "models" / "Qwen3.6"
+    model_dir.mkdir(parents=True)
+    (model_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+
+    resolution = resolve_tokenizer("qwen", model_root=str(model_dir))
+
+    assert resolution.source == "model-path"
+    assert resolution.path == str(model_dir / "tokenizer.json")
+
+
+def test_alias_matches_single_cached_repo(hf_cache: Path) -> None:
+    _make_repo(hf_cache, "Qwen/Qwen3.6-35B-A3B-FP8")
+    _make_repo(hf_cache, "gpt2")
+
+    resolution = resolve_tokenizer("qwen3.6-35b-a3b-fp8")
+
+    assert resolution.source == "hf-cache-alias"
+    assert resolution.detail == "Qwen/Qwen3.6-35B-A3B-FP8"
+
+
+def test_ambiguous_alias_is_refused(hf_cache: Path) -> None:
+    """A wrong-family tokenizer silently skews token counts — never guess."""
+    _make_repo(hf_cache, "Intel/Qwen3.6-27B-int4-AutoRound")
+    _make_repo(hf_cache, "unsloth/Qwen3.6-27B-int4-AutoRound")
+
+    resolution = resolve_tokenizer("Qwen3.6-27B-int4-AutoRound")
+
+    assert resolution.path is None
+
+
+def test_llamacpp_model_path_fallback(tmp_path: Path, hf_cache: Path) -> None:
+    gguf_dir = tmp_path / "gguf"
+    gguf_dir.mkdir()
+    (gguf_dir / "tokenizer.json").write_text("{}", encoding="utf-8")
+    gguf = gguf_dir / "model.gguf"
+    gguf.write_bytes(b"GGUF")
+
+    resolution = resolve_tokenizer("unknown-alias", model_path=str(gguf))
+
+    assert resolution.source == "model-path"
+    assert resolution.path == str(gguf_dir / "tokenizer.json")
+
+
+def test_unresolved_reports_candidates(hf_cache: Path) -> None:
+    _make_repo(hf_cache, "gpt2")
+    _make_repo(hf_cache, "deepseek-ai/DeepSeek-V4-Flash")
+
+    resolution = resolve_tokenizer("totally-unrelated-name")
+
+    assert resolution.path is None
+    assert resolution.source == "none"
+    assert bool(resolution) is False
+    assert resolution.candidates == ["deepseek-ai/DeepSeek-V4-Flash", "gpt2"]
+
+
+def test_empty_cache_resolves_to_nothing(hf_cache: Path) -> None:
+    resolution = resolve_tokenizer("any-model")
+    assert resolution.path is None
+    assert resolution.candidates == []
+
+
+# -- error-message rendering ------------------------------------------------
+
+
+def test_format_candidates_lists_entries() -> None:
+    assert format_candidates(["a/b", "c/d"]) == "  - a/b\n  - c/d"
+
+
+def test_format_candidates_truncates() -> None:
+    rendered = format_candidates([f"org/m{i}" for i in range(12)], limit=3)
+    assert rendered.endswith("… and 9 more")
+
+
+def test_format_candidates_empty() -> None:
+    assert format_candidates([]) == ""
+
+
+# -- CLI wiring -------------------------------------------------------------
+
+
+def test_perf_helper_prefers_explicit_and_skips_probe(
+    hf_cache: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit --tokenizer short-circuits both the cache scan and /props."""
+    from rich.console import Console
+
+    from tool_eval_bench.cli import perf
+
+    def _boom(_: str) -> str | None:
+        raise AssertionError("/props must not be probed when --tokenizer is given")
+
+    monkeypatch.setattr(perf, "_probe_llamacpp_model_path", _boom)
+
+    result = perf._resolve_benchy_tokenizer(
+        Console(), "m", "m", "http://localhost:8000/v1", "/explicit/tokenizer.json"
+    )
+
+    assert result == "/explicit/tokenizer.json"
+
+
+def test_perf_helper_finds_cached_tokenizer(
+    hf_cache: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from rich.console import Console
+
+    from tool_eval_bench.cli import perf
+
+    _make_repo(hf_cache, "Qwen/Qwen3.6-35B-A3B-FP8")
+    monkeypatch.setattr(perf, "_probe_llamacpp_model_path", lambda _: None)
+    console = Console(record=True, width=100)
+
+    result = perf._resolve_benchy_tokenizer(
+        console, "alias", "Qwen/Qwen3.6-35B-A3B-FP8", "http://localhost:8000/v1", None
+    )
+
+    assert result is not None
+    assert result.endswith("tokenizer.json")
+    assert "Qwen/Qwen3.6-35B-A3B-FP8" in console.export_text()
+
+
+def test_perf_helper_falls_back_to_llamacpp_props(
+    tmp_path: Path, hf_cache: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With nothing in the cache, /props.model_path is the last resort."""
+    from rich.console import Console
+
+    from tool_eval_bench.cli import perf
+
+    (tmp_path / "tokenizer.json").write_text("{}", encoding="utf-8")
+    gguf = tmp_path / "model.gguf"
+    gguf.write_bytes(b"GGUF")
+    monkeypatch.setattr(perf, "_probe_llamacpp_model_path", lambda _: str(gguf))
+
+    result = perf._resolve_benchy_tokenizer(
+        Console(), "alias", "alias", "http://localhost:8080/v1", None
+    )
+
+    assert result == str(tmp_path / "tokenizer.json")
+
+
+def test_perf_helper_returns_none_when_unresolved(
+    hf_cache: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from rich.console import Console
+
+    from tool_eval_bench.cli import perf
+
+    monkeypatch.setattr(perf, "_probe_llamacpp_model_path", lambda _: None)
+
+    assert (
+        perf._resolve_benchy_tokenizer(Console(), "m", "m", "http://localhost:8000/v1", None)
+        is None
+    )
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: object) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> object:
+        return self._payload
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"model_path": "/models/m.gguf"}, "/models/m.gguf"),
+        ({"default_generation_settings": {"model": "/models/m.gguf"}}, "/models/m.gguf"),
+        ({}, None),
+        ([], None),
+    ],
+)
+def test_probe_llamacpp_model_path(
+    payload: object, expected: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import httpx
+
+    from tool_eval_bench.cli import perf
+
+    seen: list[str] = []
+
+    def fake_get(url: str, **kwargs: object) -> _FakeResponse:
+        seen.append(url)
+        return _FakeResponse(200, payload)
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    assert perf._probe_llamacpp_model_path("http://localhost:8080/v1") == expected
+    assert seen == ["http://localhost:8080/props"]
+
+
+def test_probe_llamacpp_model_path_swallows_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    from tool_eval_bench.cli import perf
+
+    def fake_get(url: str, **kwargs: object) -> _FakeResponse:
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    assert perf._probe_llamacpp_model_path("http://localhost:8080/v1") is None


### PR DESCRIPTION
## Summary

`--perf` runs llama-benchy with `HF_HUB_OFFLINE=1`, so on a host with an empty HuggingFace cache it fails until the user hunts down a `tokenizer.json` and passes `--tokenizer` by hand — the situation reported on the [NVIDIA forum thread](https://forums.developer.nvidia.com/t/introducing-tool-eval-bench-cli/366903/187). We already know the served model id (including the vLLM `root` behind an alias, via `/v1/models`), so we can find the tokenizer ourselves.

## Changes

New `utils/tokenizers.py` — `resolve_tokenizer()` returns a `TokenizerResolution` (`path`/`source`/`detail`/`candidates`), resolving in this order:

1. explicit `--tokenizer` (always wins)
2. local model directory or file — vLLM `root` is often an absolute path; a `.gguf` resolves via its sibling dir
3. exact HF repo id → `refs/main` snapshot, falling back to the newest snapshot that actually holds `tokenizer.json`
4. alias → normalised match against cached repos, **unique matches only**
5. llama.cpp `/props.model_path`
6. otherwise, every repo id in the cache, for the error message

Cache roots honour `HUGGINGFACE_HUB_CACHE`, `HF_HUB_CACHE`, `TRANSFORMERS_CACHE`, `HF_HOME`, `XDG_CACHE_HOME`, then `~/.cache/huggingface/hub`, deduped by resolved path.

Wiring in `cli/perf.py`: `_resolve_benchy_tokenizer()` runs after the availability check and prints e.g. `🔤 Tokenizer: Qwen/Qwen3.6-35B-A3B-FP8 (HuggingFace cache)`. The `/props` probe is lazy — only fired if the cache scan comes up empty. The offline failure in `runner/llama_benchy.py` now lists the cached tokenizers and the `hf download … --include "tokenizer*"` one-liner.

User-facing impact: `--tokenizer` becomes an override rather than a requirement. No scoring impact — the tokenizer only affects llama-benchy prompt construction.

Notes for reviewers:

- **An ambiguous alias is deliberately never guessed at.** A wrong-family tokenizer silently skews prompt token counts, which is worse than asking for `--tokenizer`.
- **Stdlib only.** `huggingface_hub` is not a runtime dependency, and shelling out to the `hf` CLI would mean parsing a table meant for humans. No network calls beyond the existing-style local `/props` probe.
- **Pure GGUF llama.cpp setups with no HF cache still need `--tokenizer`** (or `hf download`, or `--perf-legacy`) — the tokenizer embedded in a GGUF isn't readable as `tokenizer.json`. They now get told exactly that instead of a traceback.

## Validation

- [x] Focused tests pass — 33 new tests in `tests/test_tokenizer_resolve.py` covering cache discovery, snapshot/dangling-ref selection, each resolution step, ambiguity refusal, and the CLI wiring. The fixture redirects `HOME` so a developer's real cache can't leak into the scan.
- [x] `.venv/bin/ruff check .` passes.
- [x] `.venv/bin/ruff format --check .` passes.
- [x] `.venv/bin/mypy` passes.
- [x] Required pytest suite passes — 2346 passed, 1 deselected.
- [x] Live-server testing not required; resolution is filesystem-only and the `/props` probe is covered by mocked-transport tests. Also sanity-checked against a real `~/.cache/huggingface/hub`: exact ids, vLLM-alias-via-`root`, and alias matching all resolve; an unknown name correctly resolves to nothing.

## Contributor checklist

- [x] This PR contains one focused, logically related change.
- [x] Regression or behavior tests were added or updated where appropriate.
- [x] Positive and negative/false-positive cases are covered for evaluator changes — n/a, no evaluator changes; the analogous false-positive case (ambiguous alias) is covered.
- [x] `README.md` and/or `CHANGELOG.md` is updated when applicable.
- [x] No credentials, live endpoints, generated run artifacts, or unrelated formatting changes are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)