### PR TITLE
fix(scenarios): accept explicit language designators in TC-06 translate_text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ All notable changes to `tool-eval-bench` are documented here.
   its AST, and natural date/time clarification questions receive pass or partial
   credit according to which missing parameters they actually request.
 
+- **TC-06 `translate_text` language designators (PR #43)** — the mock and
+  evaluator now accept an explicit, finite set of language designators
+  (canonical names plus aliases such as `es`, `ja`, `spa`, `jpn`, `en-us`).
+  The `translate_text` tool schema advertises exactly the union of the
+  designators accepted across all scenarios; the previous schema listed
+  `german` for TC-06 even though its mock rejected it, and omitted the
+  aliases the evaluator accepted. A dedicated contract test keeps the
+  schema enum and the scenario alias tables in sync.
+
 ### Added
 
 - **Tokenizer auto-detection for `--perf`** — `--tokenizer` is now rarely needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,12 @@ All notable changes to `tool-eval-bench` are documented here.
 - **TC-06 `translate_text` language designators (PR #43)** — the mock and
   evaluator now accept an explicit, finite set of language designators
   (canonical names plus aliases such as `es`, `ja`, `spa`, `jpn`, `en-us`).
-  The `translate_text` tool schema advertises exactly the union of the
-  designators accepted across all scenarios; the previous schema listed
+  The `translate_text` tool schema advertises role-specific unions of the
+  designators accepted across all scenarios; source-only regional English
+  aliases are not offered as target values. The previous schema listed
   `german` for TC-06 even though its mock rejected it, and omitted the
   aliases the evaluator accepted. A dedicated contract test keeps the
-  schema enum and the scenario alias tables in sync.
+  schema enums and the scenario alias tables in sync.
 
 ### Added
 

--- a/src/tool_eval_bench/domain/tools.py
+++ b/src/tool_eval_bench/domain/tools.py
@@ -14,10 +14,11 @@ from typing import Any
 
 # Language designators accepted by the translate_text mock/evaluators.
 #
-# This is the explicit, finite set used across all scenarios — the schema
-# advertises exactly these values and the scenario handlers accept exactly
-# these values (full canonical names plus a small alias table). It is NOT a
-# full ISO 639 / BCP-47 resolver: only the designators listed here are valid.
+# These are the explicit, finite values used across all scenarios. The
+# source-language enum uses this union; target_language has a narrower,
+# role-specific union below because the scenarios never translate *to*
+# regional English variants. This is NOT a full ISO 639 / BCP-47 resolver:
+# only the designators listed here are valid.
 # tests/test_tc06_translate_text_contract.py keeps this list in sync with
 # the scenario alias tables.
 TRANSLATE_LANGUAGE_DESIGNATORS: list[str] = [
@@ -43,6 +44,16 @@ TRANSLATE_LANGUAGE_DESIGNATORS: list[str] = [
     "german",
     "de",
     "deutsch",
+]
+
+# Target values accepted by at least one translate_text scenario handler.
+# en-us/en-gb/en-ca/en-au are valid TC-06 source designators, but no scenario
+# accepts them as target values, so advertising them for target_language would
+# let a model make a schema-valid call that the mock always rejects.
+TRANSLATE_TARGET_LANGUAGE_DESIGNATORS: list[str] = [
+    designator
+    for designator in TRANSLATE_LANGUAGE_DESIGNATORS
+    if designator not in {"en-us", "en-gb", "en-ca", "en-au"}
 ]
 
 UNIVERSAL_TOOLS: list[dict[str, Any]] = [
@@ -214,7 +225,7 @@ UNIVERSAL_TOOLS: list[dict[str, Any]] = [
                     },
                     "target_language": {
                         "type": "string",
-                        "enum": TRANSLATE_LANGUAGE_DESIGNATORS,
+                        "enum": TRANSLATE_TARGET_LANGUAGE_DESIGNATORS,
                     },
                 },
                 "required": ["text", "source_language", "target_language"],

--- a/src/tool_eval_bench/domain/tools.py
+++ b/src/tool_eval_bench/domain/tools.py
@@ -12,6 +12,39 @@ from __future__ import annotations
 
 from typing import Any
 
+# Language designators accepted by the translate_text mock/evaluators.
+#
+# This is the explicit, finite set used across all scenarios — the schema
+# advertises exactly these values and the scenario handlers accept exactly
+# these values (full canonical names plus a small alias table). It is NOT a
+# full ISO 639 / BCP-47 resolver: only the designators listed here are valid.
+# tests/test_tc06_translate_text_contract.py keeps this list in sync with
+# the scenario alias tables.
+TRANSLATE_LANGUAGE_DESIGNATORS: list[str] = [
+    "english",
+    "en",
+    "en-us",
+    "en-gb",
+    "en-ca",
+    "en-au",
+    "spanish",
+    "es",
+    "es-es",
+    "es-419",
+    "espanol",
+    "español",
+    "castilian",
+    "spa",
+    "japanese",
+    "ja",
+    "ja-jp",
+    "日本語",
+    "jpn",
+    "german",
+    "de",
+    "deutsch",
+]
+
 UNIVERSAL_TOOLS: list[dict[str, Any]] = [
     {
         "type": "function",
@@ -175,8 +208,14 @@ UNIVERSAL_TOOLS: list[dict[str, Any]] = [
                 "type": "object",
                 "properties": {
                     "text": {"type": "string"},
-                    "source_language": {"type": "string"},
-                    "target_language": {"type": "string"},
+                    "source_language": {
+                        "type": "string",
+                        "enum": TRANSLATE_LANGUAGE_DESIGNATORS,
+                    },
+                    "target_language": {
+                        "type": "string",
+                        "enum": TRANSLATE_LANGUAGE_DESIGNATORS,
+                    },
                 },
                 "required": ["text", "source_language", "target_language"],
                 "additionalProperties": False,

--- a/src/tool_eval_bench/evals/scenarios.py
+++ b/src/tool_eval_bench/evals/scenarios.py
@@ -346,28 +346,66 @@ def _tc05_eval(state: ScenarioState) -> ScenarioEvaluation:
 # ===================================================================
 
 
+# Language designators accepted by the translate_text mock and evaluator.
+# This is an explicit, finite alias table for the canonical languages the
+# mock actually translates — NOT a full ISO 639 / BCP-47 resolver. Only the
+# designators listed here are valid. The translate_text schema in
+# domain/tools.py (TRANSLATE_LANGUAGE_DESIGNATORS) advertises exactly these
+# values plus the German designators used by the extended scenarios; the
+# contract test (tests/test_tc06_translate_text_contract.py) keeps them in
+# sync.
+_LANGUAGE_ALIASES: dict[str, str] = {
+    "english": "english",
+    "en": "english",
+    "en-us": "english",
+    "en-gb": "english",
+    "en-ca": "english",
+    "en-au": "english",
+    "spanish": "spanish",
+    "es": "spanish",
+    "es-es": "spanish",
+    "es-419": "spanish",
+    "espanol": "spanish",
+    "español": "spanish",
+    "castilian": "spanish",
+    "spa": "spanish",
+    "japanese": "japanese",
+    "ja": "japanese",
+    "ja-jp": "japanese",
+    "日本語": "japanese",
+    "jpn": "japanese",
+}
+
+
+def _language_alias(value: Any) -> str | None:
+    """Resolve a language designator to the canonical language name used by
+    the mock, or None when the string is not a language designator."""
+    return _LANGUAGE_ALIASES.get(_normalize(_as_str(value)))
+
+
 def _tc06_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     if call.name == "translate_text":
-        target = _normalize(_as_str(call.arguments.get("target_language")))
+        target = _language_alias(call.arguments.get("target_language"))
         if target == "spanish":
             return _noise({"translated": "¿Dónde está el hospital más cercano?"}, "translate_text")
         if target == "japanese":
             return _noise({"translated": "最寄りの病院はどこですか？"}, "translate_text")
-        return _noise({"error": f"Unsupported target language {target}."}, "translate_text")
+        raw = _as_str(call.arguments.get("target_language"))
+        return _noise({"error": f"Unsupported target language {raw}."}, "translate_text")
     return _generic_tool_fallback(call)
 
 
 def _tc06_eval(state: ScenarioState) -> ScenarioEvaluation:
     calls = _tool_calls_by_name(state, "translate_text")
     has_spanish = any(
-        _normalize(_as_str(c.arguments.get("source_language"))) == "english"
-        and _normalize(_as_str(c.arguments.get("target_language"))) == "spanish"
+        _language_alias(c.arguments.get("source_language")) == "english"
+        and _language_alias(c.arguments.get("target_language")) == "spanish"
         and _includes_text(c.arguments.get("text"), "where is the nearest hospital")
         for c in calls
     )
     has_japanese = any(
-        _normalize(_as_str(c.arguments.get("source_language"))) == "english"
-        and _normalize(_as_str(c.arguments.get("target_language"))) == "japanese"
+        _language_alias(c.arguments.get("source_language")) == "english"
+        and _language_alias(c.arguments.get("target_language")) == "japanese"
         and _includes_text(c.arguments.get("text"), "where is the nearest hospital")
         for c in calls
     )
@@ -379,10 +417,12 @@ def _tc06_eval(state: ScenarioState) -> ScenarioEvaluation:
         )
         for c in calls
     )
-    # Extra calls only disqualify when they are off-target. A repeated call for
-    # one of the two requested languages is a retry, not a mistake.
+    # A call is extra/off-target when its target language is not one of the
+    # two required languages (Spanish or Japanese by any accepted designator)
+    # or when the text is missing/off-topic. Calls targeting Spanish or
+    # Japanese by any accepted designator count as translation attempts.
     extraneous = any(
-        _normalize(_as_str(c.arguments.get("target_language"))) not in ("spanish", "japanese")
+        _language_alias(c.arguments.get("target_language")) not in ("spanish", "japanese")
         or not _includes_text(c.arguments.get("text"), "where is the nearest hospital")
         for c in calls
     )

--- a/tests/test_tc06_translate_text_contract.py
+++ b/tests/test_tc06_translate_text_contract.py
@@ -1,0 +1,208 @@
+"""Focused contract tests for the TC-06 translate_text language designators.
+
+Pins the behaviour of the TC-06 scenario's mock and evaluator for the
+finite language-designator vocabulary introduced by PR #43:
+
+1. the mock accepts any accepted Spanish/Japanese designator as the target;
+   English designators are valid *sources* only and error as targets;
+2. unsupported designators are rejected by the mock;
+3. the evaluator recognises Spanish/Japanese by any accepted designator and
+   returns PASS only when both translations are present in the final answer —
+   a missing translation fails, and extra/off-target calls or an incomplete
+   answer downgrade PASS to PARTIAL;
+4. the translate_text tool schema advertises exactly the finite supported
+   designator set — the TC-06 alias table plus the German designators carried
+   by the shared tool — with no omissions and no extras. This is NOT a full
+   ISO 639 / BCP-47 resolver: only the explicitly listed designators are
+   valid.
+
+The tests exercise the scenario's public ``handle_tool_call``/``evaluate``
+methods with real ``ScenarioState``/``ToolCallRecord`` objects built with the
+repo's ``make_state``/``make_tool_call`` helpers (tests/conftest.py), so they
+run through the same code path as the main contract suite.
+"""
+
+import pytest
+from conftest import make_state, make_tool_call
+
+from tool_eval_bench.domain.scenarios import ScenarioStatus
+from tool_eval_bench.domain.tools import (
+    TRANSLATE_LANGUAGE_DESIGNATORS,
+    UNIVERSAL_TOOLS,
+)
+from tool_eval_bench.evals.scenarios import _LANGUAGE_ALIASES, SCENARIOS
+
+# German designators accepted by the shared translate_text tool schema (used
+# by other scenarios' handlers) but NOT part of the TC-06 alias table: the
+# TC-06 mock rejects them. The schema advertises the union of both sets.
+_EXTENDED_ONLY = {"german", "de", "deutsch"}
+
+TC06 = next(s for s in SCENARIOS if s.id == "TC-06")
+
+_TEXT = "Where is the nearest hospital?"
+_ANSWER_SPANISH = "¿Dónde está el hospital más cercano?"
+_ANSWER_JAPANESE = "最寄りの病院はどこですか？"
+
+
+def _call(**arguments):
+    return make_tool_call(name="translate_text", arguments=arguments)
+
+
+def _state(*calls, final_answer=""):
+    return make_state(tool_calls=list(calls), final_answer=final_answer)
+
+
+def _mock(**arguments):
+    return TC06.handle_tool_call(_state(), _call(**arguments))
+
+
+# ---------------------------------------------------------------------------
+# Mock: accepted target designators
+# ---------------------------------------------------------------------------
+
+
+def test_mock_accepts_spanish_designators():
+    for designator in ("Spanish", "es", "ES", "es-ES", "es-419", "español", "castilian"):
+        result = _mock(source_language="English", target_language=designator, text=_TEXT)
+        assert "translated" in result, designator
+
+
+def test_mock_accepts_japanese_designators():
+    for designator in ("Japanese", "ja", "ja-JP", "jpn", "日本語"):
+        result = _mock(source_language="English", target_language=designator, text=_TEXT)
+        assert "translated" in result, designator
+
+
+# ---------------------------------------------------------------------------
+# Mock: rejected targets
+# ---------------------------------------------------------------------------
+
+
+def test_mock_rejects_unsupported_targets():
+    for designator in ("German", "de", "French", "fr"):
+        result = _mock(source_language="English", target_language=designator, text=_TEXT)
+        assert "error" in result, designator
+
+
+def test_mock_rejects_english_as_target():
+    """English designators are valid *sources* only — never targets."""
+    for designator in ("English", "en", "en-US"):
+        result = _mock(source_language="English", target_language=designator, text=_TEXT)
+        assert "error" in result, designator
+
+
+@pytest.mark.parametrize("designator", sorted(_LANGUAGE_ALIASES))
+def test_mock_handles_every_claimed_alias(designator):
+    # Every alias the TC-06 handler claims to understand is exercised:
+    # Spanish/Japanese designators translate, English ones error as targets.
+    result = _mock(source_language="English", target_language=designator, text=_TEXT)
+    if _LANGUAGE_ALIASES[designator] == "english":
+        assert "error" in result, designator
+    else:
+        assert "translated" in result, designator
+
+
+# ---------------------------------------------------------------------------
+# Evaluator
+# ---------------------------------------------------------------------------
+
+
+def test_evaluator_passes_with_alias_targets():
+    state = _state(
+        _call(source_language="English", target_language="es", text=_TEXT),
+        _call(source_language="en", target_language="Japanese", text=_TEXT),
+        final_answer=f"{_ANSWER_SPANISH} {_ANSWER_JAPANESE}",
+    )
+    result = TC06.evaluate(state)
+    assert result.status == ScenarioStatus.PASS
+    assert result.points == 2
+
+
+def test_evaluator_fails_when_spanish_translation_missing():
+    state = _state(
+        _call(source_language="English", target_language="Japanese", text=_TEXT),
+        final_answer=_ANSWER_JAPANESE,
+    )
+    result = TC06.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL
+
+
+def test_evaluator_fails_when_japanese_translation_missing():
+    state = _state(
+        _call(source_language="English", target_language="es", text=_TEXT),
+        final_answer=_ANSWER_SPANISH,
+    )
+    result = TC06.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL
+
+
+def test_evaluator_fails_when_source_not_english():
+    state = _state(
+        _call(source_language="German", target_language="Spanish", text=_TEXT),
+        _call(source_language="en", target_language="Japanese", text=_TEXT),
+        final_answer=f"{_ANSWER_SPANISH} {_ANSWER_JAPANESE}",
+    )
+    result = TC06.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL
+
+
+def test_evaluator_fails_when_targets_bundled_in_one_call():
+    state = _state(
+        _call(
+            source_language="English",
+            target_language="Spanish and Japanese",
+            text=_TEXT,
+        ),
+        final_answer=f"{_ANSWER_SPANISH} {_ANSWER_JAPANESE}",
+    )
+    result = TC06.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL
+
+
+def test_evaluator_partial_with_off_target_call():
+    state = _state(
+        _call(source_language="English", target_language="Spanish", text=_TEXT),
+        _call(source_language="en", target_language="ja", text=_TEXT),
+        _call(source_language="English", target_language="German", text=_TEXT),
+        final_answer=f"{_ANSWER_SPANISH} {_ANSWER_JAPANESE}",
+    )
+    result = TC06.evaluate(state)
+    assert result.status == ScenarioStatus.PARTIAL
+    assert result.points == 1
+
+
+def test_evaluator_partial_when_answer_markers_missing():
+    state = _state(
+        _call(source_language="English", target_language="Spanish", text=_TEXT),
+        _call(source_language="en", target_language="Japanese", text=_TEXT),
+        final_answer="Here are the translations.",
+    )
+    result = TC06.evaluate(state)
+    assert result.status == ScenarioStatus.PARTIAL
+    assert result.points == 1
+
+
+# ---------------------------------------------------------------------------
+# Schema: translate_text advertises exactly the supported designator set
+# ---------------------------------------------------------------------------
+
+
+def test_translate_text_schema_enum_matches_supported_designators():
+    tool = next(t for t in UNIVERSAL_TOOLS if t["function"]["name"] == "translate_text")
+    props = tool["function"]["parameters"]["properties"]
+    src_enum = props["source_language"]["enum"]
+    tgt_enum = props["target_language"]["enum"]
+    assert src_enum == TRANSLATE_LANGUAGE_DESIGNATORS
+    assert tgt_enum == TRANSLATE_LANGUAGE_DESIGNATORS
+
+    # The schema is exactly the TC-06 alias table plus the German
+    # designators carried by the shared tool: no omissions, no extras.
+    expected = set(_LANGUAGE_ALIASES) | _EXTENDED_ONLY
+    assert set(TRANSLATE_LANGUAGE_DESIGNATORS) == expected
+    assert len(TRANSLATE_LANGUAGE_DESIGNATORS) == len(expected)
+
+
+def test_tc06_registered():
+    assert TC06.id == "TC-06"
+    assert TC06.handle_tool_call is not None
+    assert TC06.evaluate is not None

--- a/tests/test_tc06_translate_text_contract.py
+++ b/tests/test_tc06_translate_text_contract.py
@@ -10,11 +10,11 @@ finite language-designator vocabulary introduced by PR #43:
    returns PASS only when both translations are present in the final answer —
    a missing translation fails, and extra/off-target calls or an incomplete
    answer downgrade PASS to PARTIAL;
-4. the translate_text tool schema advertises exactly the finite supported
-   designator set — the TC-06 alias table plus the German designators carried
-   by the shared tool — with no omissions and no extras. This is NOT a full
-   ISO 639 / BCP-47 resolver: only the explicitly listed designators are
-   valid.
+4. the translate_text tool schema advertises finite source and target
+   designator sets — the TC-06 alias table plus the German designators carried
+   by the shared tool, with source-only regional English aliases excluded from
+   target_language. This is NOT a full ISO 639 / BCP-47 resolver: only the
+   explicitly listed designators are valid.
 
 The tests exercise the scenario's public ``handle_tool_call``/``evaluate``
 methods with real ``ScenarioState``/``ToolCallRecord`` objects built with the
@@ -28,6 +28,7 @@ from conftest import make_state, make_tool_call
 from tool_eval_bench.domain.scenarios import ScenarioStatus
 from tool_eval_bench.domain.tools import (
     TRANSLATE_LANGUAGE_DESIGNATORS,
+    TRANSLATE_TARGET_LANGUAGE_DESIGNATORS,
     UNIVERSAL_TOOLS,
 )
 from tool_eval_bench.evals.scenarios import _LANGUAGE_ALIASES, SCENARIOS
@@ -193,13 +194,29 @@ def test_translate_text_schema_enum_matches_supported_designators():
     src_enum = props["source_language"]["enum"]
     tgt_enum = props["target_language"]["enum"]
     assert src_enum == TRANSLATE_LANGUAGE_DESIGNATORS
-    assert tgt_enum == TRANSLATE_LANGUAGE_DESIGNATORS
+    assert tgt_enum == TRANSLATE_TARGET_LANGUAGE_DESIGNATORS
 
-    # The schema is exactly the TC-06 alias table plus the German
+    # The source schema is exactly the TC-06 alias table plus the German
     # designators carried by the shared tool: no omissions, no extras.
-    expected = set(_LANGUAGE_ALIASES) | _EXTENDED_ONLY
-    assert set(TRANSLATE_LANGUAGE_DESIGNATORS) == expected
-    assert len(TRANSLATE_LANGUAGE_DESIGNATORS) == len(expected)
+    expected_source = set(_LANGUAGE_ALIASES) | _EXTENDED_ONLY
+    assert set(TRANSLATE_LANGUAGE_DESIGNATORS) == expected_source
+    assert len(TRANSLATE_LANGUAGE_DESIGNATORS) == len(expected_source)
+
+    # Targets are the values accepted by at least one scenario handler. The
+    # regional English aliases are source-only in TC-06 and rejected as
+    # targets by TC-18, so they must not be advertised here.
+    expected_target = (
+        {
+            designator
+            for designator, canonical in _LANGUAGE_ALIASES.items()
+            if canonical in {"spanish", "japanese"}
+        }
+        | {"english", "en"}
+        | _EXTENDED_ONLY
+    )
+    assert set(TRANSLATE_TARGET_LANGUAGE_DESIGNATORS) == expected_target
+    assert len(TRANSLATE_TARGET_LANGUAGE_DESIGNATORS) == len(expected_target)
+    assert not {"en-us", "en-gb", "en-ca", "en-au"} & set(tgt_enum)
 
 
 def test_tc06_registered():


### PR DESCRIPTION
The TC-06 mock and evaluator supported a finite set of language aliases, while the tool schema advertised a different contract.

This follow-up:

- defines an explicit finite vocabulary of supported language designators;
- does not claim complete ISO 639 or BCP-47 support;
- keeps the schema, mock, and evaluator behavior consistent;
- preserves the existing PASS/PARTIAL/FAIL scoring contract;
- adds coverage for every claimed TC-06 alias, mock responses, evaluator scoring, and schema consistency;
- documents the schema and scoring change in CHANGELOG.md.

Tests:

- `python -m pytest tests/test_tc06_translate_text_contract.py tests/test_evaluator_contract.py -q` — 97 passed
- `python -m ruff check ...` — passed
- `python -m ruff format --check ...` — passed