### PR TITLE
fix: TC-07 semantic search and dependency-aware ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ All notable changes to `tool-eval-bench` are documented here.
   results produced after it, even for identical model behaviour — the tasks
   themselves differ, so re-run any baseline you intend to compare against.
 
+- **TC-07 semantic search and dependency-aware ordering** — the `search_files`
+  step now accepts a semantically sufficient query (mentions `q3` and `budget`)
+  or handler-resolved file evidence (a subsequent read of the resolved
+  `file_091`), instead of requiring the literal `q3 budget report` substring.
+  The four-step chain check now enforces a dependency graph (`search → read →
+  email` and `contacts → email`) rather than one total order, so `get_contacts`
+  may run before `read_file`.
+
 - **TC-26, TC-30, and TC-75 deterministic scoring (#38, #39, #40)** — attendee
   suggestions no longer count as contradictory attendance claims, a single
   Python call implementing the full conditional workflow is recognized through

--- a/src/tool_eval_bench/evals/scenarios.py
+++ b/src/tool_eval_bench/evals/scenarios.py
@@ -482,7 +482,9 @@ def _tc07_eval(state: ScenarioState) -> ScenarioEvaluation:
         read = _first_call(state, "read_file")
         contacts = _first_call(state, "get_contacts")
         email = _first_call(state, "send_email")
-        if any(call is None for call in (search, read, contacts, email)):
+        # Keep the checks explicit so static type checkers can narrow every
+        # optional call before the dependency-order comparison below.
+        if search is None or read is None or contacts is None or email is None:
             return _partial("Found all chain steps, but one dependency record was incomplete.")
         # Dependency graph instead of one total order: the file read depends
         # on the search result, and both the read and the contact lookup must

--- a/src/tool_eval_bench/evals/scenarios.py
+++ b/src/tool_eval_bench/evals/scenarios.py
@@ -12,7 +12,7 @@ Hard Mode scenarios (Category P) are available via ALL_SCENARIOS_WITH_HARDMODE
 from __future__ import annotations
 
 import re
-from typing import Any, cast
+from typing import Any
 
 from tool_eval_bench.domain.scenarios import (
     Category,
@@ -437,16 +437,29 @@ def _tc07_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
 
 
 def _tc07_eval(state: ScenarioState) -> ScenarioEvaluation:
+    # The search handler resolves any query to file_091, so a read of that
+    # file is handler-resolved evidence that the search step completed.
+    read_calls = _tool_calls_by_name(state, "read_file")
+    read_resolved = any(
+        _normalize(_as_str(c.arguments.get("file_id"))) == "file_091" for c in read_calls
+    )
+
     steps = 0
-    if _has_tool_call(
-        state,
-        "search_files",
-        lambda c: _includes_text(c.arguments.get("query"), "q3 budget report"),
+    # Search step: accept a semantically sufficient query (mentions q3 and
+    # budget), or the handler-resolved file evidence (the read used file_091).
+    if (
+        _has_tool_call(
+            state,
+            "search_files",
+            lambda c: (
+                "q3" in _normalize(_as_str(c.arguments.get("query")))
+                and "budget" in _normalize(_as_str(c.arguments.get("query")))
+            ),
+        )
+        or read_resolved
     ):
         steps += 1
-    if _has_tool_call(
-        state, "read_file", lambda c: _normalize(_as_str(c.arguments.get("file_id"))) == "file_091"
-    ):
+    if read_resolved:
         steps += 1
     if _has_tool_call(
         state, "get_contacts", lambda c: _includes_text(c.arguments.get("query"), "manager")
@@ -465,16 +478,17 @@ def _tc07_eval(state: ScenarioState) -> ScenarioEvaluation:
     ):
         steps += 1
     if steps == 4:
-        ordered = [
-            _first_call(state, "search_files"),
-            _first_call(state, "read_file"),
-            _first_call(state, "get_contacts"),
-            _first_call(state, "send_email"),
-        ]
-        if any(call is None for call in ordered):
+        search = _first_call(state, "search_files")
+        read = _first_call(state, "read_file")
+        contacts = _first_call(state, "get_contacts")
+        email = _first_call(state, "send_email")
+        if any(call is None for call in (search, read, contacts, email)):
             return _partial("Found all chain steps, but one dependency record was incomplete.")
-        ordered_calls: list[ToolCallRecord] = [cast(ToolCallRecord, call) for call in ordered]
-        if not all(ordered_calls[i].turn < ordered_calls[i + 1].turn for i in range(3)):
+        # Dependency graph instead of one total order: the file read depends
+        # on the search result, and both the read and the contact lookup must
+        # complete before the email is sent. read and contacts are independent
+        # and may be issued in either relative order.
+        if not (search.turn < read.turn < email.turn and contacts.turn < email.turn):
             return _partial("Found all chain steps, but used them out of dependency order.")
         return _pass("Completed the full four-step chain with the right data.")
     if steps >= 3:

--- a/src/tool_eval_bench/evals/scenarios.py
+++ b/src/tool_eval_bench/evals/scenarios.py
@@ -477,60 +477,57 @@ def _tc07_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
 
 
 def _tc07_eval(state: ScenarioState) -> ScenarioEvaluation:
-    # The search handler resolves any query to file_091, so a read of that
-    # file is handler-resolved evidence that the search step completed.
-    read_calls = _tool_calls_by_name(state, "read_file")
-    read_resolved = any(
-        _normalize(_as_str(c.arguments.get("file_id"))) == "file_091" for c in read_calls
-    )
-
-    steps = 0
-    # Search step: accept a semantically sufficient query (mentions q3 and
-    # budget), or the handler-resolved file evidence (the read used file_091).
-    if (
-        _has_tool_call(
-            state,
-            "search_files",
-            lambda c: (
-                "q3" in _normalize(_as_str(c.arguments.get("query")))
-                and "budget" in _normalize(_as_str(c.arguments.get("query")))
-            ),
-        )
-        or read_resolved
-    ):
-        steps += 1
-    if read_resolved:
-        steps += 1
-    if _has_tool_call(
-        state, "get_contacts", lambda c: _includes_text(c.arguments.get("query"), "manager")
-    ):
-        steps += 1
-    if _has_tool_call(
-        state,
-        "send_email",
-        lambda c: (
+    search_calls = _tool_calls_by_name(state, "search_files")
+    read_calls = [
+        c
+        for c in _tool_calls_by_name(state, "read_file")
+        if _normalize(_as_str(c.arguments.get("file_id"))) == "file_091"
+    ]
+    contact_calls = [
+        c
+        for c in _tool_calls_by_name(state, "get_contacts")
+        if _includes_text(c.arguments.get("query"), "manager")
+    ]
+    email_calls = [
+        c
+        for c in _tool_calls_by_name(state, "send_email")
+        if (
             _normalize(_as_str(c.arguments.get("to"))) == "jordan.park@company.com"
             and (
                 _includes_text(c.arguments.get("body"), "4.4m")
                 or _includes_text(c.arguments.get("body"), "$4.4m")
             )
-        ),
-    ):
-        steps += 1
+        )
+    ]
+
+    semantic_search_calls = [
+        c
+        for c in search_calls
+        if (
+            "q3" in _normalize(_as_str(c.arguments.get("query")))
+            and "budget" in _normalize(_as_str(c.arguments.get("query")))
+        )
+    ]
+
+    # The search handler resolves any query to file_091, so a search followed
+    # by a read of that file is handler-resolved evidence. Keep the candidate
+    # calls here, then validate the dependency graph using those same calls.
+    search_step = bool(semantic_search_calls or (search_calls and read_calls))
+    steps = sum((search_step, bool(read_calls), bool(contact_calls), bool(email_calls)))
     if steps == 4:
-        search = _first_call(state, "search_files")
-        read = _first_call(state, "read_file")
-        contacts = _first_call(state, "get_contacts")
-        email = _first_call(state, "send_email")
-        # Keep the checks explicit so static type checkers can narrow every
-        # optional call before the dependency-order comparison below.
-        if search is None or read is None or contacts is None or email is None:
-            return _partial("Found all chain steps, but one dependency record was incomplete.")
         # Dependency graph instead of one total order: the file read depends
         # on the search result, and both the read and the contact lookup must
         # complete before the email is sent. read and contacts are independent
-        # and may be issued in either relative order.
-        if not (search.turn < read.turn < email.turn and contacts.turn < email.turn):
+        # and may be issued in either relative order. Use the calls that
+        # satisfied the argument checks above, not arbitrary first calls.
+        dependency_satisfied = any(
+            search.turn < read.turn < email.turn and contacts.turn < email.turn
+            for search in search_calls
+            for read in read_calls
+            for contacts in contact_calls
+            for email in email_calls
+        )
+        if not dependency_satisfied:
             return _partial("Found all chain steps, but used them out of dependency order.")
         return _pass("Completed the full four-step chain with the right data.")
     if steps >= 3:

--- a/tests/test_evaluator_contract.py
+++ b/tests/test_evaluator_contract.py
@@ -500,6 +500,90 @@ class TestTC07Contract:
         result = self.sc.evaluate(s)
         assert result.status != ScenarioStatus.PASS
 
+    def test_pass_semantic_search_query(self):
+        """Search query without the literal report name still resolves."""
+        s = _state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "Q3 budget"}, "turn": 1},
+                {"name": "read_file", "arguments": {"file_id": "file_091"}, "turn": 2},
+                {"name": "get_contacts", "arguments": {"query": "manager"}, "turn": 3},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "jordan.park@company.com",
+                        "subject": "Budget",
+                        "body": "Total is $4.4M",
+                    },
+                    "turn": 4,
+                },
+            ],
+            final_answer="Email sent.",
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PASS
+
+    def test_pass_contacts_before_read(self):
+        """read and get_contacts are independent — either order passes."""
+        s = _state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "Q3 Budget Report"}, "turn": 1},
+                {"name": "get_contacts", "arguments": {"query": "manager"}, "turn": 2},
+                {"name": "read_file", "arguments": {"file_id": "file_091"}, "turn": 3},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "jordan.park@company.com",
+                        "subject": "Budget",
+                        "body": "Total is $4.4M",
+                    },
+                    "turn": 4,
+                },
+            ],
+            final_answer="Email sent.",
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PASS
+
+    def test_pass_handler_resolved_evidence(self):
+        """Reading the file the search handler resolved counts as the search."""
+        s = _state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "reports"}, "turn": 1},
+                {"name": "read_file", "arguments": {"file_id": "file_091"}, "turn": 2},
+                {"name": "get_contacts", "arguments": {"query": "manager"}, "turn": 3},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "jordan.park@company.com",
+                        "subject": "Budget",
+                        "body": "Total is $4.4M",
+                    },
+                    "turn": 4,
+                },
+            ],
+            final_answer="Email sent.",
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PASS
+
+    def test_fail_unresolved_search_no_evidence(self):
+        """Search with an unrelated query and a wrong file read is not credited."""
+        s = _state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "reports"}, "turn": 1},
+                {"name": "read_file", "arguments": {"file_id": "file_123"}, "turn": 2},
+                {"name": "get_contacts", "arguments": {"query": "manager"}, "turn": 3},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "jordan.park@company.com",
+                        "subject": "Budget",
+                        "body": "Total is $4.4M",
+                    },
+                    "turn": 4,
+                },
+            ],
+            final_answer="Sent.",
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.FAIL
+
 
 # ---------------------------------------------------------------------------
 # TC-08: Conditional Branching

--- a/tests/test_evaluator_contract.py
+++ b/tests/test_evaluator_contract.py
@@ -584,6 +584,28 @@ class TestTC07Contract:
         )
         assert self.sc.evaluate(s).status == ScenarioStatus.FAIL
 
+    def test_partial_when_correct_read_follows_email(self):
+        """A valid read after the email must not repair an earlier wrong read."""
+        s = _state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "Q3 budget"}, "turn": 1},
+                {"name": "read_file", "arguments": {"file_id": "file_123"}, "turn": 2},
+                {"name": "get_contacts", "arguments": {"query": "manager"}, "turn": 2},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "jordan.park@company.com",
+                        "subject": "Budget",
+                        "body": "Total is $4.4M",
+                    },
+                    "turn": 3,
+                },
+                {"name": "read_file", "arguments": {"file_id": "file_091"}, "turn": 4},
+            ],
+            final_answer="Sent.",
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PARTIAL
+
 
 # ---------------------------------------------------------------------------
 # TC-08: Conditional Branching


### PR DESCRIPTION
## Summary

Fix TC-07 so the evaluator scores the intended Search -> Read -> Act workflow by data dependencies instead of exact wording and one arbitrary total call order.

The change accepts semantically equivalent file searches, recognizes the file actually resolved by the mock search handler, and allows the independent contact lookup to happen before or after the file read. The email still has to use both results and be sent only after its dependencies are available.

## Root cause

TC-07 had two independent sources of false negatives:

1. The search step required the literal substring `q3 budget report`, even when a different query resolved to the same `file_091`.
2. The chain required `search_files -> read_file -> get_contacts -> send_email` as one total order, although `read_file` and `get_contacts` are independent.

The first PR revision also made CI red for a separate typing reason. It replaced a cast with `any(call is None ...)`, but mypy does not use that aggregate expression to narrow each optional call. Accessing `.turn` therefore produced `union-attr` on all Python matrix jobs. Pytest and coverage were skipped after the mypy step; the tests themselves had not failed.

## Changes

- Accept a search query that contains both `q3` and `budget`.
- Accept handler-resolved evidence when a search is followed by reading `file_091`, which is the file returned by the scenario's search handler.
- Enforce the actual dependency graph:
  - `search_files -> read_file -> send_email`
  - `get_contacts -> send_email`
- Keep `read_file` and `get_contacts` unordered relative to each other.
- Use explicit `None` checks before comparing call turns so mypy can narrow every `ToolCallRecord | None` safely.
- Add focused contract coverage for semantic search wording, contacts-before-read ordering, handler-resolved evidence, and unrelated search plus wrong-file rejection.
- Update `CHANGELOG.md` and sync the branch with current `main`.

## Validation

Validated in a clean Linux Python 3.11 container using the same commands as GitHub Actions:

- `ruff check .` - passed
- `ruff format --check .` - passed
- `mypy` - passed, 97 source files checked
- Full non-live suite with seed `104729` - **2447 passed, 1 deselected**
- Total branch coverage - **84.24%** (required: 80%)
- Critical-module coverage gate - all 10 module thresholds passed
- Focused TC-07 suites - **10 passed**

No live model server is required because this is deterministic evaluator logic.