### PR TITLE
fix(TC-38): make manager fixture coherent and accept org-chart verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ All notable changes to `tool-eval-bench` are documented here.
   email` and `contacts → email`) rather than one total order, so `get_contacts`
   may run before `read_file`.
 
+- **TC-38 manager fixture contract** — the `get_contacts` fixture declares the
+  canonical `role: "manager"` for Jordan Park, but the shared contacts noise
+  layer stamped a contradictory generic `title: "Team Member"` on every result.
+  The noise layer now only adds that title when a contact declares neither a
+  role nor a title, so the fixture is internally coherent. TC-38 additionally
+  accepts a semantically relevant `get_org_chart` lookup (Engineering) as a
+  manager-verification step — it is no longer penalized as an irrelevant call —
+  while unrelated org-chart lookups still count as contamination. The TC-38
+  mock now returns an Engineering org chart whose manager record agrees with
+  the contacts fixture.
+
 - **TC-26, TC-30, and TC-75 deterministic scoring (#38, #39, #40)** — attendee
   suggestions no longer count as contradictory attendance claims, a single
   Python call implementing the full conditional workflow is recognized through

--- a/src/tool_eval_bench/evals/noise.py
+++ b/src/tool_eval_bench/evals/noise.py
@@ -165,22 +165,28 @@ def enrich_calendar(payload: dict[str, Any]) -> dict[str, Any]:
 
 
 def enrich_contacts(payload: dict[str, Any]) -> dict[str, Any]:
-    """Add realistic metadata to contact lookup responses."""
+    """Add realistic metadata to contact lookup responses.
+
+    A contact that already declares a ``role`` (e.g. ``manager``) keeps it as
+    the canonical representation: stamping a generic ``title: "Team Member"``
+    on top would contradict that role, so the noise layer only adds the title
+    when the contact declares neither a role nor a title.
+    """
     results = payload.get("results", [])
     enriched_results = []
     for i, r in enumerate(results):
-        enriched_results.append(
-            {
-                **r,
-                "id": f"contact_{1000 + i}",
-                "department": "Engineering",
-                "phone": "+1-555-0100",
-                "title": "Team Member",
-                "last_contacted": "2026-03-18T15:30:00Z",
-                "notes": "",
-                "source": "directory",
-            }
-        )
+        enriched = {
+            **r,
+            "id": f"contact_{1000 + i}",
+            "department": "Engineering",
+            "phone": "+1-555-0100",
+            "last_contacted": "2026-03-18T15:30:00Z",
+            "notes": "",
+            "source": "directory",
+        }
+        if "role" not in r and "title" not in r:
+            enriched["title"] = "Team Member"
+        enriched_results.append(enriched)
     return {
         "results": enriched_results,
         "total_contacts": len(results),

--- a/src/tool_eval_bench/evals/scenarios_large_toolset.py
+++ b/src/tool_eval_bench/evals/scenarios_large_toolset.py
@@ -150,6 +150,23 @@ def _tc38_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
         )
     if call.name == "send_email":
         return _noise({"status": "sent"}, "send_email")
+    if call.name == "get_org_chart":
+        # Engineering org chart — the canonical manager record must agree with
+        # the get_contacts fixture so an org-chart verification resolves (not
+        # re-introduces) the manager identity.
+        if _includes_text(call.arguments.get("department"), "engineering"):
+            return _noise(
+                {
+                    "department": "Engineering",
+                    "manager": {
+                        "name": "Jordan Park",
+                        "email": "jordan.park@company.com",
+                        "role": "manager",
+                    },
+                },
+                "get_org_chart",
+            )
+        return _noise({"results": []}, "get_org_chart")
     # Domain-specific tools that might be tempting but wrong
     if call.name == "get_customer_profile":
         return _noise(
@@ -208,11 +225,20 @@ def _tc38_eval(state: ScenarioState) -> ScenarioEvaluation:
     ):
         steps += 1
 
+    # A get_org_chart lookup for the Engineering department is an accepted
+    # manager-verification step and is not treated as domain-tool contamination.
+    # Unrelated org-chart lookups still count as irrelevant calls.
+    def _is_manager_verification(c: ToolCallRecord) -> bool:
+        return c.name == "get_org_chart" and _includes_text(
+            c.arguments.get("department"), "engineering"
+        )
+
     # Check for domain-tool contamination
     domain_calls = [
         c.name
         for c in state.tool_calls
         if c.name not in ("search_files", "read_file", "get_contacts", "send_email", "web_search")
+        and not _is_manager_verification(c)
     ]
 
     if steps == 4 and not domain_calls:

--- a/src/tool_eval_bench/evals/scenarios_large_toolset.py
+++ b/src/tool_eval_bench/evals/scenarios_large_toolset.py
@@ -6,6 +6,7 @@ model ability to navigate a crowded 52-tool namespace.
 
 from __future__ import annotations
 
+import re
 from typing import Any, cast
 
 from tool_eval_bench.domain.scenarios import (
@@ -125,6 +126,24 @@ def _tc37_eval(state: ScenarioState) -> ScenarioEvaluation:
 # ===================================================================
 
 
+def _is_engineering_department(value: Any) -> bool:
+    """Return whether a department value requests Engineering itself.
+
+    The scenario accepts natural variants such as "Engineering team", but a
+    negated value like "not engineering" must not resolve to the canonical
+    Engineering org chart merely because it contains the word "engineering".
+    """
+    department = _as_str(value)
+    return bool(
+        re.search(r"\bengineering\b", department, re.IGNORECASE)
+        and not re.search(
+            r"\b(?:not|no|without)\s+(?:the\s+)?engineering\b",
+            department,
+            re.IGNORECASE,
+        )
+    )
+
+
 def _tc38_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     if call.name == "search_files":
         return _noise(
@@ -154,7 +173,7 @@ def _tc38_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
         # Engineering org chart — the canonical manager record must agree with
         # the get_contacts fixture so an org-chart verification resolves (not
         # re-introduces) the manager identity.
-        if _includes_text(call.arguments.get("department"), "engineering"):
+        if _is_engineering_department(call.arguments.get("department")):
             return _noise(
                 {
                     "department": "Engineering",
@@ -229,8 +248,8 @@ def _tc38_eval(state: ScenarioState) -> ScenarioEvaluation:
     # manager-verification step and is not treated as domain-tool contamination.
     # Unrelated org-chart lookups still count as irrelevant calls.
     def _is_manager_verification(c: ToolCallRecord) -> bool:
-        return c.name == "get_org_chart" and _includes_text(
-            c.arguments.get("department"), "engineering"
+        return c.name == "get_org_chart" and _is_engineering_department(
+            c.arguments.get("department")
         )
 
     # Check for domain-tool contamination

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -405,6 +405,14 @@ class TestNoiseEnrichment:
         r = enrich_contacts({"results": [{"name": "A"}, {"name": "B"}]})
         assert len(r["results"]) == 2
         assert r["results"][0]["department"] == "Engineering"
+        assert r["results"][0]["title"] == "Team Member"
+
+    def test_enrich_contacts_preserves_declared_role(self):
+        # A contact that already declares a canonical role must not get a
+        # contradictory generic title (TC-38 manager fixture coherence).
+        r = enrich_contacts({"results": [{"name": "Jordan Park", "role": "manager"}]})
+        assert r["results"][0]["role"] == "manager"
+        assert "title" not in r["results"][0]
 
     def test_enrich_stock(self):
         r = enrich_stock({"price": 100.0})

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -1474,6 +1474,43 @@ class TestTC38:
         )
         assert org.get("results") == []
 
+    def test_org_chart_negated_department_returns_empty(self) -> None:
+        org = self.sc.handle_tool_call(
+            ScenarioState(),
+            ToolCallRecord(
+                id="c1",
+                name="get_org_chart",
+                raw_arguments="{}",
+                arguments={"department": "not Engineering"},
+                turn=1,
+            ),
+        )
+        assert org.get("results") == []
+
+    def test_negated_org_chart_lookup_is_not_manager_verification(self) -> None:
+        s = _state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "Q3 budget report"}, "turn": 1},
+                {"name": "read_file", "arguments": {"file_id": "file_091"}, "turn": 2},
+                {"name": "get_contacts", "arguments": {"query": "manager"}, "turn": 3},
+                {
+                    "name": "get_org_chart",
+                    "arguments": {"department": "not Engineering"},
+                    "turn": 4,
+                },
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "jordan.park@company.com",
+                        "subject": "Budget",
+                        "body": "Total is $4.4M",
+                    },
+                    "turn": 5,
+                },
+            ]
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PARTIAL
+
 
 # ===================================================================
 # TC-39: Restraint Under Abundance

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -1267,6 +1267,48 @@ class TestTC38:
         )
         assert self.sc.evaluate(s).status == ScenarioStatus.PARTIAL
 
+    def test_pass_with_manager_verification(self) -> None:
+        """An Engineering org-chart lookup is an accepted manager-verification step."""
+        s = _state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "Q3 budget report"}, "turn": 1},
+                {"name": "read_file", "arguments": {"file_id": "file_091"}, "turn": 2},
+                {"name": "get_contacts", "arguments": {"query": "manager"}, "turn": 3},
+                {"name": "get_org_chart", "arguments": {"department": "Engineering"}, "turn": 4},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "jordan.park@company.com",
+                        "subject": "Budget",
+                        "body": "Total is $4.4M",
+                    },
+                    "turn": 5,
+                },
+            ]
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PASS
+
+    def test_partial_unrelated_org_chart(self) -> None:
+        """An org-chart lookup for an unrelated department is still penalized."""
+        s = _state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "Q3 budget report"}, "turn": 1},
+                {"name": "read_file", "arguments": {"file_id": "file_091"}, "turn": 2},
+                {"name": "get_contacts", "arguments": {"query": "manager"}, "turn": 3},
+                {"name": "get_org_chart", "arguments": {"department": "Marketing"}, "turn": 4},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "jordan.park@company.com",
+                        "subject": "Budget",
+                        "body": "Total is $4.4M",
+                    },
+                    "turn": 5,
+                },
+            ]
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PARTIAL
+
     def test_partial_missing_step(self) -> None:
         s = _state(
             tool_calls=[
@@ -1280,6 +1322,35 @@ class TestTC38:
     def test_fail_no_chain(self) -> None:
         s = _state(final_answer="The budget is $4.4M")
         assert self.sc.evaluate(s).status == ScenarioStatus.FAIL
+
+    def test_org_chart_mock_matches_contacts_fixture(self) -> None:
+        """The org-chart mock must agree with the contacts fixture's canonical manager."""
+        org = self.sc.handle_tool_call(
+            ScenarioState(),
+            ToolCallRecord(
+                id="c1",
+                name="get_org_chart",
+                raw_arguments="{}",
+                arguments={"department": "Engineering"},
+                turn=1,
+            ),
+        )
+        assert org["manager"]["name"] == "Jordan Park"
+        assert org["manager"]["email"] == "jordan.park@company.com"
+        assert org["manager"]["role"] == "manager"
+
+    def test_org_chart_unrelated_department_returns_empty(self) -> None:
+        org = self.sc.handle_tool_call(
+            ScenarioState(),
+            ToolCallRecord(
+                id="c1",
+                name="get_org_chart",
+                raw_arguments="{}",
+                arguments={"department": "Marketing"},
+                turn=1,
+            ),
+        )
+        assert org.get("results") == []
 
 
 # ===================================================================


### PR DESCRIPTION
# fix(TC-38): make manager fixture coherent and accept org-chart verification

## Problem

The `get_contacts` fixture in TC-38 (and the shared TC-07 chain) declares
Jordan Park with the canonical `role: "manager"`, but the shared contacts
noise layer (`enrich_contacts`) unconditionally stamped a generic
`title: "Team Member"` on every contact result. The fixture was therefore
internally contradictory: one record simultaneously identified a manager
relationship and a Team Member title.

When a model reasonably called `get_org_chart` to resolve the contradiction,
the evaluator counted that call as domain-tool contamination (`domain_calls`),
because `_tc38_handle` returned a generic "not relevant" error for it and
`_tc38_eval` penalized every call outside the four expected tools. A
semantically relevant manager-verification lookup was marked as irrelevant.

## Solution

- **`noise.py` (`enrich_contacts`)** — the noise layer now only adds the
  generic `title: "Team Member"` when a contact declares neither a `role` nor
  a `title`. Contacts that already declare a canonical role keep that
  representation, so the manager fixture is internally coherent.
- **`scenarios_large_toolset.py` (`_tc38_handle`)** — added a `get_org_chart`
  mock: an Engineering org-chart lookup returns a manager record
  (Jordan Park / jordan.park@company.com / role `manager`) that agrees with
  the `get_contacts` fixture; any unrelated department lookup returns empty
  results.
- **`scenarios_large_toolset.py` (`_tc38_eval`)** — a `get_org_chart` lookup
  for the Engineering department is recognized as an accepted
  manager-verification step and excluded from `domain_calls`. Unrelated
  org-chart lookups still count as irrelevant calls and are penalized.

## Contract after the change

- A direct, internally coherent `get_contacts` lookup for `manager` still
  counts toward the 4-step chain.
- A semantically relevant `get_org_chart` call (department mentioning
  Engineering) is a permitted extra verification step — the full chain can
  still PASS with it.
- An unrelated `get_org_chart` call (e.g. Marketing) is still treated as an
  irrelevant tool call and yields PARTIAL at best.
- The org-chart mock's manager record must always agree with the contacts
  fixture (same name, email, role); a dedicated contract test enforces this.

## Tests

- `tests/test_evaluators_extended.py::TestTC38`:
  - `test_pass_with_manager_verification` — full 4-step chain plus an
    Engineering org-chart lookup now PASSes.
  - `test_partial_unrelated_org_chart` — chain plus a Marketing org-chart
    lookup still PARTIAL.
  - `test_org_chart_mock_matches_contacts_fixture` — mock manager record
    agrees with the contacts fixture.
  - `test_org_chart_unrelated_department_returns_empty` — unrelated lookup
    returns no results.
- `tests/test_coverage_gaps.py::TestNoiseEnrichment`:
  - `test_enrich_contacts_preserves_declared_role` — a contact with a declared
    role no longer receives the contradictory generic title.

Results: `318 passed` across `TestTC38`, `TestPayloadEnrichment`,
`TestNoiseEnrichment`, and `test_evaluator_robustness.py`.
`ruff check` and `ruff format --check` pass on all changed files.

## Scope

Five files, all directly tied to the TC-38 manager fixture contract:
`CHANGELOG.md`, `src/tool_eval_bench/evals/noise.py`,
`src/tool_eval_bench/evals/scenarios_large_toolset.py`,
`tests/test_coverage_gaps.py`, `tests/test_evaluators_extended.py`.
No dependencies, locks, CI config, or unrelated formatting were touched.
CHANGELOG updated under `[Unreleased] → Fixed`.
