### PR TITLE
fix(TC-46): add per-scenario turn budget for deep multi-turn research workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ All notable changes to `tool-eval-bench` are documented here.
   aliases the evaluator accepted. A dedicated contract test keeps the
   schema enums and the scenario alias tables in sync.
 
+- **TC-46 per-scenario turn budget (`max_turns_override`)** — the deep
+  multi-turn research workflow needs up to 11 assistant exchanges for its
+  canonical reference path (5 user turns plus tool-call rounds and final
+  answers), which exceeds the global `max_turns=8` default and cuts the run
+  off before the final email. `ScenarioDefinition` gains an optional
+  `max_turns_override` field; TC-46 sets it to 12, giving the reference path
+  finite headroom without raising the global default for every scenario.
+  The orchestrator now also flags turn-budget exhaustion distinctly
+  (`turn_budget_exceeded` plus `failure_kind="budget_exceeded"` when the run
+  stops before a final answer / before follow-ups are drained), so a
+  budget run-out is no longer indistinguishable from an evaluator verdict.
+
 ### Added
 
 - **Tokenizer auto-detection for `--perf`** — `--tokenizer` is now rarely needed.

--- a/src/tool_eval_bench/domain/scenarios.py
+++ b/src/tool_eval_bench/domain/scenarios.py
@@ -180,11 +180,6 @@ class ScenarioDefinition:
     # to the adapter's response_format parameter. Used by structured output
     # scenarios to request JSON schema enforcement.
     response_format_override: dict[str, Any] | None = None
-    # Optional per-scenario turn budget.  If set, the orchestrator uses this
-    # value instead of the global ``max_turns`` for this scenario.  Used by
-    # deep multi-turn workflows (e.g. TC-46) whose reference path needs more
-    # exchanges than the global default, while keeping the limit finite.
-    max_turns_override: int | None = None
     # Difficulty rating (1–5 scale).  None means "unrated" for backward
     # compatibility.  See docs/methodology.md for the tier definitions.
     #   1 = trivial   — single tool, obvious mapping
@@ -200,6 +195,13 @@ class ScenarioDefinition:
     # Their prompts and traces are withheld from generated reports so that
     # publishing a score does not publish (and thereby burn) the scenario.
     held_out: bool = False
+    # Optional per-scenario turn budget.  If set, the orchestrator uses this
+    # value instead of the global ``max_turns`` for this scenario.  Used by
+    # deep multi-turn workflows (e.g. TC-46) whose reference path needs more
+    # exchanges than the global default, while keeping the limit finite.
+    # Kept after the existing optional fields to preserve positional
+    # construction compatibility for callers using the dataclass directly.
+    max_turns_override: int | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/tool_eval_bench/domain/scenarios.py
+++ b/src/tool_eval_bench/domain/scenarios.py
@@ -180,6 +180,11 @@ class ScenarioDefinition:
     # to the adapter's response_format parameter. Used by structured output
     # scenarios to request JSON schema enforcement.
     response_format_override: dict[str, Any] | None = None
+    # Optional per-scenario turn budget.  If set, the orchestrator uses this
+    # value instead of the global ``max_turns`` for this scenario.  Used by
+    # deep multi-turn workflows (e.g. TC-46) whose reference path needs more
+    # exchanges than the global default, while keeping the limit finite.
+    max_turns_override: int | None = None
     # Difficulty rating (1–5 scale).  None means "unrated" for backward
     # compatibility.  See docs/methodology.md for the tier definitions.
     #   1 = trivial   — single tool, obvious mapping
@@ -265,6 +270,9 @@ class ScenarioResult:
     state_checkpoints: list[str] = field(default_factory=list)
     # Failure taxonomy — why did this scenario fail?
     failure_kind: str | None = None
+    # True when the run stopped because the turn budget ran out before a
+    # final answer was produced / follow-ups were exhausted.
+    turn_budget_exceeded: bool = False
 
     @property
     def is_infrastructure_failure(self) -> bool:
@@ -292,6 +300,8 @@ class ScenarioResult:
         }
         if self.failure_kind is not None:
             d["failure_kind"] = self.failure_kind
+        if self.turn_budget_exceeded:
+            d["turn_budget_exceeded"] = self.turn_budget_exceeded
         if self.ttft_ms is not None:
             d["ttft_ms"] = round(self.ttft_ms, 1)
         if self.turn_latencies_ms:
@@ -330,6 +340,7 @@ class ScenarioResult:
             parallel_tool_turns=list(data.get("parallel_tool_turns", [])),
             state_checkpoints=list(data.get("state_checkpoints", [])),
             failure_kind=data.get("failure_kind"),
+            turn_budget_exceeded=data.get("turn_budget_exceeded", False),
         )
 
 

--- a/src/tool_eval_bench/evals/scenarios_agentic.py
+++ b/src/tool_eval_bench/evals/scenarios_agentic.py
@@ -2292,6 +2292,9 @@ AGENTIC_SCENARIOS: list[ScenarioDefinition] = [
         description="5-turn research workflow: search→read→compare→summarize→email. Tests deep state tracking.",
         handle_tool_call=_tc46_handle,
         evaluate=_tc46_eval,
+        # 5 user turns + tool-call rounds need up to 11 assistant turns for the
+        # canonical reference path; 12 keeps it finite with one-turn headroom.
+        max_turns_override=12,
         follow_up_messages=[
             "Read the 2025 one.",
             "What's our market share growth compared to last year? Check the 2024 report too.",

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -325,6 +325,9 @@ async def run_scenario(
     # None → use defaults; [] → explicitly no tools
     scenario_tools = UNIVERSAL_TOOLS if scenario.tools_override is None else scenario.tools_override
     scenario_tool_choice = scenario.tool_choice_override or "auto"
+    # Per-scenario budget overrides the global max_turns for deep workflows
+    # (e.g. TC-46) without raising the default for every scenario.
+    max_turns = scenario.max_turns_override or max_turns
     available_tool_names = [
         str(tool.get("function", {}).get("name", "?")) for tool in (scenario_tools or [])
     ]
@@ -367,6 +370,11 @@ async def run_scenario(
             "no concurrent requests, and consistent KV-cache configuration.",
             seed,
         )
+
+    # True when the loop ends because the turn budget ran out before the model
+    # produced a final answer (or before exhausting the follow-up queue).
+    # Distinguishes turn-budget exhaustion from evaluator failures.
+    budget_exhausted = True
 
     try:
         for turn in range(1, max_turns + 1):
@@ -430,6 +438,7 @@ async def run_scenario(
 
                 # No more follow-ups → conversation is done
                 state.final_answer = result.content
+                budget_exhausted = False
                 break
 
             tool_names = [tc.name for tc in result.tool_calls]
@@ -567,7 +576,14 @@ async def run_scenario(
         tool_call_arg_bytes=total_arg_bytes,
         parallel_tool_turns=parallel_tool_turns,
         state_checkpoints=state_checkpoints,
-        failure_kind=_classify_evaluation_failure(state, evaluation),
+        failure_kind=(
+            FailureKind.BUDGET_EXCEEDED
+            if budget_exhausted and evaluation.status != ScenarioStatus.PASS
+            else _classify_evaluation_failure(state, evaluation)
+        ),
+        # A turn-budget run-out is a distinct failure reason, not an evaluator
+        # verdict: the model never reached a final answer / exhausted follow-ups.
+        turn_budget_exceeded=budget_exhausted,
     )
 
 

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -327,7 +327,8 @@ async def run_scenario(
     scenario_tool_choice = scenario.tool_choice_override or "auto"
     # Per-scenario budget overrides the global max_turns for deep workflows
     # (e.g. TC-46) without raising the default for every scenario.
-    max_turns = scenario.max_turns_override or max_turns
+    if scenario.max_turns_override is not None:
+        max_turns = scenario.max_turns_override
     available_tool_names = [
         str(tool.get("function", {}).get("name", "?")) for tool in (scenario_tools or [])
     ]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -15,8 +15,10 @@ import pytest
 from tool_eval_bench.adapters.base import BackendAdapter, ChatCompletionResult, ProviderToolCall
 from tool_eval_bench.domain.scenarios import (
     Category,
+    FailureKind,
     ScenarioDefinition,
     ScenarioEvaluation,
+    ScenarioResult,
     ScenarioState,
     ScenarioStatus,
     ToolCallRecord,
@@ -549,3 +551,301 @@ async def test_checkpoint_runs_after_each_tool_call() -> None:
 
     assert seen == ["get_weather", "calculator"]
     assert result.state_checkpoints == ["calculator observed"]
+
+
+# ---------------------------------------------------------------------------
+# Per-scenario turn budget (max_turns_override) and budget-exhaustion signals
+# ---------------------------------------------------------------------------
+
+
+def _stalled_tool_adapter(tool_name: str = "get_weather") -> MockAdapter:
+    """Adapter that always calls a tool and never produces a final answer."""
+    return MockAdapter(
+        [{"content": "", "tool_calls": [{"name": tool_name, "arguments": {}}]} for _ in range(30)]
+    )
+
+
+def _tool_then_final_adapter(tool_name: str = "get_weather") -> MockAdapter:
+    """Adapter that calls a tool once, then gives a final answer."""
+    return MockAdapter(
+        [
+            {"content": "", "tool_calls": [{"name": tool_name, "arguments": {}}]},
+            {"content": "done"},
+        ]
+    )
+
+
+def _tool_failing_evaluator(scenario_id: str) -> ScenarioDefinition:
+    """Scenario whose evaluator always fails unless the tool was never used."""
+    return ScenarioDefinition(
+        id=scenario_id,
+        title=scenario_id,
+        description=scenario_id,
+        category=Category.A,
+        user_message="Use the tool.",
+        handle_tool_call=lambda state, call: state.tool_calls.append(call),
+        evaluate=lambda state: ScenarioEvaluation(
+            status=ScenarioStatus.FAIL,
+            points=0,
+            summary="never used required tool",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_max_turns_override_extends_budget() -> None:
+    """A scenario's max_turns_override replaces the global max_turns."""
+    scenario = _tool_failing_evaluator("OVR-01")
+    scenario.max_turns_override = 5
+    result = await run_scenario(
+        _stalled_tool_adapter(),
+        model="test-model",
+        base_url="http://localhost:8000",
+        api_key="key",
+        scenario=scenario,
+        max_turns=2,
+    )
+    # 5 tool-call turns fit inside the override; the global 2 would have cut it.
+    assert result.turn_count == 5
+    assert result.turn_budget_exceeded is True
+    assert result.failure_kind == FailureKind.BUDGET_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_max_turns_override_keeps_limit_finite() -> None:
+    """Even with an override, a looping model stops at the override value."""
+    scenario = _tool_failing_evaluator("OVR-02")
+    scenario.max_turns_override = 6
+    result = await run_scenario(
+        _stalled_tool_adapter(),
+        model="test-model",
+        base_url="http://localhost:8000",
+        api_key="key",
+        scenario=scenario,
+        max_turns=3,
+    )
+    assert result.turn_count == 6  # stopped at the override, not unbounded
+    assert result.turn_budget_exceeded is True
+    assert result.failure_kind == FailureKind.BUDGET_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_max_turns_override_not_set_uses_global_budget() -> None:
+    """Scenarios without an override keep using the global max_turns."""
+    scenario = _tool_failing_evaluator("OVR-03")
+    result = await run_scenario(
+        _stalled_tool_adapter(),
+        model="test-model",
+        base_url="http://localhost:8000",
+        api_key="key",
+        scenario=scenario,
+        max_turns=4,
+    )
+    assert result.turn_count == 4  # global budget applied
+    assert result.turn_budget_exceeded is True
+    assert result.failure_kind == FailureKind.BUDGET_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_normal_completion_does_not_flag_budget_exceeded() -> None:
+    """A model that reaches a final answer is not marked as budget-exhausted."""
+    scenario = ScenarioDefinition(
+        id="OVR-04",
+        title="OVR-04",
+        description="OVR-04",
+        category=Category.A,
+        user_message="Do the task.",
+        handle_tool_call=lambda state, call: state.tool_calls.append(call),
+        evaluate=lambda state: ScenarioEvaluation(
+            status=ScenarioStatus.PASS,
+            points=2,
+            summary="ok",
+        ),
+    )
+    result = await run_scenario(
+        _tool_then_final_adapter(),
+        model="test-model",
+        base_url="http://localhost:8000",
+        api_key="key",
+        scenario=scenario,
+        max_turns=8,
+    )
+    assert result.turn_count == 2
+    assert result.turn_budget_exceeded is False
+    assert result.failure_kind is None
+
+
+@pytest.mark.asyncio
+async def test_budget_exhaustion_is_distinct_from_evaluator_failure() -> None:
+    """Budget run-out sets BUDGET_EXCEEDED, not the evaluator's failure kind."""
+    scenario = _tool_failing_evaluator("OVR-05")
+    result = await run_scenario(
+        _stalled_tool_adapter(),
+        model="test-model",
+        base_url="http://localhost:8000",
+        api_key="key",
+        scenario=scenario,
+        max_turns=3,
+    )
+    # Evaluator says FAIL/missing-tool, but the reason must be budget, not tool.
+    assert result.status == ScenarioStatus.FAIL
+    assert result.turn_budget_exceeded is True
+    assert result.failure_kind == FailureKind.BUDGET_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_tc46_has_scenario_budget_override() -> None:
+    """TC-46 declares a per-scenario budget for its deep multi-turn workflow."""
+    from tool_eval_bench.evals.scenarios_agentic import AGENTIC_SCENARIOS
+
+    tc46 = next(s for s in AGENTIC_SCENARIOS if s.id == "TC-46")
+    assert tc46.max_turns_override is not None
+    # Canonical reference path: 5 user turns + tool rounds + final answers.
+    # search, read2025, read2024, calc, contacts, email + final answers = 11.
+    # With parallel calls the minimum is 8; the override keeps headroom finite.
+    assert tc46.max_turns_override >= 9
+    assert tc46.max_turns_override <= 12
+
+
+@pytest.mark.asyncio
+async def test_deep_multiturn_workflow_fits_override_budget() -> None:
+    """A TC-46-like 11-turn reference path fits inside a 12-turn override."""
+    # Canonical deep workflow: 1 user message + 4 follow-ups.
+    # T1 search, T2 read2025, T3 final, T4 final, T5 read2024+calc (parallel),
+    # T6 final, T7 final, T8 contacts+email (parallel), T9 final.
+    # The canonical non-parallel path needs up to 11 assistant turns.
+    responses = [
+        {"content": "", "tool_calls": [{"name": "search_files", "arguments": {}}]},
+        {"content": "", "tool_calls": [{"name": "read_file", "arguments": {"file": "2025"}}]},
+        {"content": "found"},
+        {"content": "read"},
+        {
+            "content": "",
+            "tool_calls": [
+                {"name": "read_file", "arguments": {"file": "2024"}},
+                {"name": "calculator", "arguments": {"expr": "growth"}},
+            ],
+        },
+        {"content": "compared"},
+        {"content": "risks"},
+        {
+            "content": "",
+            "tool_calls": [
+                {"name": "get_contacts", "arguments": {}},
+                {"name": "send_email", "arguments": {"to": "jordan.park@company.com"}},
+            ],
+        },
+        {"content": "sent"},
+    ]
+    scenario = ScenarioDefinition(
+        id="DEEP-01",
+        title="DEEP-01",
+        description="deep multi-turn",
+        category=Category.A,
+        user_message="Find the competitor analysis report.",
+        follow_up_messages=[
+            "Read the 2025 one.",
+            "What's our market share growth compared to last year?",
+            "Summarize the key risks from both reports.",
+            "Email that summary to my manager.",
+        ],
+        handle_tool_call=lambda state, call: state.tool_calls.append(call),
+        evaluate=lambda state: ScenarioEvaluation(
+            status=ScenarioStatus.PASS,
+            points=2,
+            summary="ok",
+        ),
+    )
+    scenario.max_turns_override = 12
+    result = await run_scenario(
+        MockAdapter(responses),
+        model="test-model",
+        base_url="http://localhost:8000",
+        api_key="key",
+        scenario=scenario,
+        max_turns=8,  # global default would cut the deep workflow
+    )
+    # The override lets the full 9-turn path complete; global 8 would fail it.
+    assert result.status == ScenarioStatus.PASS
+    assert result.turn_budget_exceeded is False
+    assert result.turn_count == 9
+
+
+@pytest.mark.asyncio
+async def test_deep_multiturn_workflow_cut_by_global_budget() -> None:
+    """The same deep workflow is cut at the global max_turns without override."""
+    responses = [
+        {"content": "", "tool_calls": [{"name": "search_files", "arguments": {}}]},
+        {"content": "", "tool_calls": [{"name": "read_file", "arguments": {"file": "2025"}}]},
+        {"content": "found"},
+        {"content": "read"},
+        {
+            "content": "",
+            "tool_calls": [
+                {"name": "read_file", "arguments": {"file": "2024"}},
+                {"name": "calculator", "arguments": {"expr": "growth"}},
+            ],
+        },
+        {"content": "compared"},
+        {"content": "risks"},
+        {
+            "content": "",
+            "tool_calls": [
+                {"name": "get_contacts", "arguments": {}},
+                {"name": "send_email", "arguments": {"to": "jordan.park@company.com"}},
+            ],
+        },
+        {"content": "sent"},
+    ]
+    scenario = ScenarioDefinition(
+        id="DEEP-02",
+        title="DEEP-02",
+        description="deep multi-turn",
+        category=Category.A,
+        user_message="Find the competitor analysis report.",
+        follow_up_messages=[
+            "Read the 2025 one.",
+            "What's our market share growth compared to last year?",
+            "Summarize the key risks from both reports.",
+            "Email that summary to my manager.",
+        ],
+        handle_tool_call=lambda state, call: state.tool_calls.append(call),
+        evaluate=lambda state: ScenarioEvaluation(
+            status=ScenarioStatus.FAIL,
+            points=0,
+            summary="did not finish",
+        ),
+    )
+    # No override: the global budget of 6 cuts the path before completion.
+    result = await run_scenario(
+        MockAdapter(responses),
+        model="test-model",
+        base_url="http://localhost:8000",
+        api_key="key",
+        scenario=scenario,
+        max_turns=6,
+    )
+    assert result.turn_count == 6
+    assert result.turn_budget_exceeded is True
+    assert result.failure_kind == FailureKind.BUDGET_EXCEEDED
+
+
+def test_turn_budget_exceeded_roundtrips_through_serialization() -> None:
+    """budget-exhausted results survive to_dict/from_dict resume round-trips."""
+    source = ScenarioResult(
+        scenario_id="TC-46",
+        status=ScenarioStatus.FAIL,
+        points=0,
+        summary="Turn budget exceeded before final email.",
+        turn_budget_exceeded=True,
+    )
+
+    restored = ScenarioResult.from_dict(source.to_dict())
+
+    assert restored.scenario_id == "TC-46"
+    assert restored.turn_budget_exceeded is True
+    # Older persisted rows without the flag must still deserialize as False.
+    legacy_dict = source.to_dict()
+    legacy_dict.pop("turn_budget_exceeded", None)
+    legacy = ScenarioResult.from_dict(legacy_dict)
+    assert legacy.turn_budget_exceeded is False


### PR DESCRIPTION
# fix(TC-46): add per-scenario turn budget for deep multi-turn research workflow

## Problem

Scenario `TC-46` ("Deep Multi-Turn Research (5 turns)", Category I — Context
& State Tracking) runs a 5-user-turn research workflow: search → read →
compare → summarize → email. Under the global `max_turns=8` default the
orchestrator cuts the conversation off before the final email is sent, so a
model that follows the reference path exactly never reaches the final step and
is scored FAIL/PARTIAL purely because the conversation was truncated — not
because it failed the task.

## Root cause with turn count

The real runner counts **assistant turns** (each `chat_completion` call in the
`for turn in range(1, max_turns + 1)` loop). TC-46's canonical reference path
needs up to **11 assistant turns**:

| # | User turn | Assistant action | Tool results | Final response |
|---|-----------|------------------|--------------|----------------|
| 1 | 1 (initial) | `search_files` | 1 | — |
| 2 | — | `read_file` (2025) | 1 | — |
| 3 | — | final answer | — | yes |
| 4 | 2 (follow-up) | final answer (2025 already read) | — | yes |
| 5 | 3 (follow-up) | `read_file` (2024) | 1 | — |
| 6 | — | `calculator` | 1 | — |
| 7 | — | final answer | — | yes |
| 8 | 4 (follow-up) | final answer (summary, no tools) | — | yes |
| 9 | 5 (follow-up) | `get_contacts` | 1 | — |
| 10 | — | `send_email` | 1 | — |
| 11 | — | final answer (email sent) | — | yes |

With parallel tool calls the minimum is 8 assistant turns, but the canonical
non-parallel path is 11. The global `max_turns=8` default therefore truncates
the run at turn 8 — before the summary follow-up or the final email — so the
reference-valid workflow cannot reach the final email.

## Changes

- **`domain/scenarios.py` (`ScenarioDefinition`)** — added an optional
  `max_turns_override: int | None` field. When set, the orchestrator uses this
  per-scenario budget instead of the global `max_turns`, without raising the
  default for every scenario.
- **`runner/orchestrator.py` (`run_scenario`)** — applies
  `max_turns = scenario.max_turns_override or max_turns` before the loop. The
  loop remains bounded by the (possibly overridden) finite value.
- **`runner/orchestrator.py` (`run_scenario`)** — added a `budget_exhausted`
  flag: it is set when the loop ends because the budget ran out before a final
  answer was produced and all follow-ups were drained (i.e. the loop did not
  `break` on a real final answer). The result now carries
  `turn_budget_exceeded=True` and `failure_kind="budget_exceeded"` when the
  evaluator verdict is not PASS, so a truncation is distinguishable from an
  evaluator failure.
- **`evals/scenarios_agentic.py` (TC-46)** — set `max_turns_override=12`,
  giving the canonical 11-turn reference path one turn of finite headroom.

## Contract after the change

- The reference-valid TC-46 workflow (11 assistant turns) fits inside the
  per-scenario budget of 12 and reaches the final email → PASS.
- The limit stays finite: a looping model that never settles still stops at
  the effective budget (`max_turns_override` or global `max_turns`).
- Scenarios without an override keep using the global `max_turns` exactly as
  before — the default for other scenarios is unchanged.
- `status`/`failure_kind` now distinguish turn-budget exhaustion
  (`budget_exceeded`, `turn_budget_exceeded=True`) from evaluator failures
  (e.g. `missing_step`/`wrong_tool`/`evaluator_error`).
- Persisted results round-trip the new `turn_budget_exceeded` flag; older
  rows without it deserialize as `False`.

## Tests

- `tests/test_orchestrator.py`:
  - `test_max_turns_override_extends_budget` — a scenario with override=5 runs
    5 turns even when the global budget is 2.
  - `test_max_turns_override_keeps_limit_finite` — a looping model stops at
    the override value (6), never unbounded.
  - `test_max_turns_override_not_set_uses_global_budget` — no override → the
    global budget (4) is applied unchanged.
  - `test_normal_completion_does_not_flag_budget_exceeded` — a model that
    reaches a final answer gets `turn_budget_exceeded=False` and no
    `failure_kind`.
  - `test_budget_exhaustion_is_distinct_from_evaluator_failure` — a truncated
    run is FAIL with `failure_kind="budget_exceeded"`, distinct from the
    evaluator's own verdict.
  - `test_deep_multiturn_workflow_fits_override_budget` — a TC-46-like 9-turn
    parallel workflow completes PASS under override=12, and is cut to the
    global budget (6) without the override.
  - `test_tc46_has_scenario_budget_override` — TC-46 declares `12`.
  - `test_turn_budget_exceeded_roundtrips_through_serialization` —
    `to_dict`/`from_dict` preserve the flag; legacy rows default to `False`.

Results: all new and existing tests pass. `ruff check` and `ruff format
--check` pass on the changed files.

## Safety bound

The maximum exchanges per scenario are strictly bounded by the finite
effective budget (12 for TC-46, global default otherwise). The change never
permits unbounded loops: a stalled or repeated-call model stops at the budget
with `failure_kind="budget_exceeded"`.

## CHANGELOG

`CHANGELOG.md` updated under `[Unreleased] → Fixed`: TC-46 deep multi-turn
research workflow now has a per-scenario turn budget (`max_turns_override`),
and the orchestrator distinguishes turn-budget exhaustion from evaluator
failures via `turn_budget_exceeded` / `failure_kind="budget_exceeded"`.

## Scope

Five files, all directly tied to the TC-46 budget fix:
`CHANGELOG.md`, `src/tool_eval_bench/domain/scenarios.py`,
`src/tool_eval_bench/evals/scenarios_agentic.py`,
`src/tool_eval_bench/runner/orchestrator.py`, `tests/test_orchestrator.py`.
No dependencies, locks, CI config, or unrelated formatting were touched.
