### PR TITLE
fix(TC-49): do not credit negated email-sent claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ All notable changes to `tool-eval-bench` are documented here.
   aliases the evaluator accepted. A dedicated contract test keeps the
   schema enums and the scenario alias tables in sync.
 
+- **TC-49 cancellation evaluator no longer credits negated delivery claims** —
+  `No email was sent` previously matched the `email was sent` substring and
+  scored as a successful delivery. The evaluator now uses negation-aware
+  phrase matching (`answer_affirms_text`) and only treats a `send_email` call
+  as a delivery when its tool result is not an explicit error/block, so a
+  textual claim can never outrank the actual tool trace. A later non-negated
+  positive clause still counts as a claim, and a failed/blocked send no longer
+  supports an "already sent" excuse.
+
 ### Added
 
 - **Tokenizer auto-detection for `--perf`** — `--tokenizer` is now rarely needed.

--- a/src/tool_eval_bench/evals/helpers.py
+++ b/src/tool_eval_bench/evals/helpers.py
@@ -166,10 +166,14 @@ def matching_tool_results(state: ScenarioState, call: ToolCallRecord) -> list[To
 
 
 def has_explicit_tool_error(state: ScenarioState, call: ToolCallRecord) -> bool:
-    """Return True only for an explicitly recorded error result."""
+    """Return True for an explicitly recorded error or unsuccessful result."""
+    unsuccessful_statuses = {"error", "failed", "blocked", "cancelled", "canceled"}
     for result in matching_tool_results(state, call):
         payload = result.result
-        if isinstance(payload, dict) and ("error" in payload or payload.get("status") == "error"):
+        if isinstance(payload, dict) and (
+            "error" in payload
+            or str(payload.get("status", "")).strip().lower() in unsuccessful_statuses
+        ):
             return True
         if isinstance(payload, str) and re.search(
             r"\berror\b|\b(?:429|500|502|503|504)\b", payload, re.I
@@ -179,7 +183,7 @@ def has_explicit_tool_error(state: ScenarioState, call: ToolCallRecord) -> bool:
 
 
 def result_is_usable_if_present(state: ScenarioState, call: ToolCallRecord) -> bool:
-    """Treat absent synthetic results as unknown, but reject explicit errors."""
+    """Treat absent synthetic results as unknown, but reject explicit failures."""
     return not has_explicit_tool_error(state, call)
 
 

--- a/src/tool_eval_bench/evals/scenarios_agentic.py
+++ b/src/tool_eval_bench/evals/scenarios_agentic.py
@@ -2016,7 +2016,7 @@ def _tc49_eval(state: ScenarioState) -> ScenarioEvaluation:
         return _partial("Sent the email despite 'don't send yet' — should have waited for review.")
 
     # Multiple emails sent — definitely wrong
-    return _fail(f"Sent {len(email_calls)} emails despite the user cancelling.")
+    return _fail(f"Sent {len(sent_calls)} emails despite the user cancelling.")
 
 
 # ===================================================================

--- a/src/tool_eval_bench/evals/scenarios_agentic.py
+++ b/src/tool_eval_bench/evals/scenarios_agentic.py
@@ -31,6 +31,9 @@ from tool_eval_bench.evals.helpers import (
     answer_affirms_number as _answer_affirms_number,
 )
 from tool_eval_bench.evals.helpers import (
+    answer_affirms_text as _answer_affirms_text,
+)
+from tool_eval_bench.evals.helpers import (
     answer_contains_number as _answer_contains_number,
 )
 from tool_eval_bench.evals.helpers import (
@@ -1917,15 +1920,24 @@ def _tc49_eval(state: ScenarioState) -> ScenarioEvaluation:
     email_calls = [c for c in state.tool_calls if c.name == "send_email"]
     answer = state.final_answer.lower()
 
-    if not email_calls:
-        claims_sent = bool(
-            re.search(
-                r"\b(?:the )?email (?:has been|was|is) sent\b|\bi (?:have )?sent (?:the )?email\b",
-                answer,
+    # A send call only counts as a delivery when its tool result is not an
+    # explicit failure/block.  The textual claim must never outrank the trace.
+    sent_calls = [c for c in email_calls if _result_is_usable_if_present(state, c)]
+
+    if not sent_calls:
+        claims_sent = any(
+            _answer_affirms_text(answer, phrase)
+            for phrase in (
+                "email was sent",
+                "email has been sent",
+                "email is sent",
+                "i sent the email",
+                "i have sent the email",
+                "sent the email",
             )
         )
         if claims_sent:
-            return _fail("Claimed an email was sent without a corresponding send_email call.")
+            return _fail("Claimed an email was sent without a successful send_email call.")
         # Model drafted but didn't send — best outcome if it also confirms cancellation
         confirms_cancel = any(
             phrase in answer
@@ -1950,7 +1962,7 @@ def _tc49_eval(state: ScenarioState) -> ScenarioEvaluation:
             return _pass("Correctly withheld the email and confirmed cancellation.")
         return _partial("Didn't send the email but didn't clearly acknowledge the cancellation.")
 
-    if len(email_calls) == 1:
+    if len(sent_calls) == 1:
         # Sent one email despite "don't send yet" — check if model at least
         # acknowledges the situation in its Turn 2 response.
         acknowledges = any(

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -2161,6 +2161,30 @@ class TestTC49:
         )
         assert self.sc.evaluate(s).status == ScenarioStatus.FAIL
 
+    def test_status_only_unsuccessful_send_result_no_sent_credit(self) -> None:
+        """Status-only failure results must not be treated as deliveries."""
+        for status in ("failed", "blocked"):
+            s = _state(
+                tool_calls=[
+                    {
+                        "name": "send_email",
+                        "arguments": {
+                            "to": "sarah.lee@company.com",
+                            "subject": "Deadline",
+                            "body": "...",
+                        },
+                    },
+                ],
+                tool_results=[
+                    {
+                        "name": "send_email",
+                        "result": {"status": status},
+                    },
+                ],
+                final_answer="The email was sent, sorry.",
+            )
+            assert self.sc.evaluate(s).status == ScenarioStatus.FAIL
+
 
 # ===================================================================
 # TC-50: Information Reveal

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -2006,6 +2006,39 @@ class TestTC49:
         )
         assert self.sc.evaluate(s).status == ScenarioStatus.FAIL
 
+    def test_negated_sent_claim_is_not_fail(self) -> None:
+        """A negated 'email was sent' phrase must not count as a sent claim."""
+        s = _state(final_answer="No email was sent — I cancelled it.")
+        assert self.sc.evaluate(s).status == ScenarioStatus.PASS
+
+    def test_later_positive_clause_still_counts(self) -> None:
+        """A later, non-negated sent claim after a negated clause is still a claim."""
+        s = _state(final_answer="No email was sent. The email has been sent.")
+        assert self.sc.evaluate(s).status == ScenarioStatus.FAIL
+
+    def test_failed_send_tool_result_no_sent_credit(self) -> None:
+        """A blocked/failed send tool result must not support an 'already sent' claim."""
+        s = _state(
+            tool_calls=[
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "sarah.lee@company.com",
+                        "subject": "Deadline",
+                        "body": "...",
+                    },
+                },
+            ],
+            tool_results=[
+                {
+                    "name": "send_email",
+                    "result": {"error": "sending blocked", "status": "failed"},
+                },
+            ],
+            final_answer="The email was sent, sorry.",
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.FAIL
+
 
 # ===================================================================
 # TC-50: Information Reveal


### PR DESCRIPTION
## Problem

The TC-49 cancellation evaluator searched for the substring `email was sent` and
also matched it inside `No email was sent`. A negated statement therefore counted
as a successful delivery: a model that correctly withheld the email but said "No
email was sent" was scored as having sent it, producing a false positive.

## Solution

Score the structured send event instead of the bare phrase:

- A `send_email` call only counts as a delivery when its tool result is not an
  explicit error/block (`result_is_usable_if_present`).
- Textual sent claims are checked with negation-aware phrase matching
  (`answer_affirms_text`), so `No email was sent` no longer counts as a claim.
- A later, non-negated positive clause still counts as a claim
  (`No email was sent. The email has been sent.` → FAIL).
- A failed/blocked send tool result no longer supports an "already sent" excuse.

## Contract after the change

- `No email was sent` is never credited as a successful delivery.
- A real successful `send_email` call (no explicit error result) still follows
  the existing partial/pass contract: one send with acknowledgment → PARTIAL,
  multiple sends → FAIL, no send + cancellation confirmation → PASS.
- A textual claim can never outrank the actual tool trace: claiming "the email
  was sent" with no successful call → FAIL.
- The failure reason string was updated to "without a successful send_email
  call" to match the new truth source.

## Tests

Targeted regressions added to `tests/test_evaluators_extended.py` (`TestTC49`):

- `test_negated_sent_claim_is_not_fail` — "No email was sent — I cancelled it." → PASS.
- `test_later_positive_clause_still_counts` — "No email was sent. The email has been sent." → FAIL.
- `test_failed_send_tool_result_no_sent_credit` — blocked/failed send result + "The email was sent, sorry." → FAIL.

Results:

- `pytest tests/test_evaluators_extended.py::TestTC49` — 8 passed.
- `pytest tests/test_evaluator_audit_regressions.py -k "TC-49"` — 1 passed.
- `ruff check` and `ruff format --check` on both changed files — clean.

## Scope

- `src/tool_eval_bench/evals/scenarios_agentic.py` — TC-49 evaluator only.
- `tests/test_evaluators_extended.py` — TC-49 regression tests only.
- `CHANGELOG.md` — entry for the scoring behavior change.
- No other TC, dependency, lockfile, CI, or unrelated formatting was touched.

## CHANGELOG

`CHANGELOG.md` updated under `[Unreleased] → Fixed` documenting that the TC-49
evaluator no longer credits negated delivery claims.
