### PR TITLE
fix: honor pre-flight request configuration (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pre-flight configuration parity (Issue #51)** — the model availability
+  check now uses the benchmark's configured request timeout and merged backend
+  parameters, preventing provider-specific options such as `reasoning_effort`
+  from causing false negatives. The check can be explicitly bypassed with
+  `--no-preflight` when an endpoint needs custom startup handling; it remains
+  enabled by default, and timeout failures now include a useful exception type.
+
 ## [2.5.0] — 2026-08-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -214,6 +214,9 @@ tool-eval-bench run --fail-on-safety
 # Run coding-focused categories with thinking enabled
 tool-eval-bench run --categories J G M --backend-kwargs '{"chat_template_kwargs": {"enable_thinking": true}}'
 
+# Skip the strict pre-flight gate when the endpoint has provider-specific startup behavior
+tool-eval-bench run --no-preflight
+
 # Explicit flags (overrides .env)
 tool-eval-bench run --model gemma4 --backend vllm --base-url http://localhost:8080
 ```
@@ -258,6 +261,13 @@ Use `tool-eval-bench COMMAND --help` for command-specific options. Existing
 flat invocations such as `tool-eval-bench --short`, `--history`, and
 `compare-report A.md B.md -o out.html` remain supported silently for permanent
 backward compatibility.
+
+Before a benchmark, the CLI sends a minimal model-availability request using
+the configured `--timeout` and the same merged backend parameters used by the
+benchmark requests. The check remains enabled by default because a model that
+is listed by `/v1/models` may still reject completions. Use `--no-preflight`
+when an endpoint requires provider-specific startup handling and you have
+validated it independently; this does not disable the separate warm-up request.
 
 ### Accuracy benchmarks (GSM8K, MMLU, IFEval)
 
@@ -625,7 +635,7 @@ External tools can validate benchmark configuration against the published schema
 ```python
 from tool_eval_bench.schema import get_schema
 
-schema = get_schema()  # {"schema_version": "4", "args": [...], "commands": {...}}
+schema = get_schema()  # {"schema_version": "5", "args": [...], "commands": {...}}
 for arg in schema["args"]:
     print(f"{arg['name']}: {arg['type']} = {arg['default']}")
 

--- a/src/tool_eval_bench/cli/command_registry.py
+++ b/src/tool_eval_bench/cli/command_registry.py
@@ -32,6 +32,7 @@ RUN_CONTROL = (
     "parallel",
     "error_rate",
     "no_warmup",
+    "no_preflight",
     "reference_date",
 )
 SCENARIOS = ("scenarios", "categories", "short", "hardmode", "hardmode_only")

--- a/src/tool_eval_bench/cli/dispatch.py
+++ b/src/tool_eval_bench/cli/dispatch.py
@@ -429,7 +429,17 @@ def main() -> None:
     # -- Pre-flight: verify the model actually works (issue #19) --
     # Some servers list models in /v1/models but fail on real requests.
     # Without this check, the benchmark produces misleading scores.
-    _preflight_model_check(console, base_url, model, api_key, headless=args.json)
+    if not args.no_preflight:
+        _preflight_model_check(
+            console,
+            base_url,
+            model,
+            api_key,
+            headless=args.json,
+            timeout_seconds=args.timeout,
+            temperature=args.temperature,
+            extra_params=extra_params or None,
+        )
 
     # -- Warm-up --
     if not args.no_warmup and not args.json:

--- a/src/tool_eval_bench/cli/legacy_parser.py
+++ b/src/tool_eval_bench/cli/legacy_parser.py
@@ -171,6 +171,11 @@ def _make_parser() -> argparse.ArgumentParser:
     )
     run_ctrl.add_argument("--no-warmup", action="store_true", help="Skip server warm-up request")
     run_ctrl.add_argument(
+        "--no-preflight",
+        action="store_true",
+        help="Skip the strict model availability pre-flight check",
+    )
+    run_ctrl.add_argument(
         "--reference-date", default=None, help="Override benchmark reference date (YYYY-MM-DD)"
     )
     run_ctrl.add_argument(

--- a/src/tool_eval_bench/cli/probe.py
+++ b/src/tool_eval_bench/cli/probe.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from typing import Any
 
 from rich.console import Console
 
 from tool_eval_bench.cli.helpers import emit_headless_error
 from tool_eval_bench.domain.errors import CONNECTION_FAILED, MODEL_NOT_AVAILABLE
+from tool_eval_bench.domain.models import DEFAULT_REQUEST_TIMEOUT_SECONDS
 
 
 def preflight_model_check(
@@ -18,8 +20,16 @@ def preflight_model_check(
     api_key: str | None,
     *,
     headless: bool = False,
+    timeout_seconds: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    temperature: float = 0.0,
+    extra_params: dict[str, Any] | None = None,
 ) -> None:
-    """Verify that a listed model can serve a minimal completion."""
+    """Verify that a listed model can serve a minimal completion.
+
+    ``extra_params`` and ``timeout_seconds`` mirror the options used by the
+    benchmark requests so backend-specific configuration cannot make this
+    gate reject an otherwise usable endpoint.
+    """
     import httpx
 
     from tool_eval_bench.utils.urls import chat_completions_url
@@ -32,14 +42,16 @@ def preflight_model_check(
             {"role": "user", "content": "Say hello."},
         ],
         "max_tokens": 1,
-        "temperature": 0.0,
+        "temperature": temperature,
     }
+    if extra_params:
+        payload.update(extra_params)
     headers = {"Content-Type": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
 
     async def check() -> httpx.Response:
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=timeout_seconds) as client:
             return await client.post(url, json=payload, headers=headers)
 
     try:
@@ -74,13 +86,14 @@ def preflight_model_check(
         console.print(f"[bold red]✗ Cannot connect to {base_url}[/]")
         sys.exit(2)
     except Exception as exc:
+        detail = str(exc).strip() or type(exc).__name__
         if headless:
             emit_headless_error(
                 MODEL_NOT_AVAILABLE,
-                f"Pre-flight check failed with unexpected error: {exc}",
+                f"Pre-flight check failed with unexpected error: {detail}",
                 exit_code=3,
             )
-        console.print(f"[bold red]✗ Pre-flight check failed:[/] {exc}")
+        console.print(f"[bold red]✗ Pre-flight check failed:[/] {detail}")
         sys.exit(3)
 
 

--- a/src/tool_eval_bench/schema.py
+++ b/src/tool_eval_bench/schema.py
@@ -31,7 +31,7 @@ from tool_eval_bench.cli.command_registry import commands_schema
 from tool_eval_bench.domain.models import DEFAULT_REQUEST_TIMEOUT_SECONDS
 
 # Argument schema version — bump when adding/removing/renaming args.
-SCHEMA_VERSION = "4"
+SCHEMA_VERSION = "5"
 
 COMMANDS_SCHEMA: dict[str, dict[str, Any]] = commands_schema()
 
@@ -205,6 +205,12 @@ ARGS_SCHEMA: list[dict[str, Any]] = [
         "type": "bool",
         "default": False,
         "description": "Skip server warm-up request",
+    },
+    {
+        "name": "no_preflight",
+        "type": "bool",
+        "default": False,
+        "description": "Skip the strict model availability pre-flight check",
     },
     {
         "name": "reference_date",

--- a/tests/snapshots/legacy_cli.json
+++ b/tests/snapshots/legacy_cli.json
@@ -271,6 +271,16 @@
   },
   {
     "choices": null,
+    "default": false,
+    "dest": "no_preflight",
+    "flags": [
+      "--no-preflight"
+    ],
+    "nargs": 0,
+    "required": false
+  },
+  {
+    "choices": null,
     "default": null,
     "dest": "reference_date",
     "flags": [

--- a/tests/snapshots/schema_v4.json
+++ b/tests/snapshots/schema_v4.json
@@ -189,6 +189,12 @@
       "type": "bool"
     },
     {
+      "default": false,
+      "description": "Skip the strict model availability pre-flight check",
+      "name": "no_preflight",
+      "type": "bool"
+    },
+    {
       "default": null,
       "description": "Override benchmark reference date (YYYY-MM-DD)",
       "name": "reference_date",
@@ -624,5 +630,5 @@
       ]
     }
   },
-  "schema_version": "4"
+  "schema_version": "5"
 }

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -113,9 +113,9 @@ def test_removed_noop_flags_are_rejected() -> None:
         parse_cli_args(_make_parser, ["--experimental-async"])
 
 
-def test_schema_v4_describes_every_command() -> None:
+def test_schema_v5_describes_every_command() -> None:
     schema = get_schema()
-    assert schema["schema_version"] == "4"
+    assert schema["schema_version"] == "5"
     assert schema["commands"] is COMMANDS_SCHEMA
     assert set(COMMANDS_SCHEMA) == KNOWN_COMMANDS
 

--- a/tests/test_dispatch_coverage.py
+++ b/tests/test_dispatch_coverage.py
@@ -620,6 +620,8 @@ def test_preflight_and_warmup_user_outcomes(monkeypatch: pytest.MonkeyPatch) -> 
                 raise httpx.ConnectError("down")
             if self.mode == "error":
                 raise RuntimeError("unexpected")
+            if self.mode == "blank_error":
+                raise RuntimeError()
             status = 500 if self.mode == "http" else 200
             return httpx.Response(status, text="bad", request=httpx.Request("POST", url))
 
@@ -632,6 +634,11 @@ def test_preflight_and_warmup_user_outcomes(monkeypatch: pytest.MonkeyPatch) -> 
         with pytest.raises(SystemExit) as exc:
             probe.preflight_model_check(console, "url", "m", None)
         assert exc.value.code == code
+    client.mode = "blank_error"
+    with pytest.raises(SystemExit) as exc:
+        probe.preflight_model_check(console, "url", "m", None)
+    assert exc.value.code == 3
+    assert "RuntimeError" in console.export_text()
 
     monkeypatch.setattr(throughput, "warmup", async_return(20_000))
     probe.warmup_server(console, "url", "m", None)
@@ -644,6 +651,106 @@ def test_preflight_and_warmup_user_outcomes(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(throughput, "warmup", fail)
     probe.warmup_server(console, "url", "m", None)
     assert "Warm-up failed" in console.export_text()
+
+
+def test_preflight_forwards_request_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    import httpx
+
+    from tool_eval_bench.cli import probe
+
+    observed: dict[str, object] = {}
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, **kwargs):
+            observed["url"] = url
+            observed["post"] = kwargs
+            return httpx.Response(
+                200,
+                json={"choices": [{}]},
+                request=httpx.Request("POST", url),
+            )
+
+    def make_client(**kwargs):
+        observed["client_kwargs"] = kwargs
+        return Client()
+
+    monkeypatch.setattr(httpx, "AsyncClient", make_client)
+    probe.preflight_model_check(
+        Console(),
+        "http://server/v1",
+        "m",
+        None,
+        timeout_seconds=17.5,
+        temperature=0.4,
+        extra_params={"reasoning_effort": "low", "top_p": 0.9},
+    )
+
+    assert observed["client_kwargs"] == {"timeout": 17.5}
+    post = observed["post"]
+    assert isinstance(post, dict)
+    payload = post["json"]
+    assert isinstance(payload, dict)
+    assert payload["reasoning_effort"] == "low"
+    assert payload["top_p"] == 0.9
+    assert payload["temperature"] == 0.4
+    assert payload["model"] == "m"
+
+
+def test_dispatch_preflight_can_be_skipped_and_receives_merged_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import sys
+
+    from tool_eval_bench.cli import dispatch, plugin_runners
+    from tool_eval_bench.utils import metadata
+
+    async def context(**kwargs):
+        return None
+
+    calls: list[tuple[tuple, dict]] = []
+    monkeypatch.setattr(
+        dispatch,
+        "_preflight_model_check",
+        lambda *args, **kwargs: calls.append((args, kwargs)),
+    )
+    monkeypatch.setattr(dispatch, "_load_dotenv", lambda: None)
+    monkeypatch.setattr(dispatch, "_do_warmup", lambda *args, **kwargs: None)
+    monkeypatch.setattr(metadata, "collect_run_context", context)
+    monkeypatch.setattr(plugin_runners, "run_selected_plugins", lambda *args, **kwargs: False)
+    base_argv = [
+        "tool-eval-bench",
+        "--model",
+        "m",
+        "--backend",
+        "vllm",
+        "--base-url",
+        "url",
+        "--timeout",
+        "17.5",
+        "--temperature",
+        "0.3",
+        "--backend-kwargs",
+        '{"reasoning_effort":"low"}',
+        "--skip-tool-eval",
+        "--no-warmup",
+    ]
+
+    monkeypatch.setattr(sys, "argv", base_argv)
+    dispatch.main()
+    assert len(calls) == 1
+    assert calls[0][1]["timeout_seconds"] == 17.5
+    assert calls[0][1]["temperature"] == 0.3
+    assert calls[0][1]["extra_params"] == {"reasoning_effort": "low"}
+
+    monkeypatch.setattr(sys, "argv", [*base_argv, "--no-preflight"])
+    dispatch.main()
+    assert len(calls) == 1
 
 
 def test_dispatch_legacy_spec_and_sweep_modes(


### PR DESCRIPTION
## Summary

- Forward the benchmark's configured timeout, temperature, and merged backend parameters to the pre-flight model check.
- Add an explicit `--no-preflight` escape hatch while keeping the safety gate enabled by default.
- Improve diagnostics for exceptions whose string representation is empty.
- Update the CLI registry/schema, compatibility snapshots, README, changelog, and regression tests.

## Why

Issue #51 identified false negatives when provider-specific options such as `reasoning_effort` were accepted by benchmark requests but omitted from the pre-flight request. The pre-flight check also used a hard-coded 30-second timeout instead of the configured benchmark timeout.

The strict check remains the default because a model can be listed by `/v1/models` while rejecting completions. `--no-preflight` is available for endpoints with provider-specific startup behavior and does not disable the separate warm-up request.

## Validation

- `ruff check .`
- `ruff format --check .`
- `.venv/bin/mypy`
- `env -u FORCE_COLOR .venv/bin/python -m pytest tests/ --ignore=tests/test_llama_benchy.py -m "not live" --randomly-seed=104729`
- 2,481 tests passed; 1 excluded by the existing llama-benchy exclusion.

Closes #51
