### PR TITLE
fix(TC-55): order both-files branch before read-one subset in revenue pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ### Fixed
 
+- **TC-55 branch ordering** — in `_tc55_eval`, the broad
+  `searched and (read_na or read_emea) and has_total` branch shadowed the
+  both-files case: reading **both** regional files and producing the correct
+  total without a calculator call was reported as *"only read one of two
+  files"*. A dedicated `searched and read_na and read_emea and has_total`
+  branch now precedes the `or`-subset, so the reason reflects the actual
+  trace. Regression test `test_partial_both_files_total_no_calculator`
+  covers the case.
 - **TC-35 no-op prompt contract** — the same-unit Kelvin conversion prompt no
   longer mandates the calculator tool or gives away the no-op answer. Direct
   recognition of the identity conversion remains the full-credit path, while

--- a/src/tool_eval_bench/evals/scenarios_planning.py
+++ b/src/tool_eval_bench/evals/scenarios_planning.py
@@ -541,6 +541,8 @@ def _tc55_eval(state: ScenarioState) -> ScenarioEvaluation:
     )
     if searched and read_na and read_emea and calculator and has_total:
         return _pass("Built data pipeline: search → read ×2 → calculate total revenue.")
+    if searched and read_na and read_emea and has_total:
+        return _partial("Read both files and produced the total but didn't use the calculator.")
     if searched and (read_na or read_emea) and has_total:
         return _partial("Got the total but only read one of two files.")
     if searched and read_na and read_emea:

--- a/tests/test_planning_scenarios.py
+++ b/tests/test_planning_scenarios.py
@@ -207,6 +207,7 @@ class TestTC55DataPipeline:
         result = self.sc.evaluate(state)
         # Partial — only read one file but got the total (somehow)
         assert result.status in (ScenarioStatus.PASS, ScenarioStatus.PARTIAL)
+
     def test_partial_both_files_total_no_calculator(self) -> None:
         """Regression: both regional files read + correct total, but no
         calculator call. The "(read_na or read_emea) and has_total" branch
@@ -224,6 +225,7 @@ class TestTC55DataPipeline:
         # Reason must reflect that both files were read, not "only one".
         assert "both" in result.summary.lower()
         assert "only read one" not in result.summary.lower()
+
     def test_fail_no_search(self) -> None:
         state = _make_state(final_answer="The Q3 revenue was around $4M.")
         result = self.sc.evaluate(state)

--- a/tests/test_planning_scenarios.py
+++ b/tests/test_planning_scenarios.py
@@ -207,7 +207,23 @@ class TestTC55DataPipeline:
         result = self.sc.evaluate(state)
         # Partial — only read one file but got the total (somehow)
         assert result.status in (ScenarioStatus.PASS, ScenarioStatus.PARTIAL)
-
+    def test_partial_both_files_total_no_calculator(self) -> None:
+        """Regression: both regional files read + correct total, but no
+        calculator call. The "(read_na or read_emea) and has_total" branch
+        must not shadow the both-files case with a misleading reason."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "Q3 revenue"}},
+                {"name": "read_file", "arguments": {"file_id": "q3_rev_na"}},
+                {"name": "read_file", "arguments": {"file_id": "q3_rev_emea"}},
+            ],
+            final_answer="NA revenue is $2,400,000 and EMEA revenue is $1,800,000; total is $4,200,000.",
+        )
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PARTIAL
+        # Reason must reflect that both files were read, not "only one".
+        assert "both" in result.summary.lower()
+        assert "only read one" not in result.summary.lower()
     def test_fail_no_search(self) -> None:
         state = _make_state(final_answer="The Q3 revenue was around $4M.")
         result = self.sc.evaluate(state)


### PR DESCRIPTION
# TC-55 — Two-region revenue pipeline: branch ordering

## Problem

In `_tc55_eval` (scenarios_planning), the branch order shadowed a valid case:

```python
if searched and read_na and read_emea and calculator and has_total:
    return _pass("Built data pipeline: search → read ×2 → calculate total revenue.")
if searched and (read_na or read_emea) and has_total:
    return _partial("Got the total but only read one of two files.")
if searched and read_na and read_emea:
    return _partial("Read both files but didn't calculate the combined total.")
...
```

When the model read **both** regional files (`q3_rev_na` and `q3_rev_emea`)
and produced the correct total without a calculator call, the second branch —
`searched and (read_na or read_emea) and has_total` — matched (because
`read_na and read_emea` implies `read_na or read_emea`) and reported:

> "Got the total but only read one of two files."

That reason is misleading: both files were read. The `or`-subset shadowed the
more specific both-files case.

## Change

Insert a dedicated both-files branch **before** the `or`-subset:

```python
if searched and read_na and read_emea and calculator and has_total:
    return _pass("Built data pipeline: search → read ×2 → calculate total revenue.")
if searched and read_na and read_emea and has_total:
    return _partial("Read both files and produced the total but didn't use the calculator.")
if searched and (read_na or read_emea) and has_total:
    return _partial("Got the total but only read one of two files.")
if searched and read_na and read_emea:
    return _partial("Read both files but didn't calculate the combined total.")
...
```

The specific both-files case now precedes its `or`-subset, so the reason
reflects the actual trace. The full-pipeline PASS branch is unchanged.

## Contract after the change

- `searched ∧ read_na ∧ read_emea ∧ calculator ∧ has_total` → PASS
  ("Built data pipeline: search → read ×2 → calculate total revenue.")
- `searched ∧ read_na ∧ read_emea ∧ has_total ∧ ¬calculator` → PARTIAL
  ("Read both files and produced the total but didn't use the calculator.")
- `searched ∧ (read_na ⊕ read_emea) ∧ has_total` → PARTIAL
  ("Got the total but only read one of two files.")
- `searched ∧ read_na ∧ read_emea ∧ ¬has_total` → PARTIAL
  ("Read both files but didn't calculate the combined total.")
- `searched ∧ ¬read_na ∧ ¬read_emea` → PARTIAL
  ("Found files but didn't read and aggregate them.")
- otherwise → FAIL

## Tests

`tests/test_planning_scenarios.py` — `TestTC55DataPipeline` and
`TestTC55EdgeCases`:

- `test_pass_full_pipeline` (PASS, unchanged)
- `test_partial_one_file_only` (PARTIAL, unchanged)
- `test_partial_both_files_no_total` (PARTIAL, unchanged)
- `test_partial_both_files_total_no_calculator` (new: PARTIAL + reason mentions
  both files and missing calculator)
- `test_fail_no_search` (FAIL, unchanged)

Focused run: `pytest tests/test_planning_scenarios.py -k TC55` → 6 passed.
Also `tests/test_scenario_branch_matrix.py` → green (single-tool TC-55
expectation unchanged).

Note: the full-suite run on this Windows checkout reports unrelated environment
failures (cp1251 decoding and `C:\` path expectations in
reporter/yaml/leaderboard/scenarios tests) — not caused by this change.

## CHANGELOG

Entry added under `[Unreleased] → Fixed`: **"TC-55 two-region revenue pipeline
branch ordering"** — documents that the both-files-with-total-but-no-calculator
case now gets its own PARTIAL reason before the read-one subset is evaluated.

## Scope

- `src/tool_eval_bench/evals/scenarios_planning.py` — `_tc55_eval` branch order
  only.
- `tests/test_planning_scenarios.py` — one new regression test.
- `CHANGELOG.md` — one entry.

No prompt, handler, tolerance, dependency, lock, CI, or unrelated-file changes.
Full suite not run (per TC-55 process); only TC-55 nodes plus the shared
branch-matrix TC-55 case and lint/format of changed files.