### PR TITLE
fix(TC-56): accept ISO timestamps for tomorrow-morning reminder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ### Fixed
 
+- **TC-56 semantic reminder time (scoring)** — a `set_reminder` call now only
+  earns the notification-workflow credit when its ISO `datetime` resolves to
+  the *next calendar day* in a documented morning window (05:00 inclusive to
+  12:00 exclusive) relative to the scenario reference date. Literal
+  `"tomorrow morning"` text remains accepted for backward compatibility.
+  Timezone offsets/`Z` are ignored (calendar date + hour only, matching the
+  shared `datetime_matches` convention), month/year rollover is handled, and
+  malformed or missing datetimes no longer pass. This is a scoring-behavior
+  change: reminders scheduled outside tomorrow's morning window now yield
+  PARTIAL instead of PASS.
 - **TC-35 no-op prompt contract** — the same-unit Kelvin conversion prompt no
   longer mandates the calculator tool or gives away the no-op answer. Direct
   recognition of the identity conversion remains the full-credit path, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ### Fixed
 
-- **TC-56 semantic reminder time (scoring)** — a `set_reminder` call now only
-  earns the notification-workflow credit when its ISO `datetime` resolves to
-  the *next calendar day* in a documented morning window (05:00 inclusive to
-  12:00 exclusive) relative to the scenario reference date. Literal
-  `"tomorrow morning"` text remains accepted for backward compatibility.
-  Timezone offsets/`Z` are ignored (calendar date + hour only, matching the
-  shared `datetime_matches` convention), month/year rollover is handled, and
-  malformed or missing datetimes no longer pass. This is a scoring-behavior
-  change: reminders scheduled outside tomorrow's morning window now yield
-  PARTIAL instead of PASS.
+- **TC-56 semantic reminder time (scoring)** — `set_reminder` now also accepts
+  an ISO `datetime` that resolves to the *next calendar day* in a documented
+  morning window (05:00 inclusive to 12:00 exclusive) relative to the scenario
+  reference date. Literal `"tomorrow morning"` text remains accepted for
+  backward compatibility. Timezone offsets/`Z` are ignored (calendar date +
+  hour only, same ignore-offset idea as `datetime_matches`), and month/year
+  rollover is handled. This is an additive scoring change: correct next-day
+  morning ISO timestamps that previously failed the literal substring gate can
+  now PASS; outside-window, wrong-day, malformed, and missing datetimes stay
+  PARTIAL as before.
 - **Pre-flight configuration parity (Issue #51)** — the model availability
   check now uses the benchmark's configured request timeout and merged backend
   parameters, preventing provider-specific options such as `reasoning_effort`

--- a/src/tool_eval_bench/evals/scenarios_planning.py
+++ b/src/tool_eval_bench/evals/scenarios_planning.py
@@ -13,6 +13,7 @@ TC-63: Accumulating constraints (Category I expansion).
 from __future__ import annotations
 
 import re
+from datetime import date, datetime, timedelta
 from typing import Any
 
 from tool_eval_bench.domain.scenarios import (
@@ -581,6 +582,56 @@ def _tc56_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     return _noise({"error": f"Tool {call.name} is not relevant."}, call.name)
 
 
+def _is_tomorrow_morning(datetime_value, state):
+    """Return whether a set_reminder datetime is semantically tomorrow
+    morning. Accepts either natural-language text ("tomorrow morning") or
+    an ISO timestamp that resolves to the next calendar day in a morning
+    window relative to the scenario reference date.
+
+    Morning window: 05:00 inclusive through 12:00 exclusive (5 <= hour < 12).
+    Timezone offsets are ignored, matching the shared ``datetime_matches``
+    convention: only the calendar date and hour are compared, so a model that
+    emits an explicit offset is not penalised for choosing a different zone.
+    """
+    if not datetime_value:
+        return False
+    dt_str = _as_str(datetime_value).strip().lower()
+    if not dt_str:
+        return False
+
+    # Natural-language form (backward compatible with existing tests).
+    if "tomorrow" in dt_str and "morning" in dt_str:
+        return True
+
+    ref = state.meta.get("reference_date")
+    if ref is None:
+        return False
+    try:
+        ref_dt = datetime.fromisoformat(str(ref).strip())
+    except Exception:
+        return False
+
+    # Normalise ISO timestamps: strip a trailing Z and parse as naive
+    # (Z means UTC, but for calendar-day semantics we compare dates only).
+    parse_str = dt_str
+    if parse_str.endswith("z"):
+        parse_str = parse_str[:-1]
+    try:
+        target = datetime.fromisoformat(parse_str)
+    except Exception:
+        return False
+    if ref_dt.tzinfo is None and target.tzinfo is not None:
+        target = target.replace(tzinfo=None)
+    if ref_dt.tzinfo is not None and target.tzinfo is None:
+        target = target.replace(tzinfo=ref_dt.tzinfo)
+
+    next_day = date(ref_dt.year, ref_dt.month, ref_dt.day) + timedelta(days=1)
+    if target.date() != next_day:
+        return False
+    hour = target.time().hour
+    return 5 <= hour < 12
+
+
 def _tc56_eval(state: ScenarioState) -> ScenarioEvaluation:
     """User: 'Check the weather in NYC. If it's below freezing, email me
     a warning and set a reminder to dress warmly tomorrow morning.'
@@ -615,8 +666,7 @@ def _tc56_eval(state: ScenarioState) -> ScenarioEvaluation:
         "set_reminder",
         lambda c: (
             "warm" in _as_str(c.arguments.get("message")).lower()
-            and "tomorrow" in _as_str(c.arguments.get("datetime")).lower()
-            and "morning" in _as_str(c.arguments.get("datetime")).lower()
+            and _is_tomorrow_morning(c.arguments.get("datetime"), state)
         ),
     )
 

--- a/src/tool_eval_bench/evals/scenarios_planning.py
+++ b/src/tool_eval_bench/evals/scenarios_planning.py
@@ -597,16 +597,19 @@ def _tc56_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     return _noise({"error": f"Tool {call.name} is not relevant."}, call.name)
 
 
-def _is_tomorrow_morning(datetime_value, state):
-    """Return whether a set_reminder datetime is semantically tomorrow
-    morning. Accepts either natural-language text ("tomorrow morning") or
-    an ISO timestamp that resolves to the next calendar day in a morning
-    window relative to the scenario reference date.
+def _is_tomorrow_morning(datetime_value: Any, state: ScenarioState) -> bool:
+    """Return whether a set_reminder datetime is semantically tomorrow morning.
 
-    Morning window: 05:00 inclusive through 12:00 exclusive (5 <= hour < 12).
-    Timezone offsets are ignored, matching the shared ``datetime_matches``
-    convention: only the calendar date and hour are compared, so a model that
-    emits an explicit offset is not penalised for choosing a different zone.
+    Accepts either natural-language text ("tomorrow morning") or an ISO
+    timestamp that resolves to the next calendar day in a morning window
+    relative to the scenario reference date in ``state.meta``.
+
+    Morning window (ISO path only): 05:00 inclusive through 12:00 exclusive
+    (``5 <= hour < 12``). Timezone offsets are ignored — only calendar date and
+    hour are compared (same ignore-offset idea as ``datetime_matches``, but
+    this helper uses a next-day hour *window*, not an exact ``HH:MM`` match).
+    The natural-language path keeps the historical substring check and does
+    not enforce the hour window, so existing full-workflow tests stay green.
     """
     if not datetime_value:
         return False
@@ -614,7 +617,7 @@ def _is_tomorrow_morning(datetime_value, state):
     if not dt_str:
         return False
 
-    # Natural-language form (backward compatible with existing tests).
+    # Natural-language form (backward compatible; hour window not applied).
     if "tomorrow" in dt_str and "morning" in dt_str:
         return True
 

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -315,6 +315,10 @@ async def run_scenario(
     """Run a single scenario through the multi-turn orchestration loop."""
     t0 = time.monotonic()
     state = ScenarioState()
+    # Meta must match the reference date actually injected into the prompt:
+    # _initial_messages falls back to the benchmark default when None.
+    state.meta["reference_date"] = reference_date or BENCHMARK_REFERENCE_DATE
+    state.meta["reference_day"] = reference_day or BENCHMARK_REFERENCE_DAY
     messages = _initial_messages(
         scenario.user_message,
         reference_date=reference_date,

--- a/tests/test_planning_scenarios.py
+++ b/tests/test_planning_scenarios.py
@@ -783,6 +783,320 @@ class TestTC56EdgeCases:
         result = self.sc.evaluate(state)
         assert result.status == ScenarioStatus.PARTIAL
 
+    def test_pass_iso_timestamp_reminder(self) -> None:
+        """TC-56: an ISO timestamp resolving to the next calendar day in the
+        morning window passes semantic validation."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-03-21T08:00:00Z",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer=(
+                "NYC is -3 degrees, below freezing. I have sent a warning "
+                "email and set a reminder to dress warmly tomorrow morning."
+            ),
+        )
+        state.meta["reference_date"] = "2026-03-20"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PASS
+
+    def test_pass_iso_morning_lower_bound(self) -> None:
+        """TC-56: 05:00 is the inclusive lower edge of the morning window."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-03-21T05:00:00",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent and reminder set.",
+        )
+        state.meta["reference_date"] = "2026-03-20"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PASS
+
+    def test_pass_iso_morning_upper_bound(self) -> None:
+        """TC-56: 11:59 is inside the morning window (12:00 is exclusive)."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-03-21T11:59:00",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent and reminder set.",
+        )
+        state.meta["reference_date"] = "2026-03-20"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PASS
+
+    def test_partial_iso_noon_exclusive(self) -> None:
+        """TC-56: 12:00 is outside the morning window, so the reminder is
+        not accepted and the workflow stays partial."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-03-21T12:00:00",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent.",
+        )
+        state.meta["reference_date"] = "2026-03-20"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PARTIAL
+
+    def test_partial_iso_today_morning(self) -> None:
+        """TC-56: today's morning is not tomorrow, so the reminder is not
+        accepted and the workflow stays partial."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-03-20T08:00:00",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent.",
+        )
+        state.meta["reference_date"] = "2026-03-20"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PARTIAL
+
+    def test_partial_iso_day_after_tomorrow(self) -> None:
+        """TC-56: the day after tomorrow is not tomorrow morning, so the
+        workflow stays partial."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-03-22T08:00:00",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent.",
+        )
+        state.meta["reference_date"] = "2026-03-20"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PARTIAL
+
+    def test_partial_iso_malformed(self) -> None:
+        """TC-56: a malformed ISO timestamp must not crash the evaluator;
+        it simply means the reminder is not accepted (partial verdict)."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-13-99T25:00:00",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent.",
+        )
+        state.meta["reference_date"] = "2026-03-20"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PARTIAL
+
+    def test_pass_iso_timezone_offset(self) -> None:
+        """TC-56: a timezone-aware timestamp still passes; offsets are
+        ignored and only the calendar date + hour are compared."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-03-21T08:00:00+02:00",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent and reminder set.",
+        )
+        state.meta["reference_date"] = "2026-03-20"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PASS
+
+    def test_pass_iso_month_boundary(self) -> None:
+        """TC-56: reference date near a month boundary still resolves the
+        next calendar day (March 31 → April 1)."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-04-01T08:00:00",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent and reminder set.",
+        )
+        state.meta["reference_date"] = "2026-03-31"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PASS
+
+    def test_pass_iso_year_boundary(self) -> None:
+        """TC-56: reference date near a year boundary still resolves the
+        next calendar day (December 31 → January 1)."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {
+                    "name": "set_reminder",
+                    "arguments": {
+                        "message": "dress warmly",
+                        "datetime": "2026-01-01T08:00:00",
+                    },
+                },
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent and reminder set.",
+        )
+        state.meta["reference_date"] = "2025-12-31"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PASS
+
+    def test_partial_iso_missing_datetime(self) -> None:
+        """TC-56: a missing datetime means the reminder is not accepted,
+        so the workflow stays partial."""
+        state = _make_state(
+            tool_calls=[
+                {"name": "get_weather", "arguments": {"location": "NYC"}},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "me",
+                        "subject": "Freezing warning",
+                        "body": "It is below freezing",
+                    },
+                },
+                {"name": "set_reminder", "arguments": {"message": "dress warmly"}},
+            ],
+            tool_results=[{"location": "NYC", "temperature": -3}],
+            final_answer="NYC is below freezing; warning sent.",
+        )
+        state.meta["reference_date"] = "2026-03-20"
+        result = self.sc.evaluate(state)
+        assert result.status == ScenarioStatus.PARTIAL
+
 
 class TestTC61EdgeCases:
     sc = _get("TC-61")


### PR DESCRIPTION
# TC-56 — Semantic tomorrow-morning reminder time validation

## Problem

TC-56's evaluator (`_tc56_eval` in `scenarios_planning.py`) credited the
`set_reminder` step only when the `datetime` argument contained the literal
words `tomorrow` and `morning`:

```python
and "tomorrow" in _as_str(c.arguments.get("datetime")).lower()
and "morning" in _as_str(c.arguments.get("datetime")).lower()
```

A model that supplies a correct ISO 8601 timestamp for the next calendar
day's morning — e.g. `2026-03-21T08:00:00Z` with the benchmark reference date
`2026-03-20` — is semantically correct, but the evaluator rejected it because
ISO 8601 contains no natural-language words. The task asked for a reminder
"tomorrow morning"; the timestamp *is* tomorrow morning, yet the workflow was
not credited.

## Root cause

The evaluator compared *literal substrings* of the `datetime` argument
instead of parsing the value semantically. The model was scored on words
rather than on the actual scheduled time.

## Semantic contract / window

A `set_reminder` call is accepted when its `datetime`:

1. is the natural-language form containing both `tomorrow` and `morning`
   (backward compatible; hour window not applied on this path), **or**
2. resolves to the **next calendar day** relative to the scenario
   `reference_date` (the date injected into the prompt as "today"), and
   falls inside the documented **morning window**:
   `05:00` inclusive through `12:00` exclusive (`5 <= hour < 12`).

Timezone offsets and a trailing `Z` are ignored — only the calendar date and
hour are compared — same ignore-offset idea as `datetime_matches` (this helper
uses a next-day hour window, not an exact `HH:MM` match). Month/year rollover
is handled via `timedelta` arithmetic. Malformed or missing datetimes yield a
normal PARTIAL verdict, never a crash.

## Scoring impact

This is an **additive** scoring change:

- Correct next-day morning ISO timestamps that previously failed the literal
  substring gate can now PASS.
- Outside-window, wrong-day, malformed, and missing datetimes stay PARTIAL
  as before (they never matched the old substring gate either).

## Changes

- `src/tool_eval_bench/evals/scenarios_planning.py`
  - New helper `_is_tomorrow_morning(datetime_value, state)` that parses the
    ISO timestamp relative to `state.meta["reference_date"]`, requires the
    next calendar day, and checks the documented morning window.
  - `_tc56_eval` now uses `_is_tomorrow_morning` instead of literal
    `tomorrow`/`morning` substring checks for the ISO path.
- `src/tool_eval_bench/runner/orchestrator.py`
  - `run_scenario` now stores the reference date actually injected into the
    prompt (`reference_date or BENCHMARK_REFERENCE_DATE`) in `state.meta`, so
    the evaluator sees the same "today" the model saw even when the CLI flag is
    unset.
- `tests/test_planning_scenarios.py`
  - Focused boundary tests for the semantic datetime contract.
- `CHANGELOG.md` — entry under `[Unreleased]` (additive impact language).

## Boundary tests / results

Added `TestTC56EdgeCases` cases covering ISO in-window, 05:00/11:59 bounds,
12:00 exclusive, today, day-after-tomorrow, malformed, timezone offset,
month/year rollover, and missing datetime.

Focused run: `pytest tests/test_planning_scenarios.py -k TC56` → all green.

## Scope

Only the TC-56 evaluator, its orchestration plumbing (`state.meta` reference
date), focused tests, and the changelog. No dependencies, locks, CI, other
TCs, or unrelated formatting.

## Maintainer follow-up

Docs-only correction on top: accurate additive scoring description in
CHANGELOG/helper docstring; dropped an incorrect "tightening / always-true
gate" narrative from the original PR text.
