### PR TITLE
feat: add --label run annotation to every report artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ All notable changes to `tool-eval-bench` are documented here.
   appended to report filenames (`<run_id>--<slug>.md`,
   `<run_id>--<slug>_summary.md`), so all artifacts of one execution share a
   grep-able marker while the timestamped run ID remains the leading identity.
-  The label is an annotation only: it never changes the config fingerprint or
-  run ID, so identical runs with different labels stay comparable.
+  Report rendering makes control characters visible and prevents Markdown or
+  terminal-markup injection; labels without an ASCII slug receive a stable hash
+  marker. The label is an annotation only: it never changes the config
+  fingerprint or run ID, so identical runs with different labels stay
+  comparable.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`--label` run annotations** — an arbitrary string (`--label "tonyd2wild
+  tool hardening 646c55f"`) is now recorded on every report an execution
+  generates: a `Label` row in the tool-eval Run Context table, a `- **Label**:`
+  header line in GSM8K / MMLU / IFEval / throughput / spec-decode /
+  context-pressure-sweep reports, and the metadata persisted to SQLite (visible
+  via `history` and `export`). A filesystem-safe slug of the label is also
+  appended to report filenames (`<run_id>--<slug>.md`,
+  `<run_id>--<slug>_summary.md`), so all artifacts of one execution share a
+  grep-able marker while the timestamped run ID remains the leading identity.
+  The label is an annotation only: it never changes the config fingerprint or
+  run ID, so identical runs with different labels stay comparable.
+
 ### Fixed
 
 - **TC-57 safety-language scoring (safety diagnostic)** — safety language that

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ tool-eval-bench run --categories K A
 # Make safety-critical failures fail a CI job (exit status 2)
 tool-eval-bench run --fail-on-safety
 
+# Tag an execution so every report it generates is identifiable
+tool-eval-bench run --label "tonyd2wild tool hardening 646c55f" --trials 3
+
 # Run coding-focused categories with thinking enabled
 tool-eval-bench run --categories J G M --backend-kwargs '{"chat_template_kwargs": {"enable_thinking": true}}'
 
@@ -765,6 +768,26 @@ Artifacts:
 - Markdown report (`runs/YYYY/MM/<run_id>.md`) with full traces for public
   scenarios; held-out pack scenarios redact titles, summaries, and traces in the
   report (traces remain in SQLite for local inspection)
+
+### Labeling runs (`--label`)
+
+`--label "..."` attaches an arbitrary, free-form string to an execution. Every
+report that execution generates carries it: a `Label` row in the tool-eval Run
+Context table, a `- **Label**:` header line in the plugin / throughput /
+spec-decode / pressure-sweep reports, and the persisted metadata (shown in
+`history` and included in `export`). Report filenames also gain a safe slug of
+the label, so all files from one execution end with the same marker:
+
+```
+runs/2026/08/<run_id>--tonyd2wild-tool-hardening-646c55f.md
+runs/2026/08/<run_id>--tonyd2wild-tool-hardening-646c55f_summary.md
+```
+
+The full human-readable label (spaces, dots, capitals — anything) is rendered
+verbatim inside the reports; only the filename uses a slug (lowercased,
+punctuation collapsed to dashes, `.-_` kept, capped at 80 chars). The label is
+purely an annotation — it does not affect the run ID or `config_fingerprint`,
+so identical runs with different labels remain comparable.
 
 ## Backends
 

--- a/README.md
+++ b/README.md
@@ -783,11 +783,13 @@ runs/2026/08/<run_id>--tonyd2wild-tool-hardening-646c55f.md
 runs/2026/08/<run_id>--tonyd2wild-tool-hardening-646c55f_summary.md
 ```
 
-The full human-readable label (spaces, dots, capitals — anything) is rendered
-verbatim inside the reports; only the filename uses a slug (lowercased,
-punctuation collapsed to dashes, `.-_` kept, capped at 80 chars). The label is
-purely an annotation — it does not affect the run ID or `config_fingerprint`,
-so identical runs with different labels remain comparable.
+The full label is persisted unchanged. Reports render it as inert inline code;
+line breaks and control characters are shown as visible escapes so a label
+cannot alter the Markdown structure. Only the filename uses a slug (lowercased,
+punctuation collapsed to dashes, `.-_` kept, capped at 80 chars). Labels with no
+ASCII representation receive a deterministic `label-<hash>` marker. The label
+is purely an annotation — it does not affect the run ID or
+`config_fingerprint`, so identical runs with different labels remain comparable.
 
 ## Backends
 

--- a/src/tool_eval_bench/cli/command_registry.py
+++ b/src/tool_eval_bench/cli/command_registry.py
@@ -24,6 +24,7 @@ OUTPUT = (
     "alpha",
     "no_probe_engine",
     "output_dir",
+    "label",
 )
 RUN_CONTROL = (
     "timeout",

--- a/src/tool_eval_bench/cli/dispatch.py
+++ b/src/tool_eval_bench/cli/dispatch.py
@@ -482,6 +482,7 @@ def main() -> None:
                 thinking_enabled=not args.no_think,
                 extra_params=extra_params or None,
                 context_pressure=args.context_pressure,
+                label=args.label,
                 probe_engine=not args.no_probe_engine,
             )
         )
@@ -629,6 +630,7 @@ def main() -> None:
             metadata_for_storage=_metadata_for_storage,
             with_config_fingerprint=_with_config_fingerprint,
             persist_plugin_run=_persist_plugin_run,
+            label=args.label,
         )
         # If --spec-bench is the only mode, or user explicitly skipped tool-eval
         if args.skip_tool_eval or (
@@ -660,6 +662,7 @@ def main() -> None:
             with_config_fingerprint=_with_config_fingerprint,
             persist_plugin_run=_persist_plugin_run,
             metadata_for_storage=_metadata_for_storage,
+            label=args.label,
         )
         return
 

--- a/src/tool_eval_bench/cli/history.py
+++ b/src/tool_eval_bench/cli/history.py
@@ -19,6 +19,11 @@ def _extract_context_summary(run: dict) -> str:
     config = run.get("config") or {}
     parts: list[str] = []
 
+    # User-supplied run label (--label), when present
+    label = metadata.get("label") or config.get("label")
+    if label:
+        parts.append(str(label))
+
     # Tool version
     version = metadata.get("tool_version")
     if version:
@@ -59,6 +64,10 @@ def _extract_context_panel(run: dict) -> list[str]:
     metadata = run.get("metadata") or {}
     config = run.get("config") or {}
     lines: list[str] = []
+
+    label = metadata.get("label") or config.get("label")
+    if label:
+        lines.append(f"  [bold]Label:[/] {label}")
 
     version = metadata.get("tool_version")
     if version:

--- a/src/tool_eval_bench/cli/history.py
+++ b/src/tool_eval_bench/cli/history.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 import sys
 
 from rich.console import Console
+from rich.markup import escape
+
+from tool_eval_bench.storage.reports import safe_label_text
 
 
 def _extract_context_summary(run: dict) -> str:
@@ -22,7 +25,7 @@ def _extract_context_summary(run: dict) -> str:
     # User-supplied run label (--label), when present
     label = metadata.get("label") or config.get("label")
     if label:
-        parts.append(str(label))
+        parts.append(escape(safe_label_text(str(label))))
 
     # Tool version
     version = metadata.get("tool_version")
@@ -67,7 +70,7 @@ def _extract_context_panel(run: dict) -> list[str]:
 
     label = metadata.get("label") or config.get("label")
     if label:
-        lines.append(f"  [bold]Label:[/] {label}")
+        lines.append(f"  [bold]Label:[/] {escape(safe_label_text(str(label)))}")
 
     version = metadata.get("tool_version")
     if version:

--- a/src/tool_eval_bench/cli/legacy_parser.py
+++ b/src/tool_eval_bench/cli/legacy_parser.py
@@ -198,6 +198,13 @@ def _make_parser() -> argparse.ArgumentParser:
     )
     output.add_argument("--no-live", action="store_true", help="Disable live updating display")
     output.add_argument(
+        "--label",
+        default=None,
+        metavar="TEXT",
+        help="Free-form annotation attached to every report this run generates "
+        "(shown in the report body; a safe slug of it is added to report filenames)",
+    )
+    output.add_argument(
         "--redact-url",
         action="store_true",
         help="Mask the server URL in display output (for screenshots/recordings)",

--- a/src/tool_eval_bench/cli/plugin_lifecycle.py
+++ b/src/tool_eval_bench/cli/plugin_lifecycle.py
@@ -53,7 +53,7 @@ def finalize_plugin_run(
     metadata_for_storage: Callable[[Any | None], dict[str, Any]],
 ) -> str:
     """Write and persist a completed plugin run through one invariant."""
-    from tool_eval_bench.storage.reports import MarkdownReporter, report_filename
+    from tool_eval_bench.storage.reports import MarkdownReporter, markdown_label, report_filename
     from tool_eval_bench.utils.ids import build_run_id
 
     run_config = with_config_fingerprint(config)
@@ -64,7 +64,7 @@ def finalize_plugin_run(
     folder = reporter.root / f"{now.year:04d}" / f"{now.month:02d}"
     folder.mkdir(parents=True, exist_ok=True)
     path = folder / report_filename(run_id, label)
-    label_line = [f"- **Label**: `{label}`"] if label else []
+    label_line = [f"- **Label**: {markdown_label(label)}"] if label else []
     markdown = [
         f"# {title} Benchmark — {display_name}",
         "",

--- a/src/tool_eval_bench/cli/plugin_lifecycle.py
+++ b/src/tool_eval_bench/cli/plugin_lifecycle.py
@@ -53,22 +53,25 @@ def finalize_plugin_run(
     metadata_for_storage: Callable[[Any | None], dict[str, Any]],
 ) -> str:
     """Write and persist a completed plugin run through one invariant."""
-    from tool_eval_bench.storage.reports import MarkdownReporter
+    from tool_eval_bench.storage.reports import MarkdownReporter, report_filename
     from tool_eval_bench.utils.ids import build_run_id
 
     run_config = with_config_fingerprint(config)
     run_id = build_run_id(run_config)
+    label = getattr(run_context, "label", None) if run_context is not None else None
     reporter = MarkdownReporter(root=output_dir)
     now = datetime.now(timezone.utc)
     folder = reporter.root / f"{now.year:04d}" / f"{now.month:02d}"
     folder.mkdir(parents=True, exist_ok=True)
-    path = folder / f"{run_id}.md"
+    path = folder / report_filename(run_id, label)
+    label_line = [f"- **Label**: `{label}`"] if label else []
     markdown = [
         f"# {title} Benchmark — {display_name}",
         "",
         f"- **Run ID**: `{run_id}`",
         f"- **Date**: `{now.isoformat()}`",
         f"- **Mode**: {mode}",
+        *label_line,
         *report_metrics,
         f"- **Rating**: {result.rating}",
         "",

--- a/src/tool_eval_bench/cli/pressure.py
+++ b/src/tool_eval_bench/cli/pressure.py
@@ -32,6 +32,7 @@ def _write_pressure_sweep_report(
     breaking_point: float | None,
     first_degradation: float | None,
     output_dir: str | None,
+    label: str | None = None,
 ) -> Path:
     """Compatibility wrapper around the shared Markdown reporter."""
     from tool_eval_bench.storage.reports import MarkdownReporter
@@ -46,6 +47,7 @@ def _write_pressure_sweep_report(
         level_results=level_results,
         breaking_point=breaking_point,
         first_degradation=first_degradation,
+        label=label,
     )
 
 
@@ -80,6 +82,7 @@ def run_pressure_sweep(
     with_config_fingerprint: Any = None,
     persist_plugin_run: Any = None,
     metadata_for_storage: Any = None,
+    label: str | None = None,
 ) -> None:
     """Run scenarios at increasing context pressure and report breaking point."""
     from rich.panel import Panel
@@ -382,6 +385,9 @@ def run_pressure_sweep(
         }
     )
     sweep_run_id = build_run_id(sweep_config)
+    metadata = metadata_for_storage(None)
+    if label:
+        metadata["label"] = label
     run_data = {
         "run_id": sweep_run_id,
         "run_type": "context-pressure",
@@ -393,7 +399,7 @@ def run_pressure_sweep(
             "first_degradation": first_degradation,
             "level_results": level_results,
         },
-        "metadata": metadata_for_storage(None),
+        "metadata": metadata,
     }
     report_path = _report_then_persist_pressure_sweep(
         report_kwargs={
@@ -406,6 +412,7 @@ def run_pressure_sweep(
             "breaking_point": breaking_point,
             "first_degradation": first_degradation,
             "output_dir": getattr(args, "output_dir", None),
+            "label": label,
         },
         run_data=run_data,
         persist_plugin_run=persist_plugin_run,

--- a/src/tool_eval_bench/cli/spec_bench.py
+++ b/src/tool_eval_bench/cli/spec_bench.py
@@ -32,6 +32,7 @@ def run_spec_bench(
     metadata_for_storage: Any = None,
     with_config_fingerprint: Any = None,
     persist_plugin_run: Any = None,
+    label: str | None = None,
 ) -> list:
     """Run speculative decoding benchmark and display results.
 
@@ -262,7 +263,12 @@ def run_spec_bench(
         from tool_eval_bench.storage.reports import MarkdownReporter
 
         reporter = MarkdownReporter(root=output_dir)
-        report_path = reporter.write_spec_decode_report(run_id, display_name, ok_samples)
+        report_path = reporter.write_spec_decode_report(
+            run_id, display_name, ok_samples, label=label
+        )
+        metadata = metadata_for_storage(None)
+        if label:
+            metadata["label"] = label
         persist_plugin_run(
             {
                 "run_id": run_id,
@@ -270,7 +276,7 @@ def run_spec_bench(
                 "status": "completed",
                 "config": run_config,
                 "scores": {"samples": len(ok_samples)},
-                "metadata": metadata_for_storage(None),
+                "metadata": metadata,
             }
         )
         console.print(f"\n  [dim]📄 Report saved to {report_path}[/]")

--- a/src/tool_eval_bench/domain/models.py
+++ b/src/tool_eval_bench/domain/models.py
@@ -58,6 +58,10 @@ class RunContext:
     thinking_enabled: bool = True
     extra_params: dict[str, Any] | None = None
     context_pressure: float | None = None
+    # Free-form user-supplied annotation recorded on every artifact a run
+    # generates (issued via --label). Deliberately not part of any
+    # config fingerprint: a label never makes identical runs incomparable.
+    label: str | None = None
 
     # -- Tier 3: inference engine (best-effort) --
     server_model_id: str | None = None

--- a/src/tool_eval_bench/schema.py
+++ b/src/tool_eval_bench/schema.py
@@ -31,7 +31,7 @@ from tool_eval_bench.cli.command_registry import commands_schema
 from tool_eval_bench.domain.models import DEFAULT_REQUEST_TIMEOUT_SECONDS
 
 # Argument schema version — bump when adding/removing/renaming args.
-SCHEMA_VERSION = "5"
+SCHEMA_VERSION = "6"
 
 COMMANDS_SCHEMA: dict[str, dict[str, Any]] = commands_schema()
 
@@ -268,6 +268,15 @@ ARGS_SCHEMA: list[dict[str, Any]] = [
         "type": "string",
         "default": None,
         "description": "Directory for report files (default: ./runs/)",
+    },
+    {
+        "name": "label",
+        "type": "string",
+        "default": None,
+        "description": (
+            "Free-form annotation recorded on every report this run generates "
+            "(shown in the report body; a safe slug is added to report filenames)"
+        ),
     },
     {
         "name": "dry_run",

--- a/src/tool_eval_bench/storage/reports.py
+++ b/src/tool_eval_bench/storage/reports.py
@@ -7,6 +7,7 @@ throughput metrics, and full traces for inspection.
 from __future__ import annotations
 
 import re
+import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping
@@ -32,6 +33,35 @@ def _default_reports_root() -> str:
     return str(Path.cwd() / "runs")
 
 
+def slugify_label(label: str | None, *, max_length: int = 80) -> str:
+    """Return a filesystem-safe slug of a run label for report filenames.
+
+    Lowercases, collapses whitespace/punctuation to single dashes, and keeps
+    ``.`` ``-`` ``_`` so version-like strings stay readable ("3.75" →
+    "3.75").  Empty or unsafe-only labels yield ``""`` so callers can fall
+    back to plain run-ID filenames.  Called with the :option:`--label` value;
+    the full human-readable label is still rendered inside the report body.
+    """
+    if not label:
+        return ""
+    normalized = unicodedata.normalize("NFKD", label).encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", normalized.lower())
+    slug = re.sub(r"-{2,}", "-", slug).strip("-._")
+    return slug[:max_length]
+
+
+def report_filename(run_id: str, label: str | None, suffix: str = "") -> str:
+    """Report file name: ``{run_id}--{slug}{suffix}.md``, or plain without a label.
+
+    ``suffix`` is used for derived reports (e.g. ``_summary``), so the slug
+    stays adjacent to the run ID: ``{run_id}--{slug}_summary.md``.
+    """
+    slug = slugify_label(label)
+    if not slug:
+        return f"{run_id}{suffix}.md"
+    return f"{run_id}--{slug}{suffix}.md"
+
+
 def _trace_block(raw_log: str) -> list[str]:
     """Return a Markdown fence long enough to preserve a complete raw trace."""
     longest = max((len(match) for match in re.findall(r"`+", raw_log)), default=0)
@@ -54,18 +84,21 @@ class MarkdownReporter:
         level_results: list[dict[str, Any]],
         breaking_point: float | None,
         first_degradation: float | None,
+        label: str | None = None,
     ) -> Path:
         """Write a trace-complete artifact for a context-pressure sweep."""
         now = datetime.now(timezone.utc)
         folder = self.root / f"{now.year:04d}" / f"{now.month:02d}"
         folder.mkdir(parents=True, exist_ok=True)
-        path = folder / f"{run_id}.md"
+        path = folder / report_filename(run_id, label)
+        label_line = [f"- **Label**: `{label}`"] if label else []
         markdown = [
             f"# Context Pressure Sweep — {model}",
             "",
             f"- **Run ID**: `{run_id}`",
             f"- **Date**: `{now.isoformat()}`",
             "- **Mode**: context-pressure-sweep",
+            *label_line,
             f"- **Backend**: {backend}",
             f"- **Server**: {display_url}",
             f"- **Context Window**: {context_size:,} tokens",
@@ -136,7 +169,8 @@ class MarkdownReporter:
         now = datetime.now(timezone.utc)
         folder = self.root / f"{now.year:04d}" / f"{now.month:02d}"
         folder.mkdir(parents=True, exist_ok=True)
-        path = folder / f"{run_id}.md"
+        label = run_context.label if run_context is not None else None
+        path = folder / report_filename(run_id, label)
 
         status_emoji = {
             ScenarioStatus.PASS: "✅",
@@ -377,7 +411,8 @@ class MarkdownReporter:
         now = datetime.now(timezone.utc)
         folder = self.root / f"{now.year:04d}" / f"{now.month:02d}"
         folder.mkdir(parents=True, exist_ok=True)
-        path = folder / f"{run_id}.md"
+        label = run_context.label if run_context is not None else None
+        path = folder / report_filename(run_id, label)
 
         # Version stamp
         version_str = ""
@@ -395,6 +430,8 @@ class MarkdownReporter:
         ]
         if version_str:
             md.append(f"- **tool-eval-bench**: `{version_str}`")
+        if label:
+            md.append(f"- **Label**: `{label}`")
         md.append("")
 
         # Run Context section
@@ -446,7 +483,8 @@ class MarkdownReporter:
         now = datetime.now(timezone.utc)
         folder = self.root / f"{now.year:04d}" / f"{now.month:02d}"
         folder.mkdir(parents=True, exist_ok=True)
-        path = folder / f"{run_id}_summary.md"
+        label = run_context.label if run_context is not None else None
+        path = folder / report_filename(run_id, label, suffix="_summary")
 
         n = agg.get("trials", len(summaries))
 
@@ -739,19 +777,22 @@ class MarkdownReporter:
         run_id: str,
         model: str,
         spec_samples: list[Any],
+        label: str | None = None,
     ) -> Path:
         """Write a Markdown report for speculative decoding benchmark results."""
         now = datetime.now(timezone.utc)
         folder = self.root / f"{now.year:04d}" / f"{now.month:02d}"
         folder.mkdir(parents=True, exist_ok=True)
-        path = folder / f"{run_id}.md"
+        path = folder / report_filename(run_id, label)
 
+        label_line = [f"- **Label**: `{label}`"] if label else []
         md = [
             f"# Speculative Decoding Benchmark — {model}",
             "",
             f"- **Run ID**: `{run_id}`",
             f"- **Date**: `{now.isoformat()}`",
             "- **Mode**: spec-bench",
+            *label_line,
         ]
 
         # Detect method
@@ -1016,6 +1057,12 @@ def _render_run_context(ctx: RunContext) -> list[str]:
             "",
             "| Parameter | Value |",
             "|---|---|",
+        ]
+    )
+    if ctx.label:
+        md.append(f"| **Label** | `{ctx.label}` |")
+    md.extend(
+        [
             f"| Backend | {ctx.backend} |",
             f"| Server | `{ctx.base_url}` |",
             f"| Model (API) | `{ctx.model}` |",

--- a/src/tool_eval_bench/storage/reports.py
+++ b/src/tool_eval_bench/storage/reports.py
@@ -6,6 +6,8 @@ throughput metrics, and full traces for inspection.
 
 from __future__ import annotations
 
+import hashlib
+import html
 import re
 import unicodedata
 from datetime import datetime, timezone
@@ -38,16 +40,44 @@ def slugify_label(label: str | None, *, max_length: int = 80) -> str:
 
     Lowercases, collapses whitespace/punctuation to single dashes, and keeps
     ``.`` ``-`` ``_`` so version-like strings stay readable ("3.75" →
-    "3.75").  Empty or unsafe-only labels yield ``""`` so callers can fall
-    back to plain run-ID filenames.  Called with the :option:`--label` value;
-    the full human-readable label is still rendered inside the report body.
+    "3.75"). Empty labels yield ``""`` so callers can fall back to plain
+    run-ID filenames. Labels without an ASCII representation use a stable hash
+    marker so every non-empty label still produces an identifiable file.
     """
     if not label:
         return ""
     normalized = unicodedata.normalize("NFKD", label).encode("ascii", "ignore").decode("ascii")
     slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", normalized.lower())
     slug = re.sub(r"-{2,}", "-", slug).strip("-._")
+    if not slug:
+        digest = hashlib.sha256(label.encode("utf-8")).hexdigest()[:12]
+        slug = f"label-{digest}"
     return slug[:max_length]
+
+
+def safe_label_text(label: str) -> str:
+    """Make control characters visible without changing persisted metadata."""
+    visible: list[str] = []
+    for char in label:
+        if char == "\n":
+            visible.append(r"\n")
+        elif char == "\r":
+            visible.append(r"\r")
+        elif char == "\t":
+            visible.append(r"\t")
+        elif unicodedata.category(char).startswith("C"):
+            visible.append(f"\\u{ord(char):04x}")
+        else:
+            visible.append(char)
+    return "".join(visible)
+
+
+def markdown_label(label: str, *, table_cell: bool = False) -> str:
+    """Render a label as inert inline HTML for Markdown reports."""
+    visible = html.escape(safe_label_text(label), quote=False)
+    if table_cell:
+        visible = visible.replace("|", "&#124;")
+    return f"<code>{visible}</code>"
 
 
 def report_filename(run_id: str, label: str | None, suffix: str = "") -> str:
@@ -91,7 +121,7 @@ class MarkdownReporter:
         folder = self.root / f"{now.year:04d}" / f"{now.month:02d}"
         folder.mkdir(parents=True, exist_ok=True)
         path = folder / report_filename(run_id, label)
-        label_line = [f"- **Label**: `{label}`"] if label else []
+        label_line = [f"- **Label**: {markdown_label(label)}"] if label else []
         markdown = [
             f"# Context Pressure Sweep — {model}",
             "",
@@ -431,7 +461,7 @@ class MarkdownReporter:
         if version_str:
             md.append(f"- **tool-eval-bench**: `{version_str}`")
         if label:
-            md.append(f"- **Label**: `{label}`")
+            md.append(f"- **Label**: {markdown_label(label)}")
         md.append("")
 
         # Run Context section
@@ -785,7 +815,7 @@ class MarkdownReporter:
         folder.mkdir(parents=True, exist_ok=True)
         path = folder / report_filename(run_id, label)
 
-        label_line = [f"- **Label**: `{label}`"] if label else []
+        label_line = [f"- **Label**: {markdown_label(label)}"] if label else []
         md = [
             f"# Speculative Decoding Benchmark — {model}",
             "",
@@ -1060,7 +1090,7 @@ def _render_run_context(ctx: RunContext) -> list[str]:
         ]
     )
     if ctx.label:
-        md.append(f"| **Label** | `{ctx.label}` |")
+        md.append(f"| **Label** | {markdown_label(ctx.label, table_cell=True)} |")
     md.extend(
         [
             f"| Backend | {ctx.backend} |",

--- a/src/tool_eval_bench/utils/metadata.py
+++ b/src/tool_eval_bench/utils/metadata.py
@@ -356,6 +356,7 @@ async def collect_run_context(
     thinking_enabled: bool = True,
     extra_params: dict[str, Any] | None = None,
     context_pressure: float | None = None,
+    label: str | None = None,
     redact_url: bool = True,
     probe_engine: bool = True,
 ) -> RunContext:
@@ -397,6 +398,7 @@ async def collect_run_context(
         thinking_enabled=thinking_enabled,
         extra_params=extra_params,
         context_pressure=context_pressure,
+        label=label,
         # Tier 3
         server_model_id=engine_info.get("server_model_id"),
         server_model_root=engine_info.get("server_model_root"),

--- a/tests/snapshots/legacy_cli.json
+++ b/tests/snapshots/legacy_cli.json
@@ -331,6 +331,16 @@
   },
   {
     "choices": null,
+    "default": null,
+    "dest": "label",
+    "flags": [
+      "--label"
+    ],
+    "nargs": null,
+    "required": false
+  },
+  {
+    "choices": null,
     "default": false,
     "dest": "redact_url",
     "flags": [

--- a/tests/snapshots/schema_v4.json
+++ b/tests/snapshots/schema_v4.json
@@ -251,6 +251,12 @@
       "type": "string"
     },
     {
+      "default": null,
+      "description": "Free-form annotation recorded on every report this run generates (shown in the report body; a safe slug is added to report filenames)",
+      "name": "label",
+      "type": "string"
+    },
+    {
       "default": false,
       "description": "Show which scenarios would run, then exit (no server needed)",
       "name": "dry_run",
@@ -630,5 +636,5 @@
       ]
     }
   },
-  "schema_version": "5"
+  "schema_version": "6"
 }

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -113,9 +113,9 @@ def test_removed_noop_flags_are_rejected() -> None:
         parse_cli_args(_make_parser, ["--experimental-async"])
 
 
-def test_schema_v5_describes_every_command() -> None:
+def test_schema_v6_describes_every_command() -> None:
     schema = get_schema()
-    assert schema["schema_version"] == "5"
+    assert schema["schema_version"] == "6"
     assert schema["commands"] is COMMANDS_SCHEMA
     assert set(COMMANDS_SCHEMA) == KNOWN_COMMANDS
 
@@ -282,3 +282,75 @@ def test_shared_plugin_finalization_writes_and_persists(
     assert persisted[0]["run_id"] == run_id
     assert persisted[0]["config"]["config_fingerprint"] == "fingerprint"
     assert persisted[0]["scores"]["accuracy"] == 75.0
+
+
+# ---------------------------------------------------------------------------
+# --label flag
+# ---------------------------------------------------------------------------
+
+
+def test_label_flag_parses_on_run_subcommand() -> None:
+    _, args = parse_cli_args(_make_parser, ["run", "--label", "tonyd2wild tool hardening 646c55f"])
+    assert args.label == "tonyd2wild tool hardening 646c55f"
+
+
+def test_label_defaults_to_none() -> None:
+    _, args = parse_cli_args(_make_parser, ["run"])
+    assert args.label is None
+
+
+def test_plugin_subcommand_preserves_label() -> None:
+    _, args = parse_cli_args(_make_parser, ["plugin", "gsm8k", "--label", "my tag"])
+    assert args.label == "my tag"
+
+
+def test_finalize_plugin_run_renders_label_and_slugifies_filename(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    from tool_eval_bench.cli import plugin_runners
+    from tool_eval_bench.domain.models import RunContext
+
+    LABEL = "aiden-sparkrun aiden-3.75-sparkrun toolargs no proxy 229a985"
+    SLUG = "aiden-sparkrun-aiden-3.75-sparkrun-toolargs-no-proxy-229a985"
+
+    persisted: list[dict] = []
+    monkeypatch.setattr(plugin_runners, "_persist_plugin_run", persisted.append)
+    monkeypatch.setattr(
+        plugin_runners,
+        "_with_config_fingerprint",
+        lambda config: {**config, "config_fingerprint": "fingerprint"},
+    )
+    result = SimpleNamespace(
+        score=75.0,
+        rating="Good",
+        details={"total": 4, "correct": 3},
+    )
+    ctx = RunContext(
+        tool_version="2.5.0",
+        git_sha="abc123",
+        hostname="h",
+        platform_info="p",
+        python_version="3.12",
+        model="model",
+        backend="vllm",
+        base_url="http://***:8000",
+        label=LABEL,
+    )
+
+    run_id = _finalize_plugin_run(
+        mode="gsm8k",
+        title="GSM8K",
+        display_name="Display Model",
+        result=result,
+        config={"model": "model", "mode": "gsm8k"},
+        report_metrics=["- **Accuracy**: **75.0%**"],
+        report_lines=["plugin-specific report"],
+        output_dir=str(tmp_path),
+        run_context=ctx,
+    )
+
+    reports = list(tmp_path.rglob(f"{run_id}--{SLUG}.md"))
+    assert len(reports) == 1
+    text = reports[0].read_text()
+    assert f"- **Label**: `{LABEL}`" in text
+    assert persisted[0]["metadata"]["label"] == LABEL

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -352,5 +352,5 @@ def test_finalize_plugin_run_renders_label_and_slugifies_filename(
     reports = list(tmp_path.rglob(f"{run_id}--{SLUG}.md"))
     assert len(reports) == 1
     text = reports[0].read_text()
-    assert f"- **Label**: `{LABEL}`" in text
+    assert f"- **Label**: <code>{LABEL}</code>" in text
     assert persisted[0]["metadata"]["label"] == LABEL

--- a/tests/test_dispatch_coverage.py
+++ b/tests/test_dispatch_coverage.py
@@ -227,7 +227,10 @@ def test_dispatch_main_skip_and_perf_only_routes(
     from tool_eval_bench.storage import reports
     from tool_eval_bench.utils import metadata
 
+    context_calls: list[dict] = []
+
     async def context(**kwargs):
+        context_calls.append(kwargs)
         return None
 
     monkeypatch.setattr(dispatch, "_load_dotenv", lambda: None)
@@ -245,6 +248,8 @@ def test_dispatch_main_skip_and_perf_only_routes(
             "--base-url",
             "url",
             "--skip-tool-eval",
+            "--label",
+            "startup A",
             "--no-warmup",
             "--no-think",
             "--top-p",
@@ -254,6 +259,7 @@ def test_dispatch_main_skip_and_perf_only_routes(
         ],
     )
     dispatch.main()
+    assert context_calls[-1]["label"] == "startup A"
 
     monkeypatch.setattr(dispatch, "_run_llama_benchy", lambda *a, **k: [_sample()])
     monkeypatch.setattr(
@@ -792,15 +798,33 @@ def test_dispatch_legacy_spec_and_sweep_modes(
     )
     dispatch.main()
 
-    called: list[str] = []
-    monkeypatch.setattr(dispatch, "_run_spec_bench", lambda *a, **k: called.append("spec"))
+    called: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        dispatch,
+        "_run_spec_bench",
+        lambda *a, **k: called.append(("spec", k)),
+    )
     monkeypatch.setattr(
         sys,
         "argv",
-        ["tool-eval-bench", "--model", "m", "--base-url", "url", "--spec-bench", "--no-warmup"],
+        [
+            "tool-eval-bench",
+            "--model",
+            "m",
+            "--base-url",
+            "url",
+            "--spec-bench",
+            "--label",
+            "spec A",
+            "--no-warmup",
+        ],
     )
     dispatch.main()
-    monkeypatch.setattr(dispatch, "_run_pressure_sweep", lambda *a, **k: called.append("sweep"))
+    monkeypatch.setattr(
+        dispatch,
+        "_run_pressure_sweep",
+        lambda *a, **k: called.append(("sweep", k)),
+    )
     monkeypatch.setattr(
         sys,
         "argv",
@@ -812,8 +836,13 @@ def test_dispatch_legacy_spec_and_sweep_modes(
             "url",
             "--context-pressure-sweep",
             "0.5-0.8",
+            "--label",
+            "sweep A",
             "--no-warmup",
         ],
     )
     dispatch.main()
-    assert called == ["spec", "sweep"]
+    assert [(name, kwargs["label"]) for name, kwargs in called] == [
+        ("spec", "spec A"),
+        ("sweep", "sweep A"),
+    ]

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -587,6 +587,7 @@ class TestLabelInReports:
         assert slugify_label(self.LABEL) == self.SLUG
         assert slugify_label("Mixed Case & Punctuation!") == "mixed-case-punctuation"
         assert slugify_label("a  b---c") == "a-b-c"
+        assert slugify_label("实验一") == "label-2dac6e5b8c89"
         assert slugify_label("") == ""
         assert slugify_label(None) == ""
 
@@ -594,7 +595,7 @@ class TestLabelInReports:
         from tool_eval_bench.storage.reports import _render_run_context
 
         md = "\n".join(_render_run_context(self._ctx(self.LABEL)))
-        assert f"| **Label** | `{self.LABEL}` |" in md
+        assert f"| **Label** | <code>{self.LABEL}</code> |" in md
 
         md_without = "\n".join(_render_run_context(self._ctx(None)))
         assert "| Label |" not in md_without
@@ -607,7 +608,7 @@ class TestLabelInReports:
         )
         assert path.name == f"run_1--{self.SLUG}.md"
         content = path.read_text()
-        assert f"| **Label** | `{self.LABEL}` |" in content
+        assert f"| **Label** | <code>{self.LABEL}</code> |" in content
 
     def test_scenario_report_without_label_keeps_plain_filename(self, tmp_path):
         reporter = MarkdownReporter(root=str(tmp_path))
@@ -630,7 +631,7 @@ class TestLabelInReports:
             "run_3", "model", summaries, agg, run_context=self._ctx(self.LABEL)
         )
         assert path.name == f"run_3--{self.SLUG}_summary.md"
-        assert f"| **Label** | `{self.LABEL}` |" in path.read_text()
+        assert f"| **Label** | <code>{self.LABEL}</code> |" in path.read_text()
 
     def test_throughput_report_labels_and_slugifies_filename(self, tmp_path):
         from dataclasses import dataclass
@@ -654,7 +655,7 @@ class TestLabelInReports:
             "tp_1", "model", [FakeSample()], run_context=self._ctx(self.LABEL)
         )
         assert path.name == f"tp_1--{self.SLUG}.md"
-        assert f"- **Label**: `{self.LABEL}`" in path.read_text()
+        assert f"- **Label**: <code>{self.LABEL}</code>" in path.read_text()
 
     def test_spec_decode_report_labels_and_slugifies_filename(self, tmp_path):
         from dataclasses import dataclass
@@ -673,7 +674,7 @@ class TestLabelInReports:
 
         path = reporter.write_spec_decode_report("spec_1", "model", [FakeSpec()], label=self.LABEL)
         assert path.name == f"spec_1--{self.SLUG}.md"
-        assert f"- **Label**: `{self.LABEL}`" in path.read_text()
+        assert f"- **Label**: <code>{self.LABEL}</code>" in path.read_text()
 
     def test_pressure_sweep_report_labels_and_slugifies_filename(self, tmp_path):
         reporter = MarkdownReporter(root=str(tmp_path))
@@ -689,4 +690,16 @@ class TestLabelInReports:
             label=self.LABEL,
         )
         assert path.name == f"ps_1--{self.SLUG}.md"
-        assert f"- **Label**: `{self.LABEL}`" in path.read_text()
+        assert f"- **Label**: <code>{self.LABEL}</code>" in path.read_text()
+
+    def test_label_cannot_inject_markdown_structure(self, tmp_path):
+        label = "baseline`\n\n# Forged Result\n\n- **Final Score**: **100** | fake"
+        reporter = MarkdownReporter(root=str(tmp_path))
+        path = reporter.write_scenario_report(
+            "run_safe", "model", _make_summary(), run_context=self._ctx(label)
+        )
+
+        content = path.read_text()
+        assert "\n# Forged Result\n" not in content
+        assert "<code>baseline`\\n\\n# Forged Result" in content
+        assert "&#124; fake</code>" in content

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -552,3 +552,141 @@ class TestDefaultPaths:
         custom = tmp_path / "custom_reports"
         reporter = MarkdownReporter(root=str(custom))
         assert reporter.root == custom
+
+
+# ---------------------------------------------------------------------------
+# --label annotations: rendered in content, slugged into filenames (format A)
+# ---------------------------------------------------------------------------
+
+
+class TestLabelInReports:
+    """Every report a run generates carries the run label."""
+
+    LABEL = "aiden-sparkrun aiden-3.75-sparkrun toolargs no proxy 229a985"
+    SLUG = "aiden-sparkrun-aiden-3.75-sparkrun-toolargs-no-proxy-229a985"
+
+    @staticmethod
+    def _ctx(label: str | None):
+        from tool_eval_bench.domain.models import RunContext
+
+        return RunContext(
+            tool_version="2.5.0",
+            git_sha="abc123",
+            hostname="h",
+            platform_info="p",
+            python_version="3.12",
+            model="m",
+            backend="vllm",
+            base_url="http://***:8000",
+            label=label,
+        )
+
+    def test_slugify_label(self):
+        from tool_eval_bench.storage.reports import slugify_label
+
+        assert slugify_label(self.LABEL) == self.SLUG
+        assert slugify_label("Mixed Case & Punctuation!") == "mixed-case-punctuation"
+        assert slugify_label("a  b---c") == "a-b-c"
+        assert slugify_label("") == ""
+        assert slugify_label(None) == ""
+
+    def test_run_context_table_renders_label_row(self):
+        from tool_eval_bench.storage.reports import _render_run_context
+
+        md = "\n".join(_render_run_context(self._ctx(self.LABEL)))
+        assert f"| **Label** | `{self.LABEL}` |" in md
+
+        md_without = "\n".join(_render_run_context(self._ctx(None)))
+        assert "| Label |" not in md_without
+
+    def test_scenario_report_labels_row_and_slugifies_filename(self, tmp_path):
+        reporter = MarkdownReporter(root=str(tmp_path))
+        summary = _make_summary()
+        path = reporter.write_scenario_report(
+            "run_1", "model", summary, run_context=self._ctx(self.LABEL)
+        )
+        assert path.name == f"run_1--{self.SLUG}.md"
+        content = path.read_text()
+        assert f"| **Label** | `{self.LABEL}` |" in content
+
+    def test_scenario_report_without_label_keeps_plain_filename(self, tmp_path):
+        reporter = MarkdownReporter(root=str(tmp_path))
+        summary = _make_summary()
+        path = reporter.write_scenario_report("run_2", "model", summary, run_context=None)
+        assert path.name == "run_2.md"
+        assert "| Label |" not in path.read_text()
+
+    def test_summary_report_labels_row_and_slugifies_filename(self, tmp_path):
+        reporter = MarkdownReporter(root=str(tmp_path))
+        summaries = [_make_summary(), _make_summary()]
+        agg = {
+            "trials": 2,
+            "final_score_mean": 87.0,
+            "final_score_stddev": 1.0,
+            "total_points_mean": 146.0,
+            "total_points_stddev": 1.0,
+        }
+        path = reporter.write_summary_report(
+            "run_3", "model", summaries, agg, run_context=self._ctx(self.LABEL)
+        )
+        assert path.name == f"run_3--{self.SLUG}_summary.md"
+        assert f"| **Label** | `{self.LABEL}` |" in path.read_text()
+
+    def test_throughput_report_labels_and_slugifies_filename(self, tmp_path):
+        from dataclasses import dataclass
+
+        reporter = MarkdownReporter(root=str(tmp_path))
+
+        @dataclass
+        class FakeSample:
+            pp_tps: float = 1000.0
+            tg_tps: float = 50.5
+            ttft_ms: float = 120.0
+            total_ms: float = 3500.0
+            pp_tokens: int = 2048
+            tg_tokens: int = 128
+            label_pp: int = 2048
+            label_depth: int = 0
+            concurrency: int = 1
+            error: str | None = None
+
+        path = reporter.write_throughput_report(
+            "tp_1", "model", [FakeSample()], run_context=self._ctx(self.LABEL)
+        )
+        assert path.name == f"tp_1--{self.SLUG}.md"
+        assert f"- **Label**: `{self.LABEL}`" in path.read_text()
+
+    def test_spec_decode_report_labels_and_slugifies_filename(self, tmp_path):
+        from dataclasses import dataclass
+
+        reporter = MarkdownReporter(root=str(tmp_path))
+
+        @dataclass
+        class FakeSpec:
+            prompt_type: str = "filler"
+            depth: int = 0
+            effective_tg_tps: float = 100.0
+            tg_tps: float = 120.0
+            ttft_ms: float = 90.0
+            total_ms: float = 2000.0
+            tg_tokens: int = 128
+
+        path = reporter.write_spec_decode_report("spec_1", "model", [FakeSpec()], label=self.LABEL)
+        assert path.name == f"spec_1--{self.SLUG}.md"
+        assert f"- **Label**: `{self.LABEL}`" in path.read_text()
+
+    def test_pressure_sweep_report_labels_and_slugifies_filename(self, tmp_path):
+        reporter = MarkdownReporter(root=str(tmp_path))
+        path = reporter.write_pressure_sweep_report(
+            run_id="ps_1",
+            model="model",
+            backend="vllm",
+            display_url="http://***:8000",
+            context_size=8192,
+            level_results=[],
+            breaking_point=None,
+            first_degradation=None,
+            label=self.LABEL,
+        )
+        assert path.name == f"ps_1--{self.SLUG}.md"
+        assert f"- **Label**: `{self.LABEL}`" in path.read_text()

--- a/tests/test_run_context.py
+++ b/tests/test_run_context.py
@@ -413,6 +413,19 @@ class TestHistoryContextExtraction:
         lines = _extract_context_panel(run)
         assert lines == []
 
+    def test_label_is_safe_for_rich_markup_and_control_characters(self):
+        from tool_eval_bench.cli.history import (
+            _extract_context_panel,
+            _extract_context_summary,
+        )
+
+        run = {"metadata": {"label": "[bold red]forged[/bold red]\nnext"}, "config": {}}
+
+        assert _extract_context_summary(run) == r"\[bold red]forged\[/bold red]\nnext"
+        assert _extract_context_panel(run) == [
+            r"  [bold]Label:[/] \[bold red]forged\[/bold red]\nnext"
+        ]
+
 
 # ---------------------------------------------------------------------------
 # JSON repair for malformed tool-call arguments

--- a/tests/test_run_context.py
+++ b/tests/test_run_context.py
@@ -505,3 +505,58 @@ class TestRepairJsonStr:
         # Must be valid JSON
         parsed = json.loads(args_str)
         assert isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# --label run annotation (Tier 2 CLI parameter)
+# ---------------------------------------------------------------------------
+
+
+class TestRunLabel:
+    """The run label is an arbitrary user string attached to an execution."""
+
+    def test_label_defaults_to_none(self):
+        from tool_eval_bench.domain.models import RunContext
+
+        ctx = RunContext(
+            tool_version="1.4.0",
+            git_sha=None,
+            hostname="h",
+            platform_info="p",
+            python_version="3.12",
+            model="m",
+            backend="vllm",
+            base_url="http://localhost",
+        )
+        assert ctx.label is None
+        assert "label" not in ctx.to_dict()
+
+    def test_to_dict_includes_label(self):
+        from tool_eval_bench.domain.models import RunContext
+
+        ctx = RunContext(
+            tool_version="1.4.0",
+            git_sha=None,
+            hostname="h",
+            platform_info="p",
+            python_version="3.12",
+            model="m",
+            backend="vllm",
+            base_url="http://localhost",
+            label="aiden-sparkrun aiden-3.75-sparkrun toolargs no proxy 229a985",
+        )
+        assert (
+            ctx.to_dict()["label"] == "aiden-sparkrun aiden-3.75-sparkrun toolargs no proxy 229a985"
+        )
+
+    async def test_collect_run_context_carries_label(self):
+        from tool_eval_bench.utils.metadata import collect_run_context
+
+        ctx = await collect_run_context(
+            model="m",
+            backend="vllm",
+            base_url="http://localhost",
+            label="tonyd2wild tool hardening 646c55f",
+            probe_engine=False,
+        )
+        assert ctx.label == "tonyd2wild tool hardening 646c55f"


### PR DESCRIPTION
A free-form string (--label "tonyd2wild tool hardening 646c55f") is now carried on RunContext and rendered into every report an execution produces: a Label row in the tool-eval Run Context table, a - **Label** header line in the GSM8K/MMLU/IFEval/throughput/spec-decode/pressure-sweep reports, and the persisted SQLite metadata (surfaced in history; included in export).

Report filenames also gain a filesystem-safe slug of the label:
  <run_id>--<slug>.md          (trial / plugin / perf / spec / pressure)
  <run_id>--<slug>_summary.md  (multi-trial summary)

The label is an annotation only: it never changes the config fingerprint or run ID, so identical runs with different labels remain comparable. The slug keeps .-_, collapses punctuation to dashes, lowercases, and caps at 80 chars; the full human-readable label is rendered verbatim inside reports.

## Summary

I was running several benchmarks against the same model with slightly different startup settings. I was looking for a way to differentiate the runs from the generated reports that could be collated later.

## Changes

The only change is to add an arbitrary string to the report. nothing affecting the scoring

## Validation

 ### Verification

 - [✓] Focused tests pass.
 - [✓] .venv/bin/ruff check . passes.
 - [✓] .venv/bin/ruff format --check . passes.
 - [✓] .venv/bin/mypy passes.
 - [✓] Required pytest suite passes.
 - [✓] Live-server testing is not required, or the test endpoint and scope are described.

 ### Contributor checklist

 - [✓] This PR contains one focused, logically related change.
 - [✓] Regression or behavior tests were added or updated where appropriate.
 - [✓] Positive and negative/false-positive cases are covered for evaluator changes.
 - [✓] README.md and/or CHANGELOG.md is updated when applicable.
 - [✓] No credentials, live endpoints, generated run artifacts, or unrelated formatting changes are included.

 Notes:
 - Focused tests: 15 new tests for --label; all pass.
 - Required suite: 2552 passed, 1 deselected (--ignore=tests/test_llama_benchy.py -m "not live" --randomly-seed=104729).
 - Live-server (checked as N/A): no evaluator or live-inference path touched — pure CLI/report plumbing, covered by unit tests + --help/--dry-run --label smoke.
 - Evaluator cases (checked as N/A): no evaluator/scoring logic modified.
 - Artifacts: runs//data/ are gitignored; only regenerated compat snapshots + README/CHANGELOG differ besides source.