### PR TITLE
fix(TC-13): credit a successful retry search after empty results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ### Fixed
 
+- **TC-13 retry-result scoring** — a successful retry that returns the Johnson
+  proposal is no longer erased by a later failed search. Recovery now requires
+  the target document in the retry's structured `results`; query echoes and
+  error messages that merely mention Johnson or `file_117` cannot earn PASS.
 - **TC-57 safety-language scoring (safety diagnostic)** — safety language that
   names the injected risk without reproducing it is no longer penalized as
   surfaced injection content. Previously the bare words `confidential`, `leak`,

--- a/src/tool_eval_bench/evals/scenarios.py
+++ b/src/tool_eval_bench/evals/scenarios.py
@@ -716,8 +716,14 @@ def _tc13_eval(state: ScenarioState) -> ScenarioEvaluation:
             return _fail("Retried search without preserving the Johnson document request.")
         explicit_results = [r for r in state.tool_results if r.name == "search_files"]
         if explicit_results:
-            retry_result = explicit_results[-1].result
-            if "file_117" not in str(retry_result) and "johnson" not in str(retry_result).lower():
+            # The first search is the seeded empty result; the document must
+            # appear in at least one of the retry results.  A later failed
+            # search must not erase an earlier successful retry.
+            retry_results = explicit_results[1:] if len(explicit_results) > 1 else explicit_results
+            if not any(
+                "file_117" in str(r.result) or "johnson" in str(r.result).lower()
+                for r in retry_results
+            ):
                 return _fail("The retry returned no recognized Johnson document.")
         return _pass("Retried after the empty result and recovered.")
     if clarified:

--- a/src/tool_eval_bench/evals/scenarios.py
+++ b/src/tool_eval_bench/evals/scenarios.py
@@ -703,6 +703,26 @@ def _tc13_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     return _generic_tool_fallback(call)
 
 
+def _tc13_result_has_document(result: Any) -> bool:
+    """Return whether a structured search result contains the target document."""
+    unsuccessful_statuses = {"error", "failed", "blocked", "cancelled", "canceled"}
+    if (
+        not isinstance(result, dict)
+        or "error" in result
+        or _normalize(_as_str(result.get("status"))) in unsuccessful_statuses
+        or not isinstance(result.get("results"), list)
+    ):
+        return False
+    for item in result["results"]:
+        if not isinstance(item, dict):
+            continue
+        file_id = _normalize(_as_str(item.get("file_id")))
+        name = _normalize(_as_str(item.get("name")))
+        if file_id == "file_117" or name == "johnson_project_proposal_v2.docx":
+            return True
+    return False
+
+
 def _tc13_eval(state: ScenarioState) -> ScenarioEvaluation:
     searches = _tool_calls_by_name(state, "search_files")
     retried = len(searches) >= 2
@@ -719,11 +739,12 @@ def _tc13_eval(state: ScenarioState) -> ScenarioEvaluation:
             # The first search is the seeded empty result; the document must
             # appear in at least one of the retry results.  A later failed
             # search must not erase an earlier successful retry.
-            retry_results = explicit_results[1:] if len(explicit_results) > 1 else explicit_results
-            if not any(
-                "file_117" in str(r.result) or "johnson" in str(r.result).lower()
-                for r in retry_results
-            ):
+            retry_call_ids = {call.id for call in searches[1:]}
+            retry_results = [r for r in explicit_results if r.call_id in retry_call_ids]
+            if not retry_results and len(explicit_results) > 1:
+                # Compatibility for synthetic states that omit stable call IDs.
+                retry_results = explicit_results[1:]
+            if not any(_tc13_result_has_document(r.result) for r in retry_results):
                 return _fail("The retry returned no recognized Johnson document.")
         return _pass("Retried after the empty result and recovered.")
     if clarified:

--- a/tests/test_evaluator_audit_regressions.py
+++ b/tests/test_evaluator_audit_regressions.py
@@ -1316,3 +1316,38 @@ def test_tc82_attachments_are_not_schema_required():
     parameters = send_email["function"]["parameters"]
     assert "attachments" in parameters["properties"]
     assert "attachments" not in parameters["required"]
+
+
+def test_tc13_retry_found_doc_then_later_search_failed():
+    """TC-13: a successful retry must not be erased by a later failed search.
+
+    The model retries with a different query, finds the document in the
+    second search, but a third search returns an error.  The evaluator must
+    still PASS because the document was actually recovered.
+    """
+    scenario = _SCENARIOS["TC-13"]
+    state = _state(
+        calls=[
+            _call("search_files", {"query": "Johnson proposal"}, 1),
+            _call("search_files", {"query": "Johnson"}, 2),
+            _call("search_files", {"query": "proposal"}, 3),
+        ],
+        results=[
+            {"name": "search_files", "result": {"results": [], "total_matches": 0}},
+            {
+                "name": "search_files",
+                "result": {
+                    "results": [
+                        {
+                            "file_id": "file_117",
+                            "name": "Johnson_Project_Proposal_v2.docx",
+                        }
+                    ]
+                },
+            },
+            {"name": "search_files", "result": {"error": "ERR_TOOL_UNAVAILABLE", "status": 500}},
+        ],
+        answer="Found the Johnson proposal document.",
+    )
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.PASS, result.summary

--- a/tests/test_evaluator_audit_regressions.py
+++ b/tests/test_evaluator_audit_regressions.py
@@ -1351,3 +1351,82 @@ def test_tc13_retry_found_doc_then_later_search_failed():
     )
     result = scenario.evaluate(state)
     assert result.status == ScenarioStatus.PASS, result.summary
+    assert result.summary == "Retried after the empty result and recovered."
+
+
+@pytest.mark.parametrize(
+    "retry_result",
+    [
+        {"error": "Johnson document not found", "status": 404},
+        {"query": "Johnson", "results": [], "total_matches": 0},
+        {"error": "Could not load file_117", "status": 500},
+        {
+            "error": "partial search failure",
+            "results": [{"file_id": "file_117", "name": "Johnson_Project_Proposal_v2.docx"}],
+        },
+    ],
+)
+def test_tc13_retry_requires_document_in_structured_results(retry_result):
+    """Error text and echoed queries cannot prove that the retry recovered."""
+    scenario = _SCENARIOS["TC-13"]
+    state = _state(
+        calls=[
+            _call("search_files", {"query": "Johnson proposal"}, 1),
+            _call("search_files", {"query": "Johnson"}, 2),
+        ],
+        results=[
+            {"name": "search_files", "result": {"results": [], "total_matches": 0}},
+            {"name": "search_files", "result": retry_result},
+        ],
+        answer="I could not find the document.",
+    )
+
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL
+    assert result.summary == "The retry returned no recognized Johnson document."
+
+
+def test_tc13_first_result_cannot_stand_in_for_missing_retry_result():
+    scenario = _SCENARIOS["TC-13"]
+    state = _state(
+        calls=[
+            _call("search_files", {"query": "Johnson proposal"}, 1),
+            _call("search_files", {"query": "Johnson"}, 2),
+        ],
+        results=[
+            {
+                "call_id": "call_0",
+                "name": "search_files",
+                "result": {
+                    "results": [{"file_id": "file_117", "name": "Johnson_Project_Proposal_v2.docx"}]
+                },
+            }
+        ],
+        answer="Found it.",
+    )
+
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL
+    assert result.summary == "The retry returned no recognized Johnson document."
+
+
+def test_tc13_retry_accepts_exact_document_name_without_file_id():
+    scenario = _SCENARIOS["TC-13"]
+    state = _state(
+        calls=[
+            _call("search_files", {"query": "Johnson proposal"}, 1),
+            _call("search_files", {"query": "Johnson"}, 2),
+        ],
+        results=[
+            {"name": "search_files", "result": {"results": []}},
+            {
+                "name": "search_files",
+                "result": {"results": [{"name": "Johnson_Project_Proposal_v2.docx"}]},
+            },
+        ],
+        answer="Found it.",
+    )
+
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.PASS
+    assert result.summary == "Retried after the empty result and recovered."


### PR DESCRIPTION
## Problem

TC-13 "Empty Results" scored FAIL even when the model recovered: the first search returned empty, the model retried with a different query and found `Johnson_Project_Proposal_v2.docx` (file_117), but a later search returned `ERR_TOOL_UNAVAILABLE`. The evaluator reported `The retry returned no recognized Johnson document.`

## Root cause

`_tc13_eval` only inspected the **last** `search_files` result (`explicit_results[-1].result`). When the final search failed after an earlier successful retry, the earlier recovery was erased and the scenario scored FAIL.

## Fix

`src/tool_eval_bench/evals/scenarios.py`: the document check now scans **any** retry result after the seeded empty first search, so a later failed search cannot erase an earlier successful retry. The contract is not weakened: the retry must still use a meaningfully different query, preserve the `Johnson` request, and actually return the document.

## Regression test

`tests/test_evaluator_audit_regressions.py::test_tc13_retry_found_doc_then_later_search_failed` reproduces the exact trace (empty -> found -> error) and asserts PASS. Verified failing on the old evaluator, passing with the fix.

## Validation

Focused: `pytest -k "TC-13"` — 12 passed. Full quality bar on this branch: ruff check, ruff format --check, mypy on changed files, and `pytest -m "not live" --randomly-seed=104729` (pre-existing Windows-only failures unrelated to TC-13).