### PR TITLE
fix: isolate Git hooks across worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.venv/
+.venv
 activate/
 # Dev-environment resolution only: CI installs via `pip install -e '.[dev]'`
 # and the package ships as a wheel resolved against pyproject constraints,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 # Pre-commit hooks — run `pre-commit install` to activate.
 # See https://pre-commit.com for more information.
 
+default_install_hook_types: [pre-commit, pre-push, post-checkout]
+
 repos:
   # ── Ruff: lint + format ─────────────────────────────────────
   - repo: https://github.com/astral-sh/ruff-pre-commit
@@ -27,3 +29,11 @@ repos:
         pass_filenames: false
         always_run: true
         stages: [pre-push]
+
+      - id: link-worktree-venv
+        name: link primary venv into Git worktrees
+        entry: python scripts/link_worktree_venv.py
+        language: python
+        pass_filenames: false
+        always_run: true
+        stages: [post-checkout]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,12 @@ across Python 3.11–3.13, and enforces the configured branch-coverage floor.
 
 ```bash
 pip install -e '.[dev]'       # includes pre-commit
-pre-commit install            # ruff lint on every commit
-pre-commit install --hook-type pre-push  # mypy + pytest on every push
+pre-commit install            # pre-commit, pre-push, and post-checkout hooks
 ```
+
+The post-checkout hook links the primary checkout's `.venv` into newly created
+Git worktrees. Re-run `pre-commit install` once after upgrading from an older
+checkout so the new hook type is installed.
 
 **Always use the project venv** (`.venv/bin/python`), not system Python.
 Dev dependencies like `pytest-asyncio` are installed in the venv via `pip install -e '.[dev]'`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ### Fixed
 
+- **Git worktree development safety** — newly created worktrees now link the
+  primary checkout's `.venv` through a `post-checkout` hook, and Git provenance
+  subprocesses discard repository-local hook variables before resolving the
+  package commit. This prevents pre-push tests from treating the active
+  worktree as a nested test repository, creating stray commits, or changing
+  shared Git configuration.
 - **TC-03 implicit-tool-need time phrasing (scoring)** — the email body must
   still state that the meeting "moved" and name a time, but accepted spellings
   now cover common 12-hour and 24-hour forms: `3pm`, `3 PM`, `3:00 PM`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,12 @@ Install the hooks once if you plan to commit or push from this checkout:
 
 ```bash
 .venv/bin/pre-commit install
-.venv/bin/pre-commit install --hook-type pre-push
 ```
+
+The configured default installs pre-commit, pre-push, and post-checkout hooks.
+The post-checkout hook links the primary checkout's `.venv` into new Git
+worktrees, so the documented quality commands work there without reinstalling
+dependencies. Re-run the install command once after upgrading an older clone.
 
 ## Checks and feedback loops
 

--- a/scripts/link_worktree_venv.py
+++ b/scripts/link_worktree_venv.py
@@ -1,0 +1,96 @@
+"""Link the primary checkout's virtual environment into a Git worktree."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_GIT_REPOSITORY_ENV_VARS = (
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_GRAFT_FILE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_PREFIX",
+    "GIT_SHALLOW_FILE",
+    "GIT_COMMON_DIR",
+)
+
+
+def _clean_git_env() -> dict[str, str]:
+    env = os.environ.copy()
+    for name in _GIT_REPOSITORY_ENV_VARS:
+        env.pop(name, None)
+    return env
+
+
+def _git(*args: str, cwd: Path) -> str:
+    return subprocess.check_output(  # noqa: S603 — fixed Git executable
+        ["git", "-C", str(cwd), *args],
+        stderr=subprocess.DEVNULL,
+        env=_clean_git_env(),
+        text=True,
+    ).strip()
+
+
+def _worktree_roots(current_root: Path) -> list[Path]:
+    output = _git("worktree", "list", "--porcelain", cwd=current_root)
+    return [
+        Path(line.removeprefix("worktree "))
+        for line in output.splitlines()
+        if line.startswith("worktree ")
+    ]
+
+
+def _has_project_venv(path: Path) -> bool:
+    return any(
+        candidate.is_file()
+        for candidate in (path / "bin" / "python", path / "Scripts" / "python.exe")
+    )
+
+
+def link_worktree_venv(current_root: Path) -> bool:
+    """Create the worktree link, returning whether a link was created."""
+    target = current_root / ".venv"
+    if target.exists() or target.is_symlink():
+        return False
+
+    sources = [
+        root / ".venv"
+        for root in _worktree_roots(current_root)
+        if root != current_root and not (root / ".venv").is_symlink()
+    ]
+    source = next((candidate for candidate in sources if _has_project_venv(candidate)), None)
+    if source is None:
+        print("No primary worktree .venv found; create one before running project checks.")
+        return False
+
+    try:
+        target.symlink_to(source.resolve(), target_is_directory=True)
+    except OSError as exc:
+        print(f"Could not link {target} to {source}: {exc}", file=sys.stderr)
+        return False
+    print(f"Linked {target} -> {source.resolve()}")
+    return True
+
+
+def main() -> int:
+    try:
+        current_root = Path(_git("rev-parse", "--show-toplevel", cwd=Path.cwd()))
+    except (OSError, subprocess.CalledProcessError):
+        return 0
+    link_worktree_venv(current_root)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/tool_eval_bench/utils/metadata.py
+++ b/src/tool_eval_bench/utils/metadata.py
@@ -32,6 +32,36 @@ logger = logging.getLogger(__name__)
 
 _PROBE_TIMEOUT = 5  # seconds — tight timeout for engine probes
 
+# Git exports repository-local variables while hooks run.  Those variables
+# override both the subprocess working directory and ``git -C``, so inheriting
+# them can make a nested ``git init`` mutate this checkout or make provenance
+# resolve against the hook's repository instead of the installed package.
+_GIT_REPOSITORY_ENV_VARS = (
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CONFIG",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_CONFIG_COUNT",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_GRAFT_FILE",
+    "GIT_INDEX_FILE",
+    "GIT_NO_REPLACE_OBJECTS",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_PREFIX",
+    "GIT_SHALLOW_FILE",
+    "GIT_COMMON_DIR",
+)
+
+
+def _git_env_without_repository() -> dict[str, str]:
+    """Return the process environment without an inherited Git repository."""
+    env = os.environ.copy()
+    for name in _GIT_REPOSITORY_ENV_VARS:
+        env.pop(name, None)
+    return env
+
 
 # ---------------------------------------------------------------------------
 # Tier 1: local environment
@@ -58,6 +88,7 @@ def _git_sha() -> str | None:
             out = subprocess.check_output(  # noqa: S603 — args are module constants
                 ["git", "-C", str(package_root), *args],
                 stderr=subprocess.DEVNULL,
+                env=_git_env_without_repository(),
             )
         except (OSError, subprocess.CalledProcessError):
             return None

--- a/tests/test_run_provenance.py
+++ b/tests/test_run_provenance.py
@@ -16,7 +16,7 @@ import pytest
 
 from tool_eval_bench.application.service import _build_run_config
 from tool_eval_bench.domain.scenarios import Category, ScenarioDefinition
-from tool_eval_bench.utils.metadata import _git_sha
+from tool_eval_bench.utils.metadata import _git_env_without_repository, _git_sha
 
 
 def _scenario(sid: str) -> ScenarioDefinition:
@@ -59,7 +59,8 @@ class TestGitShaProvenance:
         """Running from an unrelated repo must not attribute its SHA to the run."""
         unrelated = tmp_path / "unrelated"
         unrelated.mkdir()
-        subprocess.run(["git", "init", "-q"], cwd=unrelated, check=True)
+        clean_env = _git_env_without_repository()
+        subprocess.run(["git", "init", "-q"], cwd=unrelated, check=True, env=clean_env)
         subprocess.run(
             [
                 "git",
@@ -75,14 +76,19 @@ class TestGitShaProvenance:
             ],
             cwd=unrelated,
             check=True,
+            env=clean_env,
         )
         foreign = (
-            subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=unrelated)
+            subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"], cwd=unrelated, env=clean_env
+            )
             .decode()
             .strip()
         )
 
         monkeypatch.chdir(unrelated)
+        monkeypatch.setenv("GIT_DIR", str(unrelated / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(unrelated))
         sha = _git_sha()
 
         assert sha != foreign
@@ -184,6 +190,7 @@ def _package_head() -> str | None:
         out = subprocess.check_output(  # noqa: S603 — fixed argv, test-only
             ["git", "-C", str(package_root), "rev-parse", "--short", "HEAD"],
             stderr=subprocess.DEVNULL,
+            env=_git_env_without_repository(),
         )
     except (OSError, subprocess.CalledProcessError):
         return None

--- a/tests/test_worktree_venv.py
+++ b/tests/test_worktree_venv.py
@@ -1,0 +1,47 @@
+"""Regression coverage for shared virtual environments in Git worktrees."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from tool_eval_bench.utils.metadata import _git_env_without_repository
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "link_worktree_venv.py"
+
+
+def _git(*args: str, cwd: Path) -> str:
+    return subprocess.check_output(  # noqa: S603 — fixed Git executable
+        ["git", *args], cwd=cwd, env=_git_env_without_repository(), text=True
+    ).strip()
+
+
+def test_link_worktree_venv_ignores_inherited_git_dir(tmp_path: Path) -> None:
+    primary = tmp_path / "primary"
+    linked = tmp_path / "linked"
+    primary.mkdir()
+    _git("init", "-q", cwd=primary)
+    _git("config", "user.email", "test@example.com", cwd=primary)
+    _git("config", "user.name", "Test", cwd=primary)
+    (primary / "tracked.txt").write_text("tracked\n")
+    _git("add", "tracked.txt", cwd=primary)
+    _git("commit", "-qm", "initial", cwd=primary)
+
+    python = primary / ".venv" / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    python.parent.mkdir(parents=True)
+    python.write_text("")
+    _git("worktree", "add", "-qb", "topic", str(linked), cwd=primary)
+
+    polluted_env = os.environ.copy()
+    polluted_env["GIT_DIR"] = str(primary / ".git")
+    polluted_env["GIT_WORK_TREE"] = str(primary)
+    subprocess.run(  # noqa: S603 — repository-owned script under the project interpreter
+        [sys.executable, str(_SCRIPT)], cwd=linked, env=polluted_env, check=True
+    )
+
+    target = linked / ".venv"
+    assert target.is_symlink()
+    assert target.resolve() == (primary / ".venv").resolve()
+    assert _git("config", "--bool", "core.bare", cwd=primary) == "false"


### PR DESCRIPTION
## Summary

- install pre-commit, pre-push, and post-checkout hooks by default
- link the primary checkout's `.venv` into newly created Git worktrees
- strip repository-local Git environment variables from provenance subprocesses
- add regression coverage for polluted `GIT_DIR` / `GIT_WORK_TREE` execution

## Root cause

Git exports repository-local variables while hooks run. The pre-push pytest
process inherited those variables, so the provenance test's nested `git init`
targeted the active shared repository instead of its temporary directory. That
created an empty commit and changed shared repository configuration. Separately,
temporary worktrees did not contain the project `.venv`, causing the documented
pre-push commands to fail before tests could run.

## Validation

- focused provenance/worktree tests: 10 passed
- post-checkout hook created the expected `.venv` symlink
- full quality bar: Ruff, format, mypy, and 2,569 passed / 1 deselected
- pre-push hook rerun with deliberately polluted Git environment: passed, HEAD
  unchanged, `core.bare=false`
