### PR TITLE
fix: preserve reasoning_content in tool-call history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ### Fixed
 
+- **DeepSeek thinking tool-loop history** — OpenAI-compatible responses already
+  parsed `reasoning_content`, but the orchestrator dropped it while rebuilding
+  assistant tool-call messages for the next request. Those turns now preserve
+  the exact field, preventing DeepSeek's required reasoning round-trip from
+  failing a multi-turn scenario with HTTP 400. Non-tool answer turns remain
+  unchanged.
+
 - **Daily quota exhaustion no longer wastes the retry budget** — Google's
   Gemini API reports a per-day quota limit as a plain HTTP 429, the same as a
   per-minute one, and even attaches a `RetryInfo` delay that looks like normal

--- a/src/tool_eval_bench/domain/models.py
+++ b/src/tool_eval_bench/domain/models.py
@@ -88,6 +88,9 @@ class ChatMessage(TypedDict, total=False):
     tool_calls: list[dict[str, Any]] | None
     tool_call_id: str | None
     name: str | None
+    # OpenAI-compatible reasoning extension required by DeepSeek when an
+    # assistant tool-call turn is replayed in later requests.
+    reasoning_content: str | None
     # Provider-specific message metadata (for example Gemini thought
     # signatures carried in ``extra_content``).
     extra_content: dict[str, Any] | None

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -237,6 +237,8 @@ def _repair_json_str(s: str) -> str:
 
 def _assistant_message(result: ChatCompletionResult) -> ChatMessage:
     msg: ChatMessage = {"role": "assistant", "content": result.content}
+    if result.tool_calls and result.reasoning is not None:
+        msg["reasoning_content"] = result.reasoning
     if result.message_extra_content is not None:
         msg["extra_content"] = result.message_extra_content
     if result.tool_calls:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -204,6 +204,49 @@ class TestParseResponse:
         result = OpenAICompatibleAdapter._parse_response(data, 1.0)
         assert result.reasoning == "I thought about it"
 
+    def test_preserves_reasoning_content_in_tool_history(self) -> None:
+        data = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "",
+                        "reasoning_content": "I need to look up the weather.",
+                        "tool_calls": [
+                            {
+                                "id": "tc_1",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"location":"Hangzhou"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        result = OpenAICompatibleAdapter._parse_response(data, 1.0)
+
+        rebuilt = _assistant_message(result)
+
+        assert rebuilt["reasoning_content"] == "I need to look up the weather."
+
+    def test_does_not_replay_reasoning_without_tool_calls(self) -> None:
+        data = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "Answer",
+                        "reasoning_content": "Private intermediate reasoning.",
+                    }
+                }
+            ]
+        }
+        result = OpenAICompatibleAdapter._parse_response(data, 1.0)
+
+        rebuilt = _assistant_message(result)
+
+        assert "reasoning_content" not in rebuilt
+
     def test_empty_choices(self) -> None:
         """Missing choices gracefully returns empty content."""
         result = OpenAICompatibleAdapter._parse_response({}, 1.0)


### PR DESCRIPTION
DeepSeek thinking-mode tool calls require the intermediate assistant message's `reasoning_content` to be sent back in later requests. The OpenAI-compatible adapter already parses that field into `ChatCompletionResult.reasoning`, but `_assistant_message()` dropped it while rebuilding the conversation history. A multi-turn scenario can therefore stop with DeepSeek's HTTP 400 before it evaluates model behavior.

This change:

- preserves the exact reasoning text on assistant turns that contain tool calls;
- leaves non-tool answer turns unchanged;
- adds regression coverage for both paths.

The behavior follows DeepSeek's thinking-mode tool-call documentation: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls

Checks run:

- `ruff check` on the changed Python files
- `ruff format --check` on the changed Python files
- `pytest tests/test_adapter.py -q` (47 passed)
- `mypy` on the changed source files

No live endpoint was used.
