### PR TITLE
fix: round-trip DeepSeek reasoning_content in tool-loop history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,10 +54,11 @@ All notable changes to `tool-eval-bench` are documented here.
 
 - **DeepSeek thinking tool-loop history** — OpenAI-compatible responses already
   parsed `reasoning_content`, but the orchestrator dropped it while rebuilding
-  assistant tool-call messages for the next request. Those turns now preserve
-  the exact field, preventing DeepSeek's required reasoning round-trip from
-  failing a multi-turn scenario with HTTP 400. Non-tool answer turns remain
-  unchanged.
+  assistant messages for the next request. Every assistant turn that produced
+  reasoning now preserves the exact field, including final answers, so a later
+  request that still sends `tools` (the next tool-call hop, or a follow-up
+  user turn) does not fail DeepSeek's required reasoning round-trip with
+  HTTP 400. Turns without reasoning are unchanged.
 
 - **Daily quota exhaustion no longer wastes the retry budget** — Google's
   Gemini API reports a per-day quota limit as a plain HTTP 429, the same as a

--- a/src/tool_eval_bench/domain/models.py
+++ b/src/tool_eval_bench/domain/models.py
@@ -89,7 +89,7 @@ class ChatMessage(TypedDict, total=False):
     tool_call_id: str | None
     name: str | None
     # OpenAI-compatible reasoning extension required by DeepSeek when an
-    # assistant tool-call turn is replayed in later requests.
+    # assistant turn is replayed on a later request that still sends tools.
     reasoning_content: str | None
     # Provider-specific message metadata (for example Gemini thought
     # signatures carried in ``extra_content``).

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -237,7 +237,13 @@ def _repair_json_str(s: str) -> str:
 
 def _assistant_message(result: ChatCompletionResult) -> ChatMessage:
     msg: ChatMessage = {"role": "assistant", "content": result.content}
-    if result.tool_calls and result.reasoning is not None:
+    # DeepSeek thinking-mode tool loops require the exact reasoning_content
+    # from every prior assistant turn on later requests that still send
+    # ``tools``. Dropping it on a tool-call turn is an HTTP 400; dropping it
+    # on the final answer still 400s once a follow-up user message continues
+    # the conversation with tools attached. Non-thinking models leave
+    # ``result.reasoning`` as None, so the field is omitted.
+    if result.reasoning is not None:
         msg["reasoning_content"] = result.reasoning
     if result.message_extra_content is not None:
         msg["extra_content"] = result.message_extra_content

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -230,13 +230,36 @@ class TestParseResponse:
 
         assert rebuilt["reasoning_content"] == "I need to look up the weather."
 
-    def test_does_not_replay_reasoning_without_tool_calls(self) -> None:
+    def test_preserves_reasoning_content_on_final_answer(self) -> None:
         data = {
             "choices": [
                 {
                     "message": {
                         "content": "Answer",
-                        "reasoning_content": "Private intermediate reasoning.",
+                        "reasoning_content": "Share the weather result.",
+                    }
+                }
+            ]
+        }
+        result = OpenAICompatibleAdapter._parse_response(data, 1.0)
+
+        rebuilt = _assistant_message(result)
+
+        assert rebuilt["reasoning_content"] == "Share the weather result."
+        assert "tool_calls" not in rebuilt
+
+    def test_does_not_add_reasoning_when_absent(self) -> None:
+        data = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "Answer",
+                        "tool_calls": [
+                            {
+                                "id": "tc_1",
+                                "function": {"name": "get_weather", "arguments": "{}"},
+                            }
+                        ],
                     }
                 }
             ]
@@ -630,6 +653,52 @@ async def test_stream_reasoning_content() -> None:
 
     assert result.content == "The answer is 42"
     assert result.reasoning == "Let me think..."
+    await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_preserves_reasoning_content_in_tool_history() -> None:
+    """Streamed first-turn tool calls must still round-trip reasoning_content."""
+    chunks = [
+        json.dumps({"choices": [{"delta": {"reasoning_content": "Look up Hangzhou."}}]}),
+        json.dumps(
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "tc_1",
+                                    "function": {
+                                        "name": "get_weather",
+                                        "arguments": '{"location":"Hangzhou"}',
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ),
+    ]
+    body = _sse_lines(*chunks)
+
+    adapter = OpenAICompatibleAdapter()
+    adapter._client = httpx.AsyncClient(transport=_mock_stream_transport(body))
+
+    result = await adapter.chat_completion(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        base_url="http://localhost:8000",
+        stream=True,
+    )
+
+    rebuilt = _assistant_message(result)
+
+    assert result.reasoning == "Look up Hangzhou."
+    assert rebuilt["reasoning_content"] == "Look up Hangzhou."
+    assert rebuilt["tool_calls"][0]["function"]["name"] == "get_weather"
     await adapter.aclose()
 
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -221,6 +221,70 @@ async def test_tool_call_pass() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reasoning_content_round_trips_on_later_tool_requests() -> None:
+    """DeepSeek requires prior reasoning_content on every later request with tools.
+
+    That includes the tool-call hop and a follow-up user turn after the model
+    already produced a final answer.
+    """
+    follow_up_scenario = ScenarioDefinition(
+        id="TEST-REASONING",
+        title="Reasoning round-trip",
+        category=Category.A,
+        user_message="What's the weather in Hangzhou?",
+        description="Should call get_weather then answer a follow-up",
+        handle_tool_call=_simple_handler,
+        evaluate=_simple_evaluator,
+        follow_up_messages=["And tomorrow?"],
+    )
+    adapter = MockAdapter(
+        [
+            ChatCompletionResult(
+                content="",
+                tool_calls=[
+                    ProviderToolCall(
+                        id="tc_1",
+                        name="get_weather",
+                        arguments_str='{"location": "Hangzhou"}',
+                    )
+                ],
+                reasoning="I need today's weather in Hangzhou.",
+            ),
+            ChatCompletionResult(
+                content="Hangzhou is 22C and sunny.",
+                reasoning="Share the weather result.",
+            ),
+            ChatCompletionResult(
+                content="Tomorrow looks similar.",
+                reasoning="Reuse the earlier lookup.",
+            ),
+        ]
+    )
+
+    result = await run_scenario(
+        adapter,
+        model="test",
+        base_url="http://localhost:8000",
+        api_key=None,
+        scenario=follow_up_scenario,
+    )
+
+    assert result.status == ScenarioStatus.PASS
+    assert len(adapter.captured_payloads) == 3
+    assert adapter.captured_payloads[1]["tools"]
+    assert adapter.captured_payloads[2]["tools"]
+
+    tool_hop_msgs = adapter.captured_payloads[1]["messages"]
+    follow_up_msgs = adapter.captured_payloads[2]["messages"]
+    tool_hop_assistant = [m for m in tool_hop_msgs if m["role"] == "assistant"]
+    follow_up_assistant = [m for m in follow_up_msgs if m["role"] == "assistant"]
+
+    assert tool_hop_assistant[0]["reasoning_content"] == "I need today's weather in Hangzhou."
+    assert follow_up_assistant[0]["reasoning_content"] == "I need today's weather in Hangzhou."
+    assert follow_up_assistant[1]["reasoning_content"] == "Share the weather result."
+
+
+@pytest.mark.asyncio
 async def test_multi_turn_tool_chain() -> None:
     """Model makes two sequential tool calls across turns."""
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to [#68](https://github.com/SeraphimSerapis/tool-eval-bench/pull/68) (now on `main`). DeepSeek thinking-mode tool calls require the assistant message's `reasoning_content` to be sent back on later requests that still include `tools`, or the API returns HTTP 400.

#68 preserved the field only on tool-call turns. DeepSeek's docs also require it on later requests after a final answer when `tools` remain attached (follow-up user turns). This PR round-trips reasoning on **every** assistant turn that produced it.

Rebased onto `main` after #68 merged.

## Changes

- Preserve `reasoning_content` on rebuilt assistant messages whenever `result.reasoning` is set, including final answers.
- Leave turns without reasoning unchanged (non-thinking models do not gain a new field).
- Add regression coverage for: tool-call rebuild, final-answer rebuild, streamed first-turn tool calls, and the orchestrator's next-request payloads (tool hop + follow-up).
- Update the changelog to match the stricter DeepSeek rule.

Behavior follows DeepSeek's thinking-mode tool-call documentation: https://api-docs.deepseek.com/guides/thinking_mode#tool-calls

No scoring-rule change. Prompt-token counts for thinking-mode tool runs will include replayed CoT, as DeepSeek requires.

## Validation

- [x] Focused tests pass.
- [x] `.venv/bin/ruff check .` passes.
- [x] `.venv/bin/ruff format --check .` passes.
- [x] `.venv/bin/mypy` passes.
- [x] Required pytest suite passes.
- [x] Live-server testing is not required, or the test endpoint and scope are described.

Quality bar after rebase:

- `ruff check .` / `ruff format --check .` — pass
- `.venv/bin/mypy` — pass
- `env -u FORCE_COLOR .venv/bin/python -m pytest tests/ --ignore=tests/test_llama_benchy.py -m "not live" --randomly-seed=104729` — **2746 passed**, 1 deselected

No live DeepSeek endpoint in this environment. Coverage is via mocked adapter/orchestrator payloads.

## Contributor checklist

- [x] This PR contains one focused, logically related change.
- [x] Regression or behavior tests were added or updated where appropriate.
- [x] Positive and negative/false-positive cases are covered for evaluator changes.
- [x] `README.md` and/or `CHANGELOG.md` is updated when applicable.
- [x] No credentials, live endpoints, generated run artifacts, or unrelated formatting changes are included.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbbd65e4-f8ec-4759-9d0f-5e2a3511752d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbbd65e4-f8ec-4759-9d0f-5e2a3511752d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

