### PR TITLE
fix: scope DeepSeek reasoning replay to tool turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,11 +64,11 @@ All notable changes to `tool-eval-bench` are documented here.
 
 - **DeepSeek thinking tool-loop history** — OpenAI-compatible responses already
   parsed `reasoning_content`, but the orchestrator dropped it while rebuilding
-  assistant messages for the next request. Every assistant turn that produced
-  reasoning now preserves the exact field, including final answers, so a later
-  request that still sends `tools` (the next tool-call hop, or a follow-up
-  user turn) does not fail DeepSeek's required reasoning round-trip with
-  HTTP 400. Turns without reasoning are unchanged.
+  assistant messages for the next request. Every assistant message in a user
+  turn that called tools now preserves the exact field as DeepSeek requires.
+  Ordinary no-tool turns no longer replay it; doing so caused HTTP 500 errors
+  on follow-up-heavy TC-46, TC-47, and TC-50 with DeepSeek V4 Flash via both
+  vLLM and the hosted API.
 
 - **Daily quota exhaustion no longer wastes the retry budget** — Google's
   Gemini API reports a per-day quota limit as a plain HTTP 429, the same as a

--- a/src/tool_eval_bench/domain/models.py
+++ b/src/tool_eval_bench/domain/models.py
@@ -88,8 +88,7 @@ class ChatMessage(TypedDict, total=False):
     tool_calls: list[dict[str, Any]] | None
     tool_call_id: str | None
     name: str | None
-    # OpenAI-compatible reasoning extension required by DeepSeek when an
-    # assistant turn is replayed on a later request that still sends tools.
+    # OpenAI-compatible reasoning extension replayed for DeepSeek turns using tools.
     reasoning_content: str | None
     # Provider-specific message metadata (for example Gemini thought
     # signatures carried in ``extra_content``).

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -235,15 +235,13 @@ def _repair_json_str(s: str) -> str:
         return "{}"
 
 
-def _assistant_message(result: ChatCompletionResult) -> ChatMessage:
+def _assistant_message(
+    result: ChatCompletionResult, *, preserve_reasoning: bool = False
+) -> ChatMessage:
     msg: ChatMessage = {"role": "assistant", "content": result.content}
-    # DeepSeek thinking-mode tool loops require the exact reasoning_content
-    # from every prior assistant turn on later requests that still send
-    # ``tools``. Dropping it on a tool-call turn is an HTTP 400; dropping it
-    # on the final answer still 400s once a follow-up user message continues
-    # the conversation with tools attached. Non-thinking models leave
-    # ``result.reasoning`` as None, so the field is omitted.
-    if result.reasoning is not None:
+    # DeepSeek requires reasoning_content for every assistant message in a user
+    # turn that called tools. Ordinary no-tool turns must not add it back.
+    if result.reasoning is not None and (result.tool_calls or preserve_reasoning):
         msg["reasoning_content"] = result.reasoning
     if result.message_extra_content is not None:
         msg["extra_content"] = result.message_extra_content
@@ -437,7 +435,8 @@ async def run_scenario(
                 total_completion_tokens += result.completion_tokens
 
             state.assistant_messages.append(result.content)
-            messages.append(_assistant_message(result))
+            phase_has_tool_calls = any(call.user_phase == user_phase for call in state.tool_calls)
+            messages.append(_assistant_message(result, preserve_reasoning=phase_has_tool_calls))
             trace_lines.append(f"assistant_turn_{turn}={result.content or '[tool_calls_only]'}")
             if result.reasoning:
                 trace_lines.append(f"assistant_reasoning_{turn}={result.reasoning}")

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -230,7 +230,7 @@ class TestParseResponse:
 
         assert rebuilt["reasoning_content"] == "I need to look up the weather."
 
-    def test_preserves_reasoning_content_on_final_answer(self) -> None:
+    def test_does_not_replay_reasoning_content_on_final_answer(self) -> None:
         data = {
             "choices": [
                 {
@@ -245,7 +245,7 @@ class TestParseResponse:
 
         rebuilt = _assistant_message(result)
 
-        assert rebuilt["reasoning_content"] == "Share the weather result."
+        assert "reasoning_content" not in rebuilt
         assert "tool_calls" not in rebuilt
 
     def test_does_not_add_reasoning_when_absent(self) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -221,12 +221,8 @@ async def test_tool_call_pass() -> None:
 
 
 @pytest.mark.asyncio
-async def test_reasoning_content_round_trips_on_later_tool_requests() -> None:
-    """DeepSeek requires prior reasoning_content on every later request with tools.
-
-    That includes the tool-call hop and a follow-up user turn after the model
-    already produced a final answer.
-    """
+async def test_tool_turn_reasoning_round_trips_on_later_requests() -> None:
+    """DeepSeek replays all reasoning from a user turn that called tools."""
     follow_up_scenario = ScenarioDefinition(
         id="TEST-REASONING",
         title="Reasoning round-trip",
@@ -282,6 +278,41 @@ async def test_reasoning_content_round_trips_on_later_tool_requests() -> None:
     assert tool_hop_assistant[0]["reasoning_content"] == "I need today's weather in Hangzhou."
     assert follow_up_assistant[0]["reasoning_content"] == "I need today's weather in Hangzhou."
     assert follow_up_assistant[1]["reasoning_content"] == "Share the weather result."
+
+
+@pytest.mark.asyncio
+async def test_no_tool_turn_reasoning_is_not_replayed_on_follow_up() -> None:
+    scenario = ScenarioDefinition(
+        id="TEST-NO-TOOL-REASONING",
+        title="No-tool reasoning",
+        category=Category.A,
+        user_message="Draft a meeting.",
+        description="Answer a follow-up without tools",
+        handle_tool_call=_simple_handler,
+        evaluate=_simple_evaluator,
+        follow_up_messages=["Change it to 4pm."],
+    )
+    adapter = MockAdapter(
+        [
+            ChatCompletionResult(content="Drafted for 3pm.", reasoning="Prepare a draft."),
+            ChatCompletionResult(content="Changed to 4pm.", reasoning="Apply the correction."),
+        ]
+    )
+
+    await run_scenario(
+        adapter,
+        model="test",
+        base_url="http://localhost:8000",
+        api_key=None,
+        scenario=scenario,
+    )
+
+    assistant = [
+        message
+        for message in adapter.captured_payloads[1]["messages"]
+        if message["role"] == "assistant"
+    ]
+    assert "reasoning_content" not in assistant[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

DeepSeek V4 Flash returned HTTP 500 in follow-up-heavy TC-46, TC-47, and TC-50 on both vLLM and the hosted API. Older tool-eval-bench versions did not.

PR #69 started replaying `reasoning_content` for every assistant message. DeepSeek's documented contract is narrower: preserve reasoning across a user turn that performed tool calls, but do not concatenate reasoning from ordinary no-tool turns into the next user turn.

## Change

- Track whether the current user turn performed a tool call.
- Preserve `reasoning_content` for every assistant message in those tool-using turns.
- Omit it from ordinary no-tool turns before a follow-up.
- Add regression coverage for both paths.

This keeps DeepSeek tool loops intact while avoiding the malformed follow-up history behind the reported 500s.

## Evidence

- Full llama.cpp control run: 84 scenarios, `--hardmode --seed 42 --parallel 4`, no HTTP errors.
- Focused adapter/orchestrator tests: 73 passed.
- Required suite: 2,751 passed, 1 deselected.
- `ruff check .`: passed.
- `ruff format --check .`: passed.
- `.venv/bin/mypy`: passed.

A final live rerun against the reporter's DeepSeek endpoint remains useful confirmation.

DeepSeek reference: https://api-docs.deepseek.com/guides/thinking_mode
