### PR TITLE
fix: negotiate completion token parameter (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ### Fixed
 
+- **Output-token compatibility across OpenAI-style endpoints** — requests now
+  default to `max_tokens` for vLLM, LiteLLM, llama.cpp, and existing compatible
+  servers, then retry once with `max_completion_tokens` only when a 400/422
+  response explicitly requests that field. The learned choice is cached per
+  endpoint and model for benchmark, plugin, judge, and throughput requests;
+  preflight and warm-up use the same response-driven fallback. Explicit
+  `max_completion_tokens` backend parameters now suppress the legacy default
+  instead of sending both fields.
+
 - **TC-34 reasoning-neutral injection scoring** — the evaluator no longer
   penalizes a model for mentioning the injected payload (attacker address,
   API keys, passwords, or "confidential data") in its reasoning or answer.

--- a/README.md
+++ b/README.md
@@ -807,7 +807,7 @@ Any OpenAI-compatible `/v1/chat/completions` endpoint works:
 - **LiteLLM** — proxy for multiple backends
 - **llama.cpp** — lightweight local inference
 
-The adapter sends real `tools` + `tool_choice` in the request and parses `tool_calls` from the response — no prompt hacking or JSON regex matching.
+The adapter sends real `tools` + `tool_choice` in the request and parses `tool_calls` from the response — no prompt hacking or JSON regex matching. It defaults to the widely supported `max_tokens` field; if an endpoint explicitly rejects that field and requests `max_completion_tokens`, the adapter retries once and remembers the choice for that endpoint and model. This capability check is response-driven rather than tied to provider or model names.
 
 ### LiteLLM / Model Routers
 

--- a/src/tool_eval_bench/adapters/openai_compat.py
+++ b/src/tool_eval_bench/adapters/openai_compat.py
@@ -32,6 +32,7 @@ from tool_eval_bench.domain.adapters import (
     ProviderToolCall,
 )
 from tool_eval_bench.domain.models import DEFAULT_REQUEST_TIMEOUT_SECONDS, ChatMessage
+from tool_eval_bench.utils.openai_compat import max_tokens_retry_payload
 from tool_eval_bench.utils.urls import chat_completions_url as _chat_completions_url
 from tool_eval_bench.utils.urls import redact_url as _redact_url
 
@@ -126,6 +127,20 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
     Call ``aclose()`` when done (optional — Python GC handles cleanup).
     """
 
+    def __init__(
+        self,
+        *,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+        max_rate_limit_retries: int = DEFAULT_MAX_RATE_LIMIT_RETRIES,
+        rate_limit_observer: RateLimitObserver | None = None,
+    ) -> None:
+        super().__init__(
+            max_retries=max_retries,
+            max_rate_limit_retries=max_rate_limit_retries,
+            rate_limit_observer=rate_limit_observer,
+        )
+        self._max_completion_tokens_endpoints: set[tuple[str, str]] = set()
+
     async def chat_completion(
         self,
         *,
@@ -143,10 +158,17 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
         response_format: dict[str, Any] | None = None,
         parallel_tool_calls: bool | None = True,
     ) -> ChatCompletionResult:
+        url = _chat_completions_url(base_url)
+        endpoint = (url, model)
+        token_key = (
+            "max_completion_tokens"
+            if endpoint in self._max_completion_tokens_endpoints
+            else "max_tokens"
+        )
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
-            "max_tokens": max_tokens,
+            token_key: max_tokens,
             "temperature": temperature,
         }
 
@@ -161,6 +183,10 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
 
         if extra_params:
             payload.update(extra_params)
+            if "max_completion_tokens" in extra_params:
+                payload.pop("max_tokens", None)
+            elif "max_tokens" in extra_params:
+                payload.pop("max_completion_tokens", None)
 
         if stream:
             payload["stream"] = True
@@ -169,7 +195,6 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"
 
-        url = _chat_completions_url(base_url)
         client = self._get_client()
         req_timeout = httpx.Timeout(timeout_seconds)
 
@@ -206,6 +231,15 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
             ):
                 raise
             body_text = exc.response.text[:200].strip()
+            retry_payload = max_tokens_retry_payload(
+                payload, exc.response.status_code, exc.response.text
+            )
+            if retry_payload is not None:
+                payload.clear()
+                payload.update(retry_payload)
+                self._max_completion_tokens_endpoints.add((url, str(payload.get("model", ""))))
+                logger.info("Endpoint rejected max_tokens; retrying with max_completion_tokens")
+                return await self._non_stream_request(client, url, payload, headers, timeout)
             logger.warning(
                 "Server returned %d for %s: %s",
                 exc.response.status_code,
@@ -262,7 +296,17 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
                     await exc.response.aread()  # allow retry logic to inspect Retry-After
                     raise
                 body_bytes = await exc.response.aread()
-                body_text = body_bytes.decode("utf-8", errors="replace")[:200].strip()
+                full_body_text = body_bytes.decode("utf-8", errors="replace")
+                body_text = full_body_text[:200].strip()
+                retry_payload = max_tokens_retry_payload(
+                    payload, exc.response.status_code, full_body_text
+                )
+                if retry_payload is not None:
+                    payload.clear()
+                    payload.update(retry_payload)
+                    self._max_completion_tokens_endpoints.add((url, str(payload.get("model", ""))))
+                    logger.info("Endpoint rejected max_tokens; retrying with max_completion_tokens")
+                    return await self._stream_request(client, url, payload, headers, timeout)
                 logger.warning(
                     "Stream request returned %d for %s: %s",
                     exc.response.status_code,

--- a/src/tool_eval_bench/adapters/requests.py
+++ b/src/tool_eval_bench/adapters/requests.py
@@ -55,6 +55,8 @@ def minimal_request(
     }
     if extra_params:
         payload.update(extra_params)
+        if "max_completion_tokens" in extra_params:
+            payload.pop("max_tokens", None)
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     return chat_completions_url(base_url), payload, headers

--- a/src/tool_eval_bench/cli/probe.py
+++ b/src/tool_eval_bench/cli/probe.py
@@ -12,6 +12,7 @@ from tool_eval_bench.adapters.requests import minimal_request
 from tool_eval_bench.cli.helpers import emit_headless_error
 from tool_eval_bench.domain.errors import CONNECTION_FAILED, MODEL_NOT_AVAILABLE
 from tool_eval_bench.domain.models import DEFAULT_REQUEST_TIMEOUT_SECONDS
+from tool_eval_bench.utils.openai_compat import max_tokens_retry_payload
 
 
 def preflight_model_check(
@@ -46,7 +47,11 @@ def preflight_model_check(
 
     async def check() -> httpx.Response:
         async with httpx.AsyncClient(timeout=timeout_seconds) as client:
-            return await client.post(url, json=payload, headers=headers)
+            response = await client.post(url, json=payload, headers=headers)
+            retry_payload = max_tokens_retry_payload(payload, response.status_code, response.text)
+            if retry_payload is not None:
+                response = await client.post(url, json=retry_payload, headers=headers)
+            return response
 
     try:
         response = asyncio.run(check())

--- a/src/tool_eval_bench/runner/throughput.py
+++ b/src/tool_eval_bench/runner/throughput.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import httpx
 
+from tool_eval_bench.utils.openai_compat import max_tokens_retry_payload
 from tool_eval_bench.utils.urls import chat_completions_url as _chat_url
 from tool_eval_bench.utils.urls import models_url as models_url_fn
 
@@ -65,6 +66,8 @@ class TokenizerConfig:
     #   "probe"     — ratio estimated from a real request
     #   "heuristic" — 4 chars/token fallback (may be off by 20-40% for non-English text)
     calibration_confidence: str = "heuristic"
+    # OpenAI-compatible endpoints disagree on the output-token field name.
+    output_token_field: str = "max_tokens"
     # Per-run flag: ensures MTP detection is logged once per calibration
     # context instead of using module-level mutable state.
     mtp_warned: bool = False
@@ -190,6 +193,7 @@ async def calibrate(
     base_url: str,
     model: str,
     api_key: str | None = None,
+    tok_cfg: TokenizerConfig | None = None,
 ) -> TokenizerConfig:
     """Calibrate prompt building for accurate token counts.
 
@@ -198,7 +202,7 @@ async def calibrate(
 
     Returns a TokenizerConfig with the calibrated state.
     """
-    cfg = TokenizerConfig()
+    cfg = tok_cfg or TokenizerConfig()
 
     # Try /tokenize first
     probe_text = _FILLER_PARAGRAPH * 3
@@ -220,7 +224,7 @@ async def calibrate(
     payload = {
         "model": model,
         "messages": [{"role": "user", "content": probe_text}],
-        "max_tokens": 1,
+        cfg.output_token_field: 1,
         "temperature": 0.0,
     }
     try:
@@ -229,6 +233,14 @@ async def calibrate(
             json=payload,
             headers=_headers(api_key),
         )
+        retry_payload = max_tokens_retry_payload(payload, resp.status_code, resp.text)
+        if retry_payload is not None:
+            cfg.output_token_field = "max_completion_tokens"
+            resp = await client.post(
+                _chat_url(base_url),
+                json=retry_payload,
+                headers=_headers(api_key),
+            )
         resp.raise_for_status()
         data = resp.json()
         prompt_tokens = data.get("usage", {}).get("prompt_tokens", 0)
@@ -436,6 +448,7 @@ async def warmup(
     timeout: float = 120.0,
     *,
     request: tuple[str, dict[str, Any], dict[str, str]] | None = None,
+    tok_cfg: TokenizerConfig | None = None,
 ) -> float:
     """Send a trivial completion to prime the server.
 
@@ -464,15 +477,24 @@ async def warmup(
 
     t0 = time.perf_counter()
     async with httpx.AsyncClient(timeout=timeout) as client:
-        resp = await client.post(url, json=payload, headers=headers)
-        if resp.status_code in _REJECTION_STATUS_CODES:
-            retry_payload = _without_optional_hints(payload)
+        for _ in range(3):
+            resp = await client.post(url, json=payload, headers=headers)
+            if resp.status_code not in _REJECTION_STATUS_CODES:
+                break
+            retry_payload = max_tokens_retry_payload(payload, resp.status_code, resp.text)
             if retry_payload is not None:
+                if tok_cfg is not None:
+                    tok_cfg.output_token_field = "max_completion_tokens"
+                logger.debug("Warm-up rejected max_tokens; retrying with max_completion_tokens")
+            else:
+                retry_payload = _without_optional_hints(payload)
+                if retry_payload is None:
+                    break
                 logger.debug(
                     "Warm-up rejected with HTTP %s; retrying without optional hints",
                     resp.status_code,
                 )
-                resp = await client.post(url, json=retry_payload, headers=headers)
+            payload = retry_payload
         resp.raise_for_status()
     return (time.perf_counter() - t0) * 1000
     # Note: warmup intentionally uses its own client since it runs
@@ -546,7 +568,7 @@ async def _stream_one(
     payload = {
         "model": model,
         "messages": messages,
-        "max_tokens": tg,
+        (tok_cfg.output_token_field if tok_cfg else "max_tokens"): tg,
         "temperature": 0.0,
         "stream": True,
         "stream_options": {"include_usage": True},
@@ -646,6 +668,16 @@ async def _stream_one(
             if end_of_stream_time == t0:
                 end_of_stream_time = time.perf_counter()
 
+    except httpx.HTTPStatusError as exc:
+        await exc.response.aread()
+        retry_payload = max_tokens_retry_payload(
+            payload, exc.response.status_code, exc.response.text
+        )
+        if retry_payload is not None and tok_cfg is not None:
+            tok_cfg.output_token_field = "max_completion_tokens"
+            return await _stream_one(client, base_url, model, messages, tg, api_key, tok_cfg)
+        elapsed = (time.perf_counter() - t0) * 1000
+        return ThroughputSample(error=str(exc), total_ms=elapsed)
     except Exception as exc:
         elapsed = (time.perf_counter() - t0) * 1000
         return ThroughputSample(error=str(exc), total_ms=elapsed)
@@ -886,8 +918,9 @@ async def run_throughput_matrix(
     depths = depths or [0, 4096, 8192]
     concurrency_levels = concurrency_levels or [1, 2, 4]
 
-    # Warm up first
-    warmup_ms = await warmup(base_url, model, api_key)
+    # Warm up first and retain any endpoint capability learned from its response.
+    tok_cfg = TokenizerConfig()
+    warmup_ms = await warmup(base_url, model, api_key, tok_cfg=tok_cfg)
 
     # Shared client for all throughput measurements
     async with httpx.AsyncClient(
@@ -895,7 +928,7 @@ async def run_throughput_matrix(
         limits=httpx.Limits(max_connections=50, max_keepalive_connections=20),
     ) as client:
         # Calibrate tokenizer ratio + detect /tokenize
-        tok_cfg = await calibrate(client, base_url, model, api_key)
+        tok_cfg = await calibrate(client, base_url, model, api_key, tok_cfg)
         method = "/tokenize" if tok_cfg.has_tokenize_endpoint else "probe"
         logger.info(
             "Using %.2f chars/token (%s) for prompt building", tok_cfg.chars_per_token, method

--- a/src/tool_eval_bench/utils/openai_compat.py
+++ b/src/tool_eval_bench/utils/openai_compat.py
@@ -1,0 +1,25 @@
+"""Small compatibility helpers for OpenAI-style request payloads."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def max_tokens_retry_payload(
+    payload: dict[str, Any], status_code: int, response_text: str
+) -> dict[str, Any] | None:
+    """Swap output-token keys when an endpoint explicitly requests the newer one."""
+    text = response_text.lower()
+    if (
+        status_code not in (400, 422)
+        or "max_tokens" not in payload
+        or "max_tokens" not in text
+        or "max_completion_tokens" not in text
+        or not any(
+            word in text for word in ("unsupported", "not supported", "unknown", "unrecognized")
+        )
+    ):
+        return None
+    retry = dict(payload)
+    retry["max_completion_tokens"] = retry.pop("max_tokens")
+    return retry

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -500,6 +500,87 @@ async def test_response_format_included_in_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_retries_with_max_completion_tokens_and_caches_capability() -> None:
+    bodies: list[dict] = []
+
+    def reject_legacy_field(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        bodies.append(body)
+        if "max_tokens" in body:
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": "Unsupported parameter: 'max_tokens'. Use 'max_completion_tokens' instead."
+                    }
+                },
+            )
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    adapter = OpenAICompatibleAdapter()
+    adapter._client = httpx.AsyncClient(transport=httpx.MockTransport(reject_legacy_field))
+
+    for _ in range(2):
+        result = await adapter.chat_completion(
+            model="new-token-field-model",
+            messages=[{"role": "user", "content": "hi"}],
+            max_tokens=123,
+            base_url="http://localhost:8000",
+        )
+        assert result.content == "ok"
+
+    assert len(bodies) == 3
+    assert bodies[0]["max_tokens"] == 123
+    assert "max_completion_tokens" not in bodies[0]
+    assert [body["max_completion_tokens"] for body in bodies[1:]] == [123, 123]
+    assert all("max_tokens" not in body for body in bodies[1:])
+    await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_transient_retry_keeps_negotiated_token_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tool_eval_bench.adapters import http_retry
+
+    bodies: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        bodies.append(body)
+        if len(bodies) == 1:
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+                    }
+                },
+            )
+        if len(bodies) == 2:
+            return httpx.Response(503, json={"error": "busy"})
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    monkeypatch.setattr(http_retry, "_backoff_delay", lambda *args: 0.0)
+    adapter = OpenAICompatibleAdapter(max_retries=1)
+    adapter._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    result = await adapter.chat_completion(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=88,
+        base_url="http://localhost:8000",
+    )
+
+    assert result.content == "ok"
+    assert len(bodies) == 3
+    assert "max_tokens" in bodies[0]
+    assert all(body.get("max_completion_tokens") == 88 for body in bodies[1:])
+    assert all("max_tokens" not in body for body in bodies[1:])
+    await adapter.aclose()
+
+
+@pytest.mark.asyncio
 async def test_extra_params_merged_into_payload() -> None:
     """Extra params should be merged into the request payload."""
 
@@ -517,6 +598,25 @@ async def test_extra_params_merged_into_payload() -> None:
         messages=[{"role": "user", "content": "hi"}],
         base_url="http://localhost:8000",
         extra_params={"seed": 42, "top_p": 0.9},
+    )
+    await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_explicit_max_completion_tokens_suppresses_legacy_default() -> None:
+    def check_extra(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["max_completion_tokens"] == 77
+        assert "max_tokens" not in body
+        return httpx.Response(200, json={"choices": [{"message": {"content": "ok"}}]})
+
+    adapter = OpenAICompatibleAdapter()
+    adapter._client = httpx.AsyncClient(transport=httpx.MockTransport(check_extra))
+    await adapter.chat_completion(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        base_url="http://localhost:8000",
+        extra_params={"max_completion_tokens": 77},
     )
     await adapter.aclose()
 
@@ -783,6 +883,45 @@ async def test_stream_5xx_raises() -> None:
             base_url="http://localhost:8000",
             stream=True,
         )
+    await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_retries_with_max_completion_tokens() -> None:
+    bodies: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        bodies.append(body)
+        if "max_tokens" in body:
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": "Unsupported parameter: max_tokens; use max_completion_tokens instead"
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            content=_sse_lines(json.dumps({"choices": [{"delta": {"content": "ok"}}]})),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    adapter = OpenAICompatibleAdapter()
+    adapter._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    result = await adapter.chat_completion(
+        model="m",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=55,
+        base_url="http://localhost:8000",
+        stream=True,
+    )
+
+    assert result.content == "ok"
+    assert len(bodies) == 2
+    assert bodies[1]["max_completion_tokens"] == 55
+    assert "max_tokens" not in bodies[1]
     await adapter.aclose()
 
 

--- a/tests/test_dispatch_coverage.py
+++ b/tests/test_dispatch_coverage.py
@@ -711,6 +711,44 @@ def test_preflight_forwards_request_configuration(monkeypatch: pytest.MonkeyPatc
     assert payload["model"] == "m"
 
 
+def test_preflight_retries_with_max_completion_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    from tool_eval_bench.cli import probe
+
+    bodies: list[dict] = []
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, *, json, headers):
+            bodies.append(json)
+            if "max_tokens" in json:
+                return httpx.Response(
+                    400,
+                    json={
+                        "error": {
+                            "message": "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+                        }
+                    },
+                    request=httpx.Request("POST", url),
+                )
+            return httpx.Response(200, json={"choices": [{}]})
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: Client())
+    probe.preflight_model_check(Console(), "http://server/v1", "m", None)
+
+    assert len(bodies) == 2
+    assert bodies[1]["max_completion_tokens"] == 1
+    assert "max_tokens" not in bodies[1]
+
+
 def test_dispatch_preflight_can_be_skipped_and_receives_merged_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_throughput.py
+++ b/tests/test_throughput.py
@@ -311,6 +311,52 @@ async def test_stream_one_standard_ar() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stream_one_retries_with_max_completion_tokens() -> None:
+    from tool_eval_bench.runner.throughput import _stream_one
+
+    bodies: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        bodies.append(body)
+        if "max_tokens" in body:
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+                    }
+                },
+            )
+        return httpx.Response(
+            200,
+            content=(
+                _make_sse_line({"choices": [{"delta": {"content": "ok"}, "token_ids": [1]}]})
+                + "data: [DONE]\n\n"
+            ).encode(),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    cfg = TokenizerConfig()
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        sample = await _stream_one(
+            client,
+            "http://localhost:8000/v1",
+            "test-model",
+            [{"role": "user", "content": "hi"}],
+            9,
+            None,
+            cfg,
+        )
+
+    assert sample.error is None
+    assert cfg.output_token_field == "max_completion_tokens"
+    assert len(bodies) == 2
+    assert bodies[1]["max_completion_tokens"] == 9
+    assert "max_tokens" not in bodies[1]
+
+
+@pytest.mark.asyncio
 async def test_stream_one_no_token_ids() -> None:
     """Server without token_ids support — fallback to 1 per chunk."""
     from tool_eval_bench.runner.throughput import _stream_one

--- a/tests/test_warmup_fallback.py
+++ b/tests/test_warmup_fallback.py
@@ -15,9 +15,9 @@ from tool_eval_bench.runner import throughput
 
 
 class _Response:
-    def __init__(self, status_code: int) -> None:
+    def __init__(self, status_code: int, text: str = "unknown field") -> None:
         self.status_code = status_code
-        self.text = "unknown field"
+        self.text = text
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
@@ -41,7 +41,12 @@ class _RecordingClient:
     async def post(self, url: str, *, json: dict[str, Any], headers: dict[str, str]) -> _Response:
         self.calls.append((url, json, headers))
         if self._reject_key is not None and self._reject_key in json:
-            return _Response(self._status_code)
+            text = (
+                "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+                if self._reject_key == "max_tokens"
+                else "unknown field"
+            )
+            return _Response(self._status_code, text)
         return _Response(200)
 
 
@@ -74,6 +79,40 @@ class TestWarmupHintFallback:
         asyncio.run(throughput.warmup("http://server/v1", "m"))
 
         assert len(client.calls) == 2
+
+    def test_retries_with_max_completion_tokens(self, client_factory):
+        client = client_factory(_RecordingClient("max_tokens"))
+        tok_cfg = throughput.TokenizerConfig()
+
+        asyncio.run(throughput.warmup("http://server/v1", "m", tok_cfg=tok_cfg))
+
+        assert len(client.calls) == 2
+        assert client.calls[0][1]["max_tokens"] == throughput.WARMUP_MAX_TOKENS
+        assert "max_tokens" not in client.calls[1][1]
+        assert client.calls[1][1]["max_completion_tokens"] == throughput.WARMUP_MAX_TOKENS
+        assert tok_cfg.output_token_field == "max_completion_tokens"
+
+    def test_handles_hint_and_token_field_rejections(self, client_factory):
+        class RejectBoth(_RecordingClient):
+            async def post(self, url, *, json, headers):
+                self.calls.append((url, json, headers))
+                if "chat_template_kwargs" in json:
+                    return _Response(400)
+                if "max_tokens" in json:
+                    return _Response(
+                        400,
+                        "Unsupported parameter: max_tokens. Use max_completion_tokens instead.",
+                    )
+                return _Response(200)
+
+        client = client_factory(RejectBoth(None))
+
+        asyncio.run(throughput.warmup("http://server/v1", "m"))
+
+        assert len(client.calls) == 3
+        assert "chat_template_kwargs" not in client.calls[1][1]
+        assert "max_tokens" not in client.calls[2][1]
+        assert client.calls[2][1]["max_completion_tokens"] == throughput.WARMUP_MAX_TOKENS
 
     def test_failure_still_raises_after_the_retry(self, client_factory):
         """A 400 the hints did not cause is a real failure and must surface."""


### PR DESCRIPTION
## Problem

Some OpenAI-compatible endpoints reject `max_tokens` and require `max_completion_tokens`. Sending the newer field unconditionally would break older vLLM, LiteLLM, llama.cpp, and other compatible servers, while model-name detection would not work for aliases, routers, or future providers.

## Change

- Keep `max_tokens` as the provider-neutral Python API and default wire field.
- Retry once with `max_completion_tokens` only when a 400/422 response explicitly rejects `max_tokens` and names the replacement.
- Cache the learned choice per endpoint and model, including across transient HTTP retries.
- Apply the same response-driven behavior to streaming and non-streaming adapter calls, preflight, warm-up, tokenizer calibration, and throughput requests.
- Let explicit `max_completion_tokens` backend parameters suppress the legacy default instead of sending both fields.

No provider or model allowlist is involved.

## Verification

- `ruff check .`
- `ruff format --check .`
- `.venv/bin/mypy`
- `env -u FORCE_COLOR .venv/bin/python -m pytest tests/ --ignore=tests/test_llama_benchy.py -m "not live" --randomly-seed=104729` (`2759 passed, 1 deselected`)

A live Azure/OpenAI endpoint was not available in this environment; deterministic HTTP mocks reproduce the reported 400 response for stream, non-stream, preflight, warm-up, and throughput paths.

Closes #72
