### PR TITLE
fix: support reasoning-model startup probes (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ All notable changes to `tool-eval-bench` are documented here.
 
 ### Fixed
 
+- **Reasoning-model preflight and warm-up compatibility** — hosted endpoints
+  that report a small probe's output-token exhaustion as HTTP 400/422 now count
+  as successfully serving and warming the model. Warm-up also uses the
+  benchmark's configured temperature and backend parameters instead of an
+  independent `temperature: 0.0` request, preventing false startup failures on
+  models that only support their default sampling configuration.
+
 - **Output-token compatibility across OpenAI-style endpoints** — requests now
   default to `max_tokens` for vLLM, LiteLLM, llama.cpp, and existing compatible
   servers, then retry once with `max_completion_tokens` only when a 400/422

--- a/README.md
+++ b/README.md
@@ -272,9 +272,12 @@ backward compatibility.
 Before a benchmark, the CLI sends a minimal model-availability request using
 the configured `--timeout` and the same merged backend parameters used by the
 benchmark requests. The check remains enabled by default because a model that
-is listed by `/v1/models` may still reject completions. Use `--no-preflight`
-when an endpoint requires provider-specific startup handling and you have
-validated it independently; this does not disable the separate warm-up request.
+is listed by `/v1/models` may still reject completions. A hosted reasoning model
+that exhausts the probe's deliberately small output budget still counts as
+available. The separate warm-up request uses the benchmark's temperature and
+backend parameters and treats the same response as successful model work. Use
+`--no-preflight` when an endpoint requires provider-specific startup handling
+and you have validated it independently; this does not disable warm-up.
 
 ### Accuracy benchmarks (GSM8K, MMLU, IFEval)
 

--- a/src/tool_eval_bench/cli/dispatch.py
+++ b/src/tool_eval_bench/cli/dispatch.py
@@ -460,7 +460,15 @@ def main() -> None:
 
     # -- Warm-up --
     if not args.no_warmup and not args.json:
-        _do_warmup(console, base_url, model, api_key, wire_format=wire_format)
+        _do_warmup(
+            console,
+            base_url,
+            model,
+            api_key,
+            wire_format=wire_format,
+            temperature=args.temperature,
+            extra_params=extra_params or None,
+        )
 
     # -- Build RunContext (issue #6: full execution context metadata) --
     # Built early so perf-only and spec-bench paths also get engine detection.

--- a/src/tool_eval_bench/cli/probe.py
+++ b/src/tool_eval_bench/cli/probe.py
@@ -12,7 +12,10 @@ from tool_eval_bench.adapters.requests import minimal_request
 from tool_eval_bench.cli.helpers import emit_headless_error
 from tool_eval_bench.domain.errors import CONNECTION_FAILED, MODEL_NOT_AVAILABLE
 from tool_eval_bench.domain.models import DEFAULT_REQUEST_TIMEOUT_SECONDS
-from tool_eval_bench.utils.openai_compat import max_tokens_retry_payload
+from tool_eval_bench.utils.openai_compat import (
+    max_tokens_retry_payload,
+    output_token_limit_reached,
+)
 
 
 def preflight_model_check(
@@ -55,7 +58,9 @@ def preflight_model_check(
 
     try:
         response = asyncio.run(check())
-        if response.status_code >= 400:
+        if response.status_code >= 400 and not output_token_limit_reached(
+            response.status_code, response.text
+        ):
             body = response.text[:300].strip()
             if headless:
                 emit_headless_error(
@@ -103,6 +108,8 @@ def warmup_server(
     api_key: str | None,
     *,
     wire_format: str = "openai",
+    temperature: float = 0.0,
+    extra_params: dict[str, Any] | None = None,
 ) -> None:
     """Prime the model server before measuring benchmark behavior."""
     from tool_eval_bench.runner.throughput import (
@@ -111,13 +118,16 @@ def warmup_server(
         warmup,
     )
 
+    warmup_params = dict(extra_params or {})
+    warmup_params.setdefault("chat_template_kwargs", WARMUP_EXTRA_PARAMS["chat_template_kwargs"])
     request = minimal_request(
         base_url,
         model,
         api_key,
         wire_format=wire_format,
+        temperature=temperature,
         max_tokens=WARMUP_MAX_TOKENS,
-        extra_params=WARMUP_EXTRA_PARAMS,
+        extra_params=warmup_params,
     )
 
     with console.status(
@@ -139,4 +149,8 @@ def warmup_server(
                 )
         except Exception as exc:
             message = str(exc) or type(exc).__name__
+            response = getattr(exc, "response", None)
+            body = getattr(response, "text", "").strip()
+            if body and body not in message:
+                message = f"{message}: {body[:300]}"
             console.print(f"  [bold yellow]⚠[/] Warm-up failed [dim]({message})[/]")

--- a/src/tool_eval_bench/runner/throughput.py
+++ b/src/tool_eval_bench/runner/throughput.py
@@ -21,7 +21,10 @@ from typing import Any
 
 import httpx
 
-from tool_eval_bench.utils.openai_compat import max_tokens_retry_payload
+from tool_eval_bench.utils.openai_compat import (
+    max_tokens_retry_payload,
+    output_token_limit_reached,
+)
 from tool_eval_bench.utils.urls import chat_completions_url as _chat_url
 from tool_eval_bench.utils.urls import models_url as models_url_fn
 
@@ -479,6 +482,9 @@ async def warmup(
     async with httpx.AsyncClient(timeout=timeout) as client:
         for _ in range(3):
             resp = await client.post(url, json=payload, headers=headers)
+            if output_token_limit_reached(resp.status_code, resp.text):
+                logger.debug("Warm-up reached the model's output-token limit")
+                break
             if resp.status_code not in _REJECTION_STATUS_CODES:
                 break
             retry_payload = max_tokens_retry_payload(payload, resp.status_code, resp.text)
@@ -495,7 +501,8 @@ async def warmup(
                     resp.status_code,
                 )
             payload = retry_payload
-        resp.raise_for_status()
+        if not output_token_limit_reached(resp.status_code, resp.text):
+            resp.raise_for_status()
     return (time.perf_counter() - t0) * 1000
     # Note: warmup intentionally uses its own client since it runs
     # before the throughput sweep and has a much longer timeout.

--- a/src/tool_eval_bench/utils/openai_compat.py
+++ b/src/tool_eval_bench/utils/openai_compat.py
@@ -5,6 +5,26 @@ from __future__ import annotations
 from typing import Any
 
 
+def output_token_limit_reached(status_code: int, response_text: str) -> bool:
+    """Return whether a valid request exhausted its output-token allowance.
+
+    Some hosted reasoning endpoints report this as HTTP 400 instead of a
+    successful response with ``finish_reason=length``. Reaching generation is
+    sufficient evidence for availability checks and model warm-up.
+    """
+    if status_code not in (400, 422):
+        return False
+    text = response_text.lower()
+    mentions_output_budget = any(
+        marker in text for marker in ("max_tokens", "max_completion_tokens", "model output limit")
+    )
+    reports_exhaustion = any(
+        marker in text
+        for marker in ("limit was reached", "limit reached", "try again with higher max_")
+    )
+    return mentions_output_budget and reports_exhaustion
+
+
 def max_tokens_retry_payload(
     payload: dict[str, Any], status_code: int, response_text: str
 ) -> dict[str, Any] | None:

--- a/tests/test_dispatch_coverage.py
+++ b/tests/test_dispatch_coverage.py
@@ -661,6 +661,15 @@ def test_preflight_and_warmup_user_outcomes(monkeypatch: pytest.MonkeyPatch) -> 
     probe.warmup_server(console, "url", "m", None)
     assert "Warm-up failed" in console.export_text()
 
+    async def fail_with_response(*args, **kwargs):
+        request = httpx.Request("POST", "http://server/v1/chat/completions")
+        response = httpx.Response(400, text="provider detail", request=request)
+        raise httpx.HTTPStatusError("bad request", request=request, response=response)
+
+    monkeypatch.setattr(throughput, "warmup", fail_with_response)
+    probe.warmup_server(console, "url", "m", None)
+    assert "provider detail" in console.export_text()
+
 
 def test_preflight_forwards_request_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
     import httpx
@@ -749,6 +758,53 @@ def test_preflight_retries_with_max_completion_tokens(
     assert "max_tokens" not in bodies[1]
 
 
+def test_preflight_accepts_output_limit_as_model_availability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    from tool_eval_bench.cli import probe
+
+    bodies: list[dict] = []
+
+    class Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, *, json, headers):
+            bodies.append(json)
+            request = httpx.Request("POST", url)
+            if "max_tokens" in json:
+                return httpx.Response(
+                    400,
+                    json={
+                        "error": {
+                            "message": "Unsupported parameter: max_tokens. Use max_completion_tokens instead."
+                        }
+                    },
+                    request=request,
+                )
+            return httpx.Response(
+                400,
+                json={
+                    "error": {
+                        "message": "Could not finish the message because max_tokens or model output limit was reached. Please try again with higher max_tokens."
+                    }
+                },
+                request=request,
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: Client())
+
+    probe.preflight_model_check(Console(), "http://server/v1", "reasoning-model", None)
+
+    assert len(bodies) == 2
+    assert bodies[1]["max_completion_tokens"] == 1
+
+
 def test_dispatch_preflight_can_be_skipped_and_receives_merged_config(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -761,13 +817,18 @@ def test_dispatch_preflight_can_be_skipped_and_receives_merged_config(
         return None
 
     calls: list[tuple[tuple, dict]] = []
+    warmup_calls: list[tuple[tuple, dict]] = []
     monkeypatch.setattr(
         dispatch,
         "_preflight_model_check",
         lambda *args, **kwargs: calls.append((args, kwargs)),
     )
     monkeypatch.setattr(dispatch, "_load_dotenv", lambda: None)
-    monkeypatch.setattr(dispatch, "_do_warmup", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        dispatch,
+        "_do_warmup",
+        lambda *args, **kwargs: warmup_calls.append((args, kwargs)),
+    )
     monkeypatch.setattr(metadata, "collect_run_context", context)
     monkeypatch.setattr(plugin_runners, "run_selected_plugins", lambda *args, **kwargs: False)
     base_argv = [
@@ -785,7 +846,6 @@ def test_dispatch_preflight_can_be_skipped_and_receives_merged_config(
         "--backend-kwargs",
         '{"reasoning_effort":"low"}',
         "--skip-tool-eval",
-        "--no-warmup",
     ]
 
     monkeypatch.setattr(sys, "argv", base_argv)
@@ -794,10 +854,14 @@ def test_dispatch_preflight_can_be_skipped_and_receives_merged_config(
     assert calls[0][1]["timeout_seconds"] == 17.5
     assert calls[0][1]["temperature"] == 0.3
     assert calls[0][1]["extra_params"] == {"reasoning_effort": "low"}
+    assert len(warmup_calls) == 1
+    assert warmup_calls[0][1]["temperature"] == 0.3
+    assert warmup_calls[0][1]["extra_params"] == {"reasoning_effort": "low"}
 
     monkeypatch.setattr(sys, "argv", [*base_argv, "--no-preflight"])
     dispatch.main()
     assert len(calls) == 1
+    assert len(warmup_calls) == 2
 
 
 def test_dispatch_legacy_spec_and_sweep_modes(

--- a/tests/test_warmup_fallback.py
+++ b/tests/test_warmup_fallback.py
@@ -114,6 +114,30 @@ class TestWarmupHintFallback:
         assert "max_tokens" not in client.calls[2][1]
         assert client.calls[2][1]["max_completion_tokens"] == throughput.WARMUP_MAX_TOKENS
 
+    def test_output_limit_after_fallbacks_counts_as_success(self, client_factory):
+        class ExhaustedReasoningBudget(_RecordingClient):
+            async def post(self, url, *, json, headers):
+                self.calls.append((url, json, headers))
+                if "max_tokens" in json:
+                    return _Response(
+                        400,
+                        "Unsupported parameter: max_tokens. Use max_completion_tokens instead.",
+                    )
+                if "chat_template_kwargs" in json:
+                    return _Response(400)
+                return _Response(
+                    400,
+                    "Could not finish the message because max_tokens or model output limit "
+                    "was reached. Please try again with higher max_tokens.",
+                )
+
+        client = client_factory(ExhaustedReasoningBudget(None))
+
+        elapsed = asyncio.run(throughput.warmup("http://server/v1", "reasoning-model"))
+
+        assert elapsed >= 0
+        assert len(client.calls) == 3
+
     def test_failure_still_raises_after_the_retry(self, client_factory):
         """A 400 the hints did not cause is a real failure and must surface."""
         client = client_factory(_RecordingClient("model"))
@@ -149,6 +173,38 @@ class TestWarmupHintFallback:
 
 
 class TestWarmupRequestOverride:
+    def test_probe_builds_warmup_with_request_configuration(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from rich.console import Console
+
+        from tool_eval_bench.cli import probe
+
+        observed: dict[str, Any] = {}
+
+        async def record(*args, **kwargs):
+            observed.update(kwargs)
+            return 1.0
+
+        monkeypatch.setattr(throughput, "warmup", record)
+
+        probe.warmup_server(
+            Console(),
+            "http://server/v1",
+            "reasoning-model",
+            None,
+            temperature=1.0,
+            extra_params={
+                "reasoning_effort": "low",
+                "chat_template_kwargs": {"thinking": True},
+            },
+        )
+
+        _, payload, _ = observed["request"]
+        assert payload["temperature"] == 1.0
+        assert payload["reasoning_effort"] == "low"
+        assert payload["chat_template_kwargs"] == {"thinking": True}
+
     def test_supplied_request_is_used_verbatim(self, client_factory):
         client = client_factory(_RecordingClient(None))
         request = (


### PR DESCRIPTION
Issue #72 remained reproducible after output-token parameter negotiation: preflight treated a deliberately exhausted reasoning budget as model unavailability, while warm-up ignored the benchmark temperature and backend parameters.

This change:

- recognizes narrowly scoped HTTP 400/422 output-limit responses as evidence that the model served and warmed successfully;
- passes the benchmark temperature and merged backend parameters into warm-up without overwriting an explicit thinking configuration;
- preserves provider response details in warm-up warnings;
- adds regression coverage for the reported Azure-style response and the full field, hint, and output-limit fallback sequence;
- updates the README and changelog compatibility guidance.

Verification:

- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/mypy`
- `env -u FORCE_COLOR .venv/bin/python -m pytest tests/ --ignore=tests/test_llama_benchy.py -m "not live" --randomly-seed=104729` -- 2,762 passed, 1 deselected
- focused compatibility suite -- 183 passed

Closes #72

AI assistance was used to implement and verify this change.
