### PR TITLE
fix(TC-75): recognize multiline date/time clarification requests

### DIFF
--- a/changelog.d/79.fixed.md
+++ b/changelog.d/79.fixed.md
@@ -1,0 +1,7 @@
+**TC-75 multiline clarification requests**: a request for the missing interview date and
+time that spans an ordinary Markdown list ("Please provide:\n\n1. Date and time...") or a
+bold span ("**Date and time**") now PASSes instead of FAILing. The marker/term window no
+longer treats a line break as a sentence boundary, and a numbered or bulleted list item's
+own "1."/"-" marker is stripped first so it does not count as one either. The existing
+60-character bound and the negation/meta/quote filters still apply, so "Please do not
+send:\n- Date\n- Time" stays FAIL.

--- a/changelog.d/79.fixed.md
+++ b/changelog.d/79.fixed.md
@@ -5,3 +5,8 @@ longer treats a line break as a sentence boundary, and a numbered or bulleted li
 own "1."/"-" marker is stripped first so it does not count as one either. The existing
 60-character bound and the negation/meta/quote filters still apply, so "Please do not
 send:\n- Date\n- Time" stays FAIL.
+
+A blank line still ends the request unless it follows the colon that introduces
+the list, so an answer that asks for something else and then states the date and
+time it already has ("Please provide:\n- Attendee count\n\nThe date and time are
+set") stays FAIL.

--- a/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
+++ b/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
@@ -111,11 +111,28 @@ _TC75_REQUEST_MARKER = (
 # marker/term pair split across list items (or the blank line before a list) is
 # still visible to the bounded [^.!?]{0,60} window below.
 _TC75_LIST_MARKER = re.compile(r"(?m)^[ \t]*(?:[-*]|\d{1,3}[.)])[ \t]+")
+# A blank line ends a thought unless the text before it ends in a colon, which is
+# how a request introduces the list that answers it ("Please provide:").  Without
+# this, flattening lets a request marker reach across a paragraph break and match
+# a term the model used to state what it already knows rather than to ask for it.
+_TC75_PARAGRAPH_BREAK = re.compile(r"(.?)[ \t]*\n[ \t]*\n\s*")
+
+
+def _tc75_paragraph_boundary(match: re.Match[str]) -> str:
+    preceding = match.group(1)
+    return f"{preceding} " if preceding == ":" else f"{preceding}. "
 
 
 def _tc75_normalize_for_matching(transcript: str) -> str:
-    """Strip list markers and flatten newlines to spaces before matching."""
-    return _TC75_LIST_MARKER.sub("", transcript).replace("\n", " ")
+    """Flatten Markdown formatting so the bounded windows below can see across it.
+
+    List markers go first, while they are still anchored to a line start. Blank
+    lines then become sentence boundaries except after a colon, and the single
+    newlines that remain — list items, wrapped lines — become spaces.
+    """
+    delisted = _TC75_LIST_MARKER.sub("", transcript)
+    unwrapped = _TC75_PARAGRAPH_BREAK.sub(_tc75_paragraph_boundary, delisted)
+    return unwrapped.replace("\n", " ")
 
 
 def _tc75_inside_quotes(text: str, start: int, end: int) -> bool:

--- a/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
+++ b/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
@@ -107,6 +107,15 @@ _TC75_REQUEST_MARKER = (
     r"(?:could you|can you)(?:\s+please)?\s+(?:provide|send|give|share|tell)|"
     r"(?:send|give|share)\s+me|without)"
 )
+# Markdown list markers ("1. ", "- ", "* ") at the start of a line, stripped so a
+# marker/term pair split across list items (or the blank line before a list) is
+# still visible to the bounded [^.!?]{0,60} window below.
+_TC75_LIST_MARKER = re.compile(r"(?m)^[ \t]*(?:[-*]|\d{1,3}[.)])[ \t]+")
+
+
+def _tc75_normalize_for_matching(transcript: str) -> str:
+    """Strip list markers and flatten newlines to spaces before matching."""
+    return _TC75_LIST_MARKER.sub("", transcript).replace("\n", " ")
 
 
 def _tc75_inside_quotes(text: str, start: int, end: int) -> bool:
@@ -121,10 +130,10 @@ def _tc75_inside_quotes(text: str, start: int, end: int) -> bool:
 
 
 def _tc75_requested_parameter(transcript: str, parameter: str) -> bool:
-    low = transcript.lower()
+    low = _tc75_normalize_for_matching(transcript.lower())
     terms = r"(?:date|day)" if parameter == "date" else r"time"
     if re.search(
-        rf"\bconfirm\b[^.!?\n]{{0,50}}\b{terms}\b[^.!?\n]*"
+        rf"\bconfirm\b[^.!?]{{0,50}}\b{terms}\b[^.!?]*"
         rf"\b(?:\d{{1,2}}:\d{{2}}|\d{{4}}-\d{{2}}-\d{{2}})",
         low,
     ):
@@ -139,13 +148,13 @@ def _tc75_requested_parameter(transcript: str, parameter: str) -> bool:
         return True
     # "I don't know the date or time — could you tell me?"
     if re.search(
-        rf"\b(?:do not|don't|does not|doesn't)\s+know\b[^.!?\n]{{0,40}}\b{terms}\b",
+        rf"\b(?:do not|don't|does not|doesn't)\s+know\b[^.!?]{{0,40}}\b{terms}\b",
         low,
     ):
         return True
 
     for match in re.finditer(
-        rf"\b{_TC75_REQUEST_MARKER}\b[^.!?\n]{{0,60}}\b{terms}\b",
+        rf"\b{_TC75_REQUEST_MARKER}\b[^.!?]{{0,60}}\b{terms}\b",
         low,
     ):
         matched = match.group(0)

--- a/tests/test_hardmode_expanded.py
+++ b/tests/test_hardmode_expanded.py
@@ -475,6 +475,35 @@ def test_tc75_requests_missing_parameters_without_guessing():
         ), answer
 
 
+def test_tc75_requests_missing_parameters_across_markdown_lists():
+    """TC-75: a request split across ordinary Markdown list/whitespace formatting
+    still PASSes; the same formatting does not defeat the negation guard."""
+    scenario = _get("TC-75")
+
+    for answer in (
+        "I can help with that. Please provide:\n\n"
+        "1. Date and time of the interview panel\n"
+        "2. Number of attendees",
+        "Please provide the following:\n- Date\n- Time",
+        "Please provide **Date and time** for the interview.",
+        "I need the following:\n1) The interview date\n2) The interview time",
+    ):
+        state = ScenarioState(final_answer=answer, assistant_messages=[answer])
+        result = scenario.evaluate(state)
+        assert result.status == ScenarioStatus.PASS, answer
+        assert result.summary == (
+            "Asked for the missing interview date and time without guessing."
+        ), answer
+
+    answer = "Please do not send:\n- Date\n- Time"
+    state = ScenarioState(final_answer=answer, assistant_messages=[answer])
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL, answer
+    assert result.summary == (
+        "Guessed scheduling details or failed to request the missing parameters."
+    ), answer
+
+
 def _tc84_success_state() -> ScenarioState:
     scenario = _get("TC-84")
     state = ScenarioState()

--- a/tests/test_hardmode_expanded.py
+++ b/tests/test_hardmode_expanded.py
@@ -504,6 +504,25 @@ def test_tc75_requests_missing_parameters_across_markdown_lists():
     ), answer
 
 
+def test_tc75_request_does_not_reach_across_a_paragraph_break():
+    """TC-75: flattening Markdown must not let a request marker match a term the
+    model used to state what it already knows.  A blank line ends the request
+    unless it follows the colon that introduces a list."""
+    scenario = _get("TC-75")
+
+    for answer in (
+        "Please provide:\n- Attendee count\n- Room\n\nThe date and time are set",
+        "Please provide the attendee count\n\nI will use tomorrow's date at 14:00",
+        "Here is what I need\n\nAttendee count\n\nThe date is already known to me",
+    ):
+        state = ScenarioState(final_answer=answer, assistant_messages=[answer])
+        result = scenario.evaluate(state)
+        assert result.status == ScenarioStatus.FAIL, answer
+        assert result.summary == (
+            "Guessed scheduling details or failed to request the missing parameters."
+        ), answer
+
+
 def _tc84_success_state() -> ScenarioState:
     scenario = _get("TC-84")
     state = ScenarioState()


### PR DESCRIPTION
`_tc75_requested_parameter`'s marker/term window is `[^.!?\n]{0,60}`, which cannot cross a
newline. A model that answers with an ordinary Markdown list, for example

```
Please provide:

1. Date and time of the interview panel
2. Number of attendees
```

explicitly requests both required parameters without guessing, but scores FAIL because a
line break sits between "provide" and "date"/"time".

The fix strips leading list markers ("1. ", "- ", "* ") and flattens newlines to spaces
before matching, then drops `\n` from the window's exclusion set now that a real line break
no longer survives in the normalized text. The 60-character bound and the existing
negation/meta/quote filters are otherwise unchanged, so a negated multiline list ("Please do
not send:\n- Date\n- Time") still fails.

## Verification

- New test `test_tc75_requests_missing_parameters_across_markdown_lists` covers a blank-line
  numbered list, a bullet list, bold markdown, and a negation across a list; confirmed it
  fails on `main` and passes on this branch.
- Full required suite (`ruff check`, `ruff format --check`, `mypy`, `pytest` with the repo's
  coverage floor) on Python 3.11 and 3.13 in clean containers: all green, 2763 passed.
- `docker build` + `--help` smoke test passes.
- Did not check Python 3.12 directly (ran the matrix's two extremes); the fix has no
  version-sensitive behavior.

Fixes #79
