### PR TITLE
fix: derive date-sensitive evaluators from the reference date

### DIFF
--- a/changelog.d/78.fixed.md
+++ b/changelog.d/78.fixed.md
@@ -1,0 +1,16 @@
+**`--reference-date` now reaches the evaluators.** The flag set the date in the
+system prompt and in `ScenarioState.meta`, but only two evaluators read it back.
+Six date-sensitive scenarios graded against hard-coded March 2026 dates instead,
+so a model that correctly parsed "next Monday" from the date it was actually
+given scored FAIL. TC-05, TC-08, TC-17, TC-74, TC-79, and TC-84 now derive their
+expected dates from the effective reference date, with `BENCHMARK_REFERENCE_DATE`
+as the fallback.
+
+Two fixtures were part of the same defect. TC-84's simulator always offered a
+slot on 2026-03-25, contradicting the date its own prompt asked for, and TC-17
+accepted "CET" as a synonym for Europe/Berlin year-round, which is wrong for any
+reference date inside EU summer time. Both now follow the target date.
+
+Default runs are unaffected: every scenario grades the same dates it graded
+before, because the derivation reproduces the previous constants on the default
+reference date.

--- a/src/tool_eval_bench/evals/helpers.py
+++ b/src/tool_eval_bench/evals/helpers.py
@@ -10,7 +10,9 @@ import ast
 import operator
 import re
 from collections.abc import Callable
+from datetime import date, datetime, timedelta
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from tool_eval_bench.domain.scenarios import (
     ScenarioEvaluation,
@@ -19,6 +21,7 @@ from tool_eval_bench.domain.scenarios import (
     ToolCallRecord,
     ToolResultRecord,
 )
+from tool_eval_bench.domain.tools import BENCHMARK_REFERENCE_DATE
 
 # ---------------------------------------------------------------------------
 # String helpers
@@ -595,3 +598,77 @@ def scan_for_injection(state: ScenarioState, injection_markers: list[str]) -> bo
     """
     transcript = full_assistant_transcript(state).lower()
     return any(marker.lower() in transcript for marker in injection_markers)
+
+
+# ---------------------------------------------------------------------------
+# Reference-date helpers
+# ---------------------------------------------------------------------------
+
+_WEEKDAYS = {
+    "monday": 0,
+    "tuesday": 1,
+    "wednesday": 2,
+    "thursday": 3,
+    "friday": 4,
+    "saturday": 5,
+    "sunday": 6,
+}
+
+
+def reference_date(state: ScenarioState) -> date:
+    """The date the model was told is "today" for this run.
+
+    ``--reference-date`` reaches the model through the system prompt and reaches
+    the evaluator through ``state.meta``.  Any scenario whose prompt says
+    "tomorrow" or "next Tuesday" must derive its expected date from here rather
+    than hard-coding one, or the flag silently grades against a date the model
+    was never given.  ``BENCHMARK_REFERENCE_DATE`` is the fallback for states
+    built directly in tests.
+    """
+    raw = as_str(state.meta.get("reference_date")).strip() or BENCHMARK_REFERENCE_DATE
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return date.fromisoformat(BENCHMARK_REFERENCE_DATE)
+
+
+def days_after_reference(state: ScenarioState, days: int) -> str:
+    """ISO date ``days`` after the reference date. ``days=1`` is "tomorrow"."""
+    return (reference_date(state) + timedelta(days=days)).isoformat()
+
+
+def next_weekday_after_reference(state: ScenarioState, weekday: str, *, offset: int = 0) -> str:
+    """ISO date of the next ``weekday`` strictly after the reference date.
+
+    "Next Monday" on a Friday is three days out; on a Monday it is seven, never
+    zero.  ``offset`` shifts the result in days, for prompts that name a weekday
+    and then move the event ("next Tuesday", corrected to Wednesday).
+    """
+    try:
+        target = _WEEKDAYS[weekday.strip().lower()]
+    except KeyError:
+        raise ValueError(f"Unknown weekday {weekday!r}") from None
+    ref = reference_date(state)
+    ahead = (target - ref.weekday()) % 7 or 7
+    return (ref + timedelta(days=ahead + offset)).isoformat()
+
+
+def utc_offset_aliases(iso_date: str, timezone: str) -> set[str]:
+    """Offset spellings that are correct for ``timezone`` on ``iso_date``.
+
+    Europe/Berlin is UTC+1 in winter and UTC+2 in summer, so a scenario that
+    accepts "cet" as a synonym for "europe/berlin" is only right for part of the
+    year.  Deriving the aliases from the date keeps the timezone check honest
+    when ``--reference-date`` moves the event across a DST transition.
+    """
+    winter, summer = ("cet", "utc+1"), ("cest", "utc+2")
+    try:
+        moment = datetime.fromisoformat(f"{iso_date}T12:00:00").replace(tzinfo=ZoneInfo(timezone))
+    except (ValueError, ZoneInfoNotFoundError):
+        return {*winter, *summer}
+    offset = moment.utcoffset()
+    if offset == timedelta(hours=1):
+        return set(winter)
+    if offset == timedelta(hours=2):
+        return set(summer)
+    return set()

--- a/src/tool_eval_bench/evals/scenarios.py
+++ b/src/tool_eval_bench/evals/scenarios.py
@@ -51,6 +51,9 @@ from tool_eval_bench.evals.helpers import (
     datetime_matches as _datetime_matches,
 )
 from tool_eval_bench.evals.helpers import (
+    days_after_reference as _days_after_reference,
+)
+from tool_eval_bench.evals.helpers import (
     fail_eval as _fail,
 )
 from tool_eval_bench.evals.helpers import (
@@ -70,6 +73,9 @@ from tool_eval_bench.evals.helpers import (
 )
 from tool_eval_bench.evals.helpers import (
     is_only_tool as _is_only_tool,
+)
+from tool_eval_bench.evals.helpers import (
+    next_weekday_after_reference as _next_weekday_after_reference,
 )
 from tool_eval_bench.evals.helpers import (
     normalize as _normalize,
@@ -337,11 +343,13 @@ def _tc05_eval(state: ScenarioState) -> ScenarioEvaluation:
     has_attendees = any(_includes_text(a, "alex") for a in attendees) and any(
         _includes_text(a, "jamie") for a in attendees
     )
+    # "next Monday" is relative to the run's reference date, not a fixed day.
+    expected_date = _next_weekday_after_reference(state, "monday")
     # Use flexible date matching — accept any ISO 8601 date representation
-    correct_date = _date_matches(event.arguments.get("date"), "2026-03-23")
+    correct_date = _date_matches(event.arguments.get("date"), expected_date)
     # Time: accept "09:30" with any seconds/offset
     correct_time = _datetime_matches(
-        f"2026-03-23T{_as_str(event.arguments.get('time', ''))}:00", "2026-03-23", "09:30"
+        f"{expected_date}T{_as_str(event.arguments.get('time', ''))}:00", expected_date, "09:30"
     ) or _as_str(event.arguments.get("time", "")).startswith("09:30")
     has_title = "standup" in _normalize(_as_str(event.arguments.get("title")))
     if correct_date and correct_time and has_duration and has_attendees and has_title:
@@ -570,7 +578,9 @@ def _tc08_eval(state: ScenarioState) -> ScenarioEvaluation:
         and weather.turn < reminder.turn
         and _includes_text(reminder.arguments.get("message"), "umbrella")
         # Use flexible datetime matching — accept any timezone representation
-        and _datetime_matches(reminder.arguments.get("datetime"), "2026-03-21", "08:00")
+        and _datetime_matches(
+            reminder.arguments.get("datetime"), _days_after_reference(state, 1), "08:00"
+        )
     ):
         return _pass("Checked the weather first, then set the rainy-day reminder.")
     if weather and not reminder and _asks_for_clarification(state.final_answer):
@@ -1084,7 +1094,8 @@ SCENARIO_DISPLAY_DETAILS: dict[str, ScenarioDisplayDetail] = {
         "Fail if it ignores the Fahrenheit instruction.",
     ),
     "TC-05": ScenarioDisplayDetail(
-        "Pass if it creates the event for 2026-03-23 at 09:30 with 30 minutes and Alex plus Jamie.",
+        "Pass if it creates the event for the Monday after the reference date "
+        "at 09:30 with 30 minutes and Alex plus Jamie.",
         "Fail if it misparses next Monday or drops core event details.",
     ),
     "TC-06": ScenarioDisplayDetail(

--- a/src/tool_eval_bench/evals/scenarios_extended.py
+++ b/src/tool_eval_bench/evals/scenarios_extended.py
@@ -18,10 +18,6 @@ from tool_eval_bench.domain.scenarios import (
     ScenarioState,
     ToolCallRecord,
 )
-
-# ---------------------------------------------------------------------------
-# Helpers (shared via evals.helpers)
-# ---------------------------------------------------------------------------
 from tool_eval_bench.evals.helpers import (
     answer_contains_number as _answer_contains_number,
 )
@@ -40,6 +36,13 @@ from tool_eval_bench.evals.helpers import (
 from tool_eval_bench.evals.helpers import (
     includes_text as _includes_text,
 )
+
+# ---------------------------------------------------------------------------
+# Helpers (shared via evals.helpers)
+# ---------------------------------------------------------------------------
+from tool_eval_bench.evals.helpers import (
+    next_weekday_after_reference as _next_weekday_after_reference,
+)
 from tool_eval_bench.evals.helpers import (
     normalize as _normalize,
 )
@@ -51,6 +54,9 @@ from tool_eval_bench.evals.helpers import (
 )
 from tool_eval_bench.evals.helpers import (
     pass_eval as _pass,
+)
+from tool_eval_bench.evals.helpers import (
+    utc_offset_aliases as _utc_offset_aliases,
 )
 from tool_eval_bench.evals.helpers import (
     with_noise as _noise,
@@ -191,10 +197,17 @@ def _tc17_eval(state: ScenarioState) -> ScenarioEvaluation:
     date_val = _as_str(event.arguments.get("date"))
     title_val = _normalize(_as_str(event.arguments.get("title")))
 
+    # "nächsten Dienstag" is relative to the run's reference date.
+    expected_date = _next_weekday_after_reference(state, "tuesday")
+
     correct_time = time_val == "14:00"
-    # 2026-03-24 is before the EU DST transition, so CEST is not valid here.
-    correct_tz = tz_val in ("europe/berlin", "cet", "utc+1")
-    correct_date = date_val == "2026-03-24"  # next Tuesday from reference date (Friday 2026-03-20)
+    # Which offset spelling is correct depends on whether the target date falls
+    # inside EU summer time, so derive the accepted aliases from the date rather
+    # than assuming the March default.
+    correct_tz = tz_val == "europe/berlin" or tz_val in _utc_offset_aliases(
+        expected_date, "Europe/Berlin"
+    )
+    correct_date = date_val == expected_date
     has_title = "standup" in title_val or "meeting" in title_val or "besprechung" in title_val
 
     if correct_time and correct_tz and correct_date and has_title:
@@ -576,7 +589,8 @@ EXTENDED_DISPLAY_DETAILS: dict[str, ScenarioDisplayDetail] = {
         "Fail if it responds in English or misses the weather tool.",
     ),
     "TC-17": ScenarioDisplayDetail(
-        "Pass if it creates the event at 14:00 with timezone Europe/Berlin for 2026-03-24.",
+        "Pass if it creates the event at 14:00 with timezone Europe/Berlin "
+        "for the Tuesday after the reference date.",
         "Fail if it uses UTC or gets the date wrong.",
     ),
     "TC-18": ScenarioDisplayDetail(

--- a/src/tool_eval_bench/evals/scenarios_hardmode.py
+++ b/src/tool_eval_bench/evals/scenarios_hardmode.py
@@ -38,6 +38,7 @@ from tool_eval_bench.evals.helpers import (
     generic_tool_fallback,
     has_tool_call,
     includes_text,
+    next_weekday_after_reference,
     normalize,
     result_is_usable_if_present,
     tool_calls_by_name,
@@ -557,7 +558,7 @@ def _tc74_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
 def _tc74_eval(state: ScenarioState) -> ScenarioEvaluation:
     # After all follow-ups, the final event should be:
     # Title: Product Review (changed from "Team Sync")
-    # Date: 2026-03-25 (Wednesday, changed from Tuesday)
+    # Date: the Wednesday after "next Tuesday", per the third follow-up
     # Time: 14:00 (changed from 10:00)
     # Duration: 45 min (changed from 30)
     # Attendees should include Mark Chen (original) + Sarah Jones (added in follow-up)
@@ -582,7 +583,8 @@ def _tc74_eval(state: ScenarioState) -> ScenarioEvaluation:
     event_usable = result_is_usable_if_present(state, last_event)
 
     title_ok = includes_text(args.get("title"), "product review")
-    date_ok = "2026-03-25" in as_str(args.get("date", ""))
+    expected_date = next_weekday_after_reference(state, "tuesday", offset=1)
+    date_ok = expected_date in as_str(args.get("date", ""))
     time_ok = "14:00" in as_str(args.get("time", "")) or "14:00" in as_str(args.get("date", ""))
     duration_ok = args.get("duration_minutes") == 45
 

--- a/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
+++ b/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
@@ -20,8 +20,10 @@ from tool_eval_bench.evals.helpers import (
     as_str,
     asks_for_clarification,
     contains_refusal,
+    days_after_reference,
     full_assistant_transcript,
     has_tool_call,
+    next_weekday_after_reference,
     result_is_usable_if_present,
     tool_calls_by_name,
 )
@@ -425,7 +427,7 @@ def _tc79_eval(state: ScenarioState) -> ScenarioEvaluation:
     event_usable = result_is_usable_if_present(state, event)
     attendee_values = args.get("attendees")
     required = [
-        args.get("date") == "2026-03-21",
+        args.get("date") == days_after_reference(state, 1),
         args.get("time") == "09:00",
         args.get("timezone") == "Europe/Lisbon",
         args.get("duration_minutes") == 30,
@@ -837,6 +839,11 @@ _TC84_TOOLS = [
 ]
 
 
+def _tc84_slot_date(state: ScenarioState) -> str:
+    """The "next Wednesday" the prompt asks for, relative to the reference date."""
+    return next_weekday_after_reference(state, "wednesday")
+
+
 def _tc84_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     if call.name == "get_contacts":
         query = as_str(call.arguments.get("query")).strip().lower()
@@ -852,8 +859,19 @@ def _tc84_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
             ]
         return _noise({"results": results}, call.name)
     if call.name == "search_slots":
+        # The offered slot has to be the day the prompt asked for, or the
+        # simulator contradicts the reference date the model was given.
         return _noise(
-            {"slots": [{"date": "2026-03-25", "time": "14:00", "duration_minutes": 45}]}, call.name
+            {
+                "slots": [
+                    {
+                        "date": _tc84_slot_date(state),
+                        "time": "14:00",
+                        "duration_minutes": 45,
+                    }
+                ]
+            },
+            call.name,
         )
     if call.name == "search_rooms":
         return _noise({"rooms": copy.deepcopy(_ROOMS)}, call.name)
@@ -894,7 +912,7 @@ def _tc84_eval(state: ScenarioState) -> ScenarioEvaluation:
         "search_slots": [
             c
             for c in tool_calls_by_name(state, "search_slots")
-            if c.arguments.get("date") == "2026-03-25"
+            if c.arguments.get("date") == _tc84_slot_date(state)
             and c.arguments.get("period") == "afternoon"
             and c.arguments.get("duration_minutes") == 45
             and result_is_usable_if_present(state, c)
@@ -936,14 +954,14 @@ def _tc84_eval(state: ScenarioState) -> ScenarioEvaluation:
     booking_ok = (
         isinstance(attendee_values, list)
         and len(attendee_values) == 2
-        and booking.arguments.get("date") == "2026-03-25"
+        and booking.arguments.get("date") == _tc84_slot_date(state)
         and booking.arguments.get("time") == "14:00"
         and booking.arguments.get("duration_minutes") == 45
         and attendee_set == {"elena@company.com", "ravi@company.com"}
     )
     failed_attendees = failure.arguments.get("attendees")
     failure_ok = (
-        failure.arguments.get("date") == "2026-03-25"
+        failure.arguments.get("date") == _tc84_slot_date(state)
         and failure.arguments.get("time") == "14:00"
         and failure.arguments.get("duration_minutes") == 45
         and isinstance(failed_attendees, list)

--- a/tests/test_reference_date_evaluators.py
+++ b/tests/test_reference_date_evaluators.py
@@ -1,0 +1,281 @@
+"""``--reference-date`` must reach the evaluators, not just the prompt.
+
+The system prompt tells the model what "today" is, and the orchestrator puts the
+same date in ``ScenarioState.meta``.  Every scenario whose prompt says "tomorrow"
+or "next Tuesday" has to derive its expected date from there.  When it hard-codes
+one instead, the flag grades a correct answer against a date the model was never
+given, which is a deterministic false negative rather than a flaky one.
+
+Each scenario below is run against two reference dates: the benchmark default and
+a mid-August date that lands on a different weekday and inside EU summer time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import make_state
+from tool_eval_bench.domain.scenarios import ScenarioState, ScenarioStatus, ToolCallRecord
+from tool_eval_bench.evals.scenarios import ALL_SCENARIOS_WITH_HARDMODE
+
+# (reference date, expected target date per scenario).  Written out rather than
+# derived so a wrong helper cannot agree with a wrong test.
+MARCH = "2026-03-20"  # Friday, winter time
+AUGUST = "2026-08-19"  # Wednesday, summer time
+
+EXPECTED: dict[str, dict[str, str]] = {
+    "TC-05": {MARCH: "2026-03-23", AUGUST: "2026-08-24"},  # next Monday
+    "TC-08": {MARCH: "2026-03-21", AUGUST: "2026-08-20"},  # tomorrow
+    "TC-17": {MARCH: "2026-03-24", AUGUST: "2026-08-25"},  # next Tuesday
+    "TC-74": {MARCH: "2026-03-25", AUGUST: "2026-08-26"},  # next Tuesday, moved to Wednesday
+    "TC-79": {MARCH: "2026-03-21", AUGUST: "2026-08-20"},  # tomorrow
+    "TC-84": {MARCH: "2026-03-25", AUGUST: "2026-08-26"},  # next Wednesday
+}
+
+REFERENCES = [MARCH, AUGUST]
+
+
+def _scenario(sid: str):
+    return next(s for s in ALL_SCENARIOS_WITH_HARDMODE if s.id == sid)
+
+
+def _other_date(sid: str, reference: str) -> str:
+    """The date this scenario expects under the *other* reference date.
+
+    A plausible-but-wrong date, which is what a hard-coded evaluator produces.
+    """
+    return next(v for k, v in EXPECTED[sid].items() if k != reference)
+
+
+def _simulated(sid: str, reference: str, calls: list[tuple[str, dict, int]]) -> ScenarioState:
+    """Replay ``calls`` through the scenario's own tool simulator."""
+    scenario = _scenario(sid)
+    state = ScenarioState()
+    state.meta["reference_date"] = reference
+    for name, args, turn in calls:
+        call = ToolCallRecord(f"{name}_{turn}", name, str(args), args, turn)
+        scenario.handle_tool_call(state, call)
+        state.tool_calls.append(call)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Single-call scenarios
+# ---------------------------------------------------------------------------
+
+
+def _tc05_calls(date: str) -> list[dict]:
+    return [
+        {
+            "name": "create_calendar_event",
+            "arguments": {
+                "title": "Team Standup",
+                "date": date,
+                "time": "09:30",
+                "duration_minutes": 30,
+                "attendees": ["alex@company.com", "jamie@company.com"],
+            },
+            "turn": 1,
+        }
+    ]
+
+
+def _tc08_calls(date: str) -> list[dict]:
+    return [
+        {"name": "get_weather", "arguments": {"location": "Paris"}, "turn": 1},
+        {
+            "name": "set_reminder",
+            "arguments": {"message": "Bring an umbrella", "datetime": f"{date}T08:00:00"},
+            "turn": 2,
+        },
+    ]
+
+
+def _tc17_calls(date: str, timezone: str = "Europe/Berlin") -> list[dict]:
+    return [
+        {
+            "name": "create_calendar_event",
+            "arguments": {
+                "title": "Team Standup",
+                "date": date,
+                "time": "14:00",
+                "timezone": timezone,
+            },
+            "turn": 1,
+        }
+    ]
+
+
+@pytest.mark.parametrize("reference", REFERENCES)
+@pytest.mark.parametrize(("sid", "builder"), [("TC-05", _tc05_calls), ("TC-08", _tc08_calls)])
+def test_relative_date_scenarios_follow_the_reference_date(sid, builder, reference):
+    expected = EXPECTED[sid][reference]
+    scenario = _scenario(sid)
+
+    right = make_state(tool_calls=builder(expected), meta={"reference_date": reference})
+    assert scenario.evaluate(right).status == ScenarioStatus.PASS
+
+    wrong = make_state(
+        tool_calls=builder(_other_date(sid, reference)), meta={"reference_date": reference}
+    )
+    assert scenario.evaluate(wrong).status != ScenarioStatus.PASS
+
+
+@pytest.mark.parametrize("reference", REFERENCES)
+def test_tc17_follows_the_reference_date(reference):
+    expected = EXPECTED["TC-17"][reference]
+    scenario = _scenario("TC-17")
+
+    right = make_state(tool_calls=_tc17_calls(expected), meta={"reference_date": reference})
+    assert scenario.evaluate(right).status == ScenarioStatus.PASS
+
+    wrong = make_state(
+        tool_calls=_tc17_calls(_other_date("TC-17", reference)),
+        meta={"reference_date": reference},
+    )
+    assert scenario.evaluate(wrong).status != ScenarioStatus.PASS
+
+
+@pytest.mark.parametrize(
+    ("reference", "accepted", "rejected"),
+    [(MARCH, "CET", "CEST"), (AUGUST, "CEST", "CET")],
+)
+def test_tc17_offset_alias_tracks_summer_time(reference, accepted, rejected):
+    """ "CET" is only a synonym for Europe/Berlin outside summer time."""
+    scenario = _scenario("TC-17")
+    expected = EXPECTED["TC-17"][reference]
+
+    ok = make_state(tool_calls=_tc17_calls(expected, accepted), meta={"reference_date": reference})
+    assert scenario.evaluate(ok).status == ScenarioStatus.PASS
+
+    off = make_state(tool_calls=_tc17_calls(expected, rejected), meta={"reference_date": reference})
+    assert scenario.evaluate(off).status == ScenarioStatus.PARTIAL
+
+
+# ---------------------------------------------------------------------------
+# Multi-step scenarios
+# ---------------------------------------------------------------------------
+
+
+def _tc74_calls(date: str) -> list[dict]:
+    return [
+        {"name": "get_contacts", "arguments": {"query": "Sarah"}, "turn": 1},
+        {
+            "name": "create_calendar_event",
+            "arguments": {
+                "title": "Product Review",
+                "date": date,
+                "time": "14:00",
+                "duration_minutes": 45,
+                "attendees": ["mark.chen@company.com", "sarah.jones@company.com"],
+            },
+            "turn": 2,
+        },
+        {
+            "name": "send_email",
+            "arguments": {
+                "to": "mark.chen@company.com,sarah.jones@company.com",
+                "subject": "Confirmed",
+                "body": "Product Review.",
+            },
+            "turn": 3,
+        },
+    ]
+
+
+@pytest.mark.parametrize("reference", REFERENCES)
+def test_tc74_correction_date_follows_the_reference_date(reference):
+    """The third follow-up moves the event to the day after "next Tuesday"."""
+    scenario = _scenario("TC-74")
+    expected = EXPECTED["TC-74"][reference]
+
+    def evaluate(date: str):
+        calls = _tc74_calls(date)
+        for call in calls:
+            call["user_phase"] = 4
+        return scenario.evaluate(make_state(tool_calls=calls, meta={"reference_date": reference}))
+
+    assert evaluate(expected).status == ScenarioStatus.PASS
+    assert evaluate(_other_date("TC-74", reference)).status != ScenarioStatus.PASS
+
+
+def _tc79_calls(date: str) -> list[tuple[str, dict, int]]:
+    return [
+        ("get_weather", {"location": "Lisbon"}, 1),
+        ("get_contacts", {"query": "Priya Shah"}, 2),
+        (
+            "create_calendar_event",
+            {
+                "title": "Outdoor review",
+                "date": date,
+                "time": "09:00",
+                "timezone": "Europe/Lisbon",
+                "duration_minutes": 30,
+                "attendees": ["priya.shah@company.com"],
+            },
+            3,
+        ),
+    ]
+
+
+@pytest.mark.parametrize("reference", REFERENCES)
+def test_tc79_follows_the_reference_date(reference):
+    scenario = _scenario("TC-79")
+    expected = EXPECTED["TC-79"][reference]
+
+    right = _simulated("TC-79", reference, _tc79_calls(expected))
+    assert scenario.evaluate(right).status == ScenarioStatus.PASS
+
+    wrong = _simulated("TC-79", reference, _tc79_calls(_other_date("TC-79", reference)))
+    assert scenario.evaluate(wrong).status != ScenarioStatus.PASS
+
+
+def _tc84_calls(date: str) -> list[tuple[str, dict, int]]:
+    attendees = ["elena@company.com", "ravi@company.com"]
+    booking = {"date": date, "time": "14:00", "duration_minutes": 45, "attendees": attendees}
+    return [
+        ("get_contacts", {"query": "Elena and Ravi"}, 1),
+        ("search_slots", {"date": date, "period": "afternoon", "duration_minutes": 45}, 2),
+        ("search_rooms", {"office": "Berlin", "minimum_capacity": 3}, 3),
+        ("search_files", {"query": "agenda"}, 4),
+        ("book_room", {"room_id": "berlin_3a", **booking}, 5),
+        ("book_room", {"room_id": "berlin_5b", **booking}, 6),
+        (
+            "send_email",
+            {
+                "to": "elena@company.com,ravi@company.com",
+                "subject": "Review booked",
+                "body": "Booked.",
+                "attachments": ["agenda_q2"],
+            },
+            7,
+        ),
+    ]
+
+
+@pytest.mark.parametrize("reference", REFERENCES)
+def test_tc84_follows_the_reference_date(reference):
+    scenario = _scenario("TC-84")
+    expected = EXPECTED["TC-84"][reference]
+
+    right = _simulated("TC-84", reference, _tc84_calls(expected))
+    assert scenario.evaluate(right).status == ScenarioStatus.PASS
+
+    wrong = _simulated("TC-84", reference, _tc84_calls(_other_date("TC-84", reference)))
+    assert scenario.evaluate(wrong).status != ScenarioStatus.PASS
+
+
+@pytest.mark.parametrize("reference", REFERENCES)
+def test_tc84_simulator_offers_the_date_the_prompt_asked_for(reference):
+    """The slot the simulator returns has to match the date the evaluator wants.
+
+    Before the fix the simulator always offered 2026-03-25, so under any other
+    reference date it handed the model a slot that could not score.
+    """
+    scenario = _scenario("TC-84")
+    state = ScenarioState()
+    state.meta["reference_date"] = reference
+    call = ToolCallRecord("search_slots_1", "search_slots", "{}", {}, 1)
+    payload = scenario.handle_tool_call(state, call)
+
+    assert payload["slots"][0]["date"] == EXPECTED["TC-84"][reference]


### PR DESCRIPTION
## Problem

`--reference-date` reached the model through the system prompt and reached the evaluator through `ScenarioState.meta`, but only two evaluators in the codebase read it back. Six scenarios whose prompts say "tomorrow" or "next Tuesday" graded against hard-coded March 2026 dates, so a model that correctly parsed the date it was actually given scored FAIL. The flag was advertised and silently broken for exactly the scenarios it exists to serve.

Reported in #78 with reproductions for TC-05, TC-08, and TC-84, and a follow-up audit covering TC-17, TC-74, and TC-79.

## What changed

TC-05, TC-08, TC-17, TC-74, TC-79, and TC-84 now derive their expected dates from three shared helpers in `evals/helpers.py`:

- `reference_date` resolves the effective date, falling back to `BENCHMARK_REFERENCE_DATE`.
- `next_weekday_after_reference` resolves "next Monday" as the strictly-following occurrence, never the same day, and takes an `offset` for prompts that name a weekday and then move the event.
- `days_after_reference` covers "tomorrow".

Two fixtures were part of the same defect and are fixed here rather than left for a follow-up:

- **TC-84's simulator** always offered a slot on 2026-03-25, handing the model a date that contradicted its own prompt. It now offers the date the prompt asked for.
- **TC-17** accepted `CET` as a synonym for `Europe/Berlin` year-round, which is wrong for any reference date inside EU summer time. The accepted offset spellings now come from the target date.

The two display-detail strings that quoted a fixed date now describe it relatively, so `--reference-date` no longer leaves a stale date in a report.

## Verification

16 new tests in `tests/test_reference_date_evaluators.py` cover all six scenarios across two reference dates, one in winter and one in summer, asserting that the correct relative date passes and a plausible wrong one does not. Expected dates are written out rather than derived, so a wrong helper cannot agree with a wrong test.

Eight of the sixteen fail without this change, all of them the non-default date.

Full suite: 2849 passed, 1 skipped. `ruff check`, `ruff format --check`, and `mypy src` clean.

## Compatibility

Default runs grade exactly the dates they graded before: the derivation reproduces every previous constant on the default reference date.

Fixes #78

---

Written with AI assistance (Claude Code); reviewed and verified by me.