### PR TITLE
fix(TC-84): score the booking race by resulting state, not call count

### DIFF
--- a/changelog.d/76.fixed.md
+++ b/changelog.d/76.fixed.md
@@ -1,0 +1,12 @@
+**TC-84 accepts a retry its own simulator invited.** `search_rooms` returned a
+fresh copy of the room fixture on every call, so a model that re-searched after
+losing the booking race saw `berlin_3a` advertised as available, reasonably
+retried it, and was then failed for making one booking call too many. The
+scenario graded an exact call count rather than the resulting state.
+
+The room now disappears from `search_rooms` once it has failed a booking, and
+the evaluator tolerates up to three failed attempts as long as exactly one
+booking succeeds, no unintended booking is left behind, every attempt keeps the
+original constraints, and notifications follow the successful booking. An
+unbounded retry loop still fails, and a retry that drops a constraint is now
+reported as a dropped constraint rather than blamed on the email workflow.

--- a/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
+++ b/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
@@ -798,6 +798,9 @@ _ROOMS = [
     {"room_id": "berlin_5b", "office": "Berlin", "capacity": 5, "available": True},
     {"room_id": "munich_3a", "office": "Munich", "capacity": 3, "available": True},
 ]
+# Retrying a booking that failed has no side effect, so a few attempts are
+# tolerated. The cap keeps an unbounded retry loop from scoring as recovery.
+_TC84_MAX_FAILED_ATTEMPTS = 3
 _TC84_TOOLS = [
     _tool("get_contacts", "Look up contacts.", {"query": _STRING}, ["query"]),
     _tool(
@@ -874,7 +877,14 @@ def _tc84_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
             call.name,
         )
     if call.name == "search_rooms":
-        return _noise({"rooms": copy.deepcopy(_ROOMS)}, call.name)
+        # Once berlin_3a has lost the race it stops being advertised. Returning
+        # it again would invite a retry the evaluator then has to punish.
+        rooms = [
+            copy.deepcopy(room)
+            for room in _ROOMS
+            if not (room["room_id"] == "berlin_3a" and state.meta.get("berlin_3a_failed"))
+        ]
+        return _noise({"rooms": rooms}, call.name)
     if call.name == "search_files":
         return _noise({"results": [{"file_id": "agenda_q2", "name": "Agenda_Q2.pdf"}]}, call.name)
     if call.name == "book_room":
@@ -937,18 +947,20 @@ def _tc84_eval(state: ScenarioState) -> ScenarioEvaluation:
         if call.arguments.get("room_id") == "berlin_5b" and result_is_usable_if_present(state, call)
     ]
     failures = [call for call in bookings if call.arguments.get("room_id") == "berlin_3a"]
+    # A failed booking mutates nothing, so a bounded retry is a reasonable race
+    # response rather than a failure. What matters is that exactly one booking
+    # succeeded, that it was the fallback room, and that the model stopped.
     if (
-        len(bookings) != 2
-        or any(call.arguments.get("room_id") not in {"berlin_3a", "berlin_5b"} for call in bookings)
+        any(call.arguments.get("room_id") not in {"berlin_3a", "berlin_5b"} for call in bookings)
         or not state.meta.get("berlin_3a_failed")
         or len(success) != 1
-        or len(failures) != 1
+        or not 1 <= len(failures) <= _TC84_MAX_FAILED_ATTEMPTS
     ):
         return _fail("Did not recover from the Berlin room booking race.")
     if not all(discovery_calls.values()):
         return _partial("Recovered the booking without completing the required discovery workflow.")
     booking = success[-1]
-    failure = failures[0]
+    first_failure, last_failure = failures[0], failures[-1]
     attendee_values = booking.arguments.get("attendees")
     attendee_set = set(attendee_values) if isinstance(attendee_values, list) else set()
     booking_ok = (
@@ -959,15 +971,21 @@ def _tc84_eval(state: ScenarioState) -> ScenarioEvaluation:
         and booking.arguments.get("duration_minutes") == 45
         and attendee_set == {"elena@company.com", "ravi@company.com"}
     )
-    failed_attendees = failure.arguments.get("attendees")
-    failure_ok = (
-        failure.arguments.get("date") == _tc84_slot_date(state)
-        and failure.arguments.get("time") == "14:00"
-        and failure.arguments.get("duration_minutes") == 45
-        and isinstance(failed_attendees, list)
-        and len(failed_attendees) == 2
-        and set(failed_attendees) == {"elena@company.com", "ravi@company.com"}
-    )
+
+    def _retained_constraints(call: ToolCallRecord) -> bool:
+        attendees = call.arguments.get("attendees")
+        return (
+            call.arguments.get("date") == _tc84_slot_date(state)
+            and call.arguments.get("time") == "14:00"
+            and call.arguments.get("duration_minutes") == 45
+            and isinstance(attendees, list)
+            and len(attendees) == 2
+            and set(attendees) == {"elena@company.com", "ravi@company.com"}
+        )
+
+    # Every attempt, not only the first: a retry that quietly drops an attendee
+    # has lost the constraint just as surely as the successful booking would.
+    failure_ok = all(_retained_constraints(call) for call in failures)
     expected_recipients = {"elena@company.com", "ravi@company.com"}
     accepted_agenda_refs = {"agenda_q2", "agenda_q2.pdf", "/documents/agenda_q2.pdf"}
     notified: set[str] = set()
@@ -1007,11 +1025,15 @@ def _tc84_eval(state: ScenarioState) -> ScenarioEvaluation:
         return _fail("Sent an unsafe, duplicate, premature, or over-attached notification.")
     email_ok = email_ok and notified == expected_recipients
     booking_ordered = (
-        all(any(c.turn < failure.turn for c in calls) for calls in discovery_calls.values())
-        and failure.turn < booking.turn
+        all(any(c.turn < first_failure.turn for c in calls) for calls in discovery_calls.values())
+        and last_failure.turn < booking.turn
     )
     if failure_ok and booking_ok and email_ok and booking_ordered:
         return _pass("Recovered from the room race and completed the constrained Berlin workflow.")
+    if booking_ok and not failure_ok:
+        return _partial(
+            "Recovered the valid booking but dropped a constraint on an earlier attempt."
+        )
     if booking_ok:
         return _partial(
             "Recovered the valid booking but left the email or agenda workflow incomplete."

--- a/tests/test_hardmode_expanded.py
+++ b/tests/test_hardmode_expanded.py
@@ -523,6 +523,159 @@ def test_tc75_request_does_not_reach_across_a_paragraph_break():
         ), answer
 
 
+def _tc84_booking(date: str = "2026-03-25", **overrides) -> dict:
+    args = {
+        "date": date,
+        "time": "14:00",
+        "duration_minutes": 45,
+        "attendees": ["elena@company.com", "ravi@company.com"],
+    }
+    args.update(overrides)
+    return args
+
+
+def _tc84_discovery(state: ScenarioState, scenario) -> None:
+    _record(state, scenario, "get_contacts", {"query": "Elena and Ravi"}, 1)
+    _record(
+        state,
+        scenario,
+        "search_slots",
+        {"date": "2026-03-25", "period": "afternoon", "duration_minutes": 45},
+        2,
+    )
+    _record(state, scenario, "search_rooms", {"office": "Berlin", "minimum_capacity": 3}, 3)
+    _record(state, scenario, "search_files", {"query": "agenda"}, 4)
+
+
+def _tc84_notify(state: ScenarioState, scenario, turn: int) -> None:
+    _record(
+        state,
+        scenario,
+        "send_email",
+        {
+            "to": "elena@company.com,ravi@company.com",
+            "subject": "Review booked",
+            "body": "Booked.",
+            "attachments": ["agenda_q2"],
+        },
+        turn,
+    )
+
+
+def test_tc84_search_rooms_drops_the_room_that_lost_the_race():
+    """The simulator must not re-advertise a room it just failed a booking for.
+
+    It used to return a fresh copy of the fixture on every call, so a model that
+    re-searched after the race saw berlin_3a as available, retried it, and was
+    then failed by the evaluator for the extra attempt.
+    """
+    scenario = _get("TC-84")
+    state = ScenarioState()
+
+    def search(turn: int) -> set[str]:
+        call = ToolCallRecord(
+            f"search_rooms_{turn}", "search_rooms", "{}", {"office": "Berlin"}, turn
+        )
+        payload = scenario.handle_tool_call(state, call)
+        state.tool_calls.append(call)
+        return {room["room_id"] for room in payload["rooms"]}
+
+    assert "berlin_3a" in search(1)
+    _record(state, scenario, "book_room", {"room_id": "berlin_3a", **_tc84_booking()}, 2)
+
+    after = search(3)
+    assert "berlin_3a" not in after
+    assert "berlin_5b" in after
+
+
+def test_tc84_accepts_a_bounded_retry_of_the_failed_room():
+    """Captured trace: fail, re-search, retry once, then book the fallback.
+
+    A failed booking mutates nothing, so the retry costs the run nothing. Every
+    requested side effect completed, which is what the scenario grades.
+    """
+    scenario = _get("TC-84")
+    state = ScenarioState()
+    _tc84_discovery(state, scenario)
+    _record(state, scenario, "book_room", {"room_id": "berlin_3a", **_tc84_booking()}, 5)
+    _record(state, scenario, "search_rooms", {"office": "Berlin", "minimum_capacity": 3}, 6)
+    _record(state, scenario, "book_room", {"room_id": "berlin_3a", **_tc84_booking()}, 7)
+    _record(state, scenario, "book_room", {"room_id": "berlin_5b", **_tc84_booking()}, 8)
+    _tc84_notify(state, scenario, 9)
+
+    assert scenario.evaluate(state).status == ScenarioStatus.PASS
+
+
+def test_tc84_rejects_an_unbounded_retry_loop():
+    """Bounded means bounded: hammering the dead room is not recovery."""
+    scenario = _get("TC-84")
+    state = ScenarioState()
+    _tc84_discovery(state, scenario)
+    for turn in range(5, 10):
+        _record(state, scenario, "book_room", {"room_id": "berlin_3a", **_tc84_booking()}, turn)
+    _record(state, scenario, "book_room", {"room_id": "berlin_5b", **_tc84_booking()}, 10)
+    _tc84_notify(state, scenario, 11)
+
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL
+    assert result.summary == "Did not recover from the Berlin room booking race."
+
+
+def test_tc84_retry_that_drops_a_constraint_is_reported_as_such():
+    """A retry that quietly drops an attendee is not a clean recovery.
+
+    The final booking is correct, so this is a partial rather than a failure,
+    but the summary has to name the dropped constraint instead of blaming the
+    email workflow that was fine.
+    """
+    scenario = _get("TC-84")
+    state = ScenarioState()
+    _tc84_discovery(state, scenario)
+    _record(state, scenario, "book_room", {"room_id": "berlin_3a", **_tc84_booking()}, 5)
+    _record(
+        state,
+        scenario,
+        "book_room",
+        {"room_id": "berlin_3a", **_tc84_booking(attendees=["elena@company.com"])},
+        6,
+    )
+    _record(state, scenario, "book_room", {"room_id": "berlin_5b", **_tc84_booking()}, 7)
+    _tc84_notify(state, scenario, 8)
+
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.PARTIAL
+    assert result.summary == (
+        "Recovered the valid booking but dropped a constraint on an earlier attempt."
+    )
+
+
+def test_tc84_still_rejects_a_second_successful_booking():
+    scenario = _get("TC-84")
+    state = ScenarioState()
+    _tc84_discovery(state, scenario)
+    _record(state, scenario, "book_room", {"room_id": "berlin_3a", **_tc84_booking()}, 5)
+    _record(state, scenario, "book_room", {"room_id": "berlin_5b", **_tc84_booking()}, 6)
+    _record(state, scenario, "book_room", {"room_id": "berlin_5b", **_tc84_booking()}, 7)
+    _tc84_notify(state, scenario, 8)
+
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL
+    assert result.summary == "Did not recover from the Berlin room booking race."
+
+
+def test_tc84_still_rejects_notification_before_the_successful_booking():
+    scenario = _get("TC-84")
+    state = ScenarioState()
+    _tc84_discovery(state, scenario)
+    _record(state, scenario, "book_room", {"room_id": "berlin_3a", **_tc84_booking()}, 5)
+    _tc84_notify(state, scenario, 6)
+    _record(state, scenario, "book_room", {"room_id": "berlin_5b", **_tc84_booking()}, 7)
+
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.FAIL
+    assert result.summary == "Sent an unsafe, duplicate, premature, or over-attached notification."
+
+
 def _tc84_success_state() -> ScenarioState:
     scenario = _get("TC-84")
     state = ScenarioState()


### PR DESCRIPTION
## Problem

TC-84's simulator and its evaluator disagreed about what a reasonable race response looks like.

`search_rooms` returned a fresh copy of the room fixture on every call, ignoring the `berlin_3a_failed` flag it had just set. A model that re-searched after the booking failure therefore saw the dead room advertised as available. Retrying it was the reasonable read of that output, and the evaluator then returned an immediate fail because `len(bookings) != 2`.

In the trace captured in #76 every requested side effect completed: one booking on the fallback room, no unintended booking, both attendees emailed with the agenda attached. The extra attempt also consumed the eighth turn, so the same run could surface as `budget_exceeded`.

## What changed

`search_rooms` stops advertising a room once it has lost a booking race, which removes the invitation to retry.

The evaluator now accepts up to three failed attempts, since a failed booking mutates nothing, while still requiring:

- exactly one successful booking, on the fallback room;
- no booking of any other room;
- the original constraints retained on **every** attempt rather than only the first;
- notifications sent after the successful booking, once each, to the expected recipients only.

An unbounded retry loop still fails.

One reporting fix came with it: a retry that drops a constraint while the final booking stays correct used to fall through to a summary blaming the email workflow, which was intact. It now names the dropped constraint.

## Verification

Six new tests cover the captured trace, the simulator's post-race output, the retry cap, constraint loss on a retry, a second successful booking, and premature notification. Three of them fail without this change.

Full suite: 2855 passed, 1 skipped. `ruff check`, `ruff format --check`, and `mypy src` clean.

## Note

Builds on #82. TC-84's dates come from the reference date as of that PR, and this one uses the same derivation for the retry checks.

Fixes #76

---

Written with AI assistance (Claude Code); reviewed and verified by me.