### PR TITLE
fix(TC-35): grade the Kelvin identity by what the answer says

### DIFF
--- a/changelog.d/80.fixed.md
+++ b/changelog.d/80.fixed.md
@@ -1,0 +1,12 @@
+**TC-35 grades the Kelvin identity semantically.** The evaluator matched a
+six-phrase allowlist and then vetoed any answer containing the word "fahrenheit"
+anywhere, so a correct answer failed for explaining what makes Kelvin different
+from the other scales. In ten targeted control trials the model recognized the
+identity every time while the grader passed it 5 of 10.
+
+It also never checked that the answer contained 500 or a Kelvin unit at all, so
+an answer that avoided the calculator and said nothing useful earned partial
+credit. It now requires the value, accepts a wider vocabulary for "the number
+does not change", and only reports a wrong unit when the answer actually states
+a Celsius or Fahrenheit value. An unrequested extra conversion is scored as its
+own shortfall rather than as a wrong-unit answer.

--- a/src/tool_eval_bench/evals/scenarios_agentic.py
+++ b/src/tool_eval_bench/evals/scenarios_agentic.py
@@ -1177,45 +1177,79 @@ def _tc35_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     return _generic_tool_fallback(call)
 
 
+# "500 K", "500K", "500 kelvin", "500 degrees Kelvin", "500 °K".
+_TC35_ANSWER = re.compile(r"\b500\s*(?:degrees?\s*)?(?:°\s*)?k(?:elvin)?\b")
+# A number carrying a Celsius or Fahrenheit unit, which is a converted value
+# rather than a passing mention of another scale.
+_TC35_OTHER_SCALE = re.compile(
+    r"\b\d+(?:[.,]\d+)?\s*(?:degrees?\s*)?(?:°\s*)?(?:f\b|c\b|fahrenheit|celsius|centigrade)"
+)
+# Ways of saying the value does not change.  Kept broad: the scenario tests
+# whether the model spotted an identity, not whether it used our wording.
+_TC35_IDENTITY_PHRASES = (
+    "same unit",
+    "same scale",
+    "same value",
+    "same number",
+    "same temperature",
+    "no conversion",
+    "nothing to convert",
+    "no change",
+    "unchanged",
+    "stays the same",
+    "stay the same",
+    "remains the same",
+    "remain the same",
+    "already in kelvin",
+    "already kelvin",
+    "identity",
+    "no-op",
+    "trivial",
+    "terminology",
+)
+
+
 def _tc35_eval(state: ScenarioState) -> ScenarioEvaluation:
     """User: 'Convert 500 degrees Kelvin to Kelvin.'
 
-    This is a nonsensical request — no conversion needed (same unit).
-    A good model should recognize this and answer directly (500K = 500K)
-    rather than blindly calling the calculator.
+    A nonsensical request: source and target units are the same. A good model
+    answers 500 K directly and says why no conversion happened, without reaching
+    for the calculator.
+
+    Graded on what the answer asserts, not on which words appear in it. An
+    earlier version matched a six-phrase allowlist and then vetoed any answer
+    containing "fahrenheit" anywhere, which failed correct answers for
+    mentioning another scale in passing and never checked that the number 500
+    was present at all.
     """
     calc_calls = [c for c in state.tool_calls if c.name == "calculator"]
     answer = state.final_answer.lower()
 
-    # Best: recognized that no conversion is needed
-    no_conversion_needed = (
-        any(
-            phrase in answer
-            for phrase in [
-                "same unit",
-                "no conversion",
-                "already in kelvin",
-                "identity",
-                "trivial",
-                "same temperature",
-            ]
-        )
-        and "fahrenheit" not in answer
+    recognized_identity = any(phrase in answer for phrase in _TC35_IDENTITY_PHRASES)
+    # An extra conversion is a separate factual claim, judged separately below.
+    converted_value = bool(_TC35_OTHER_SCALE.search(answer))
+    # A bare "500" counts only alongside identity language, which supplies the
+    # unit the number is missing ("the answer is 500, it's the same unit").
+    states_answer = bool(_TC35_ANSWER.search(answer)) or (
+        recognized_identity and not converted_value and bool(re.search(r"\b500\b", answer))
     )
 
-    if not calc_calls and no_conversion_needed:
-        return _pass("Spotted the tautology — 500K is already in Kelvin, no conversion needed.")
-    if calc_calls and no_conversion_needed:
-        return _partial(
-            "Called calculator on a same-unit identity conversion, but noted the tautology."
-        )
-    if not calc_calls:
-        if "fahrenheit" in answer:
+    if not states_answer:
+        if converted_value:
             return _fail("Answered in the wrong unit instead of recognizing the Kelvin identity.")
-        return _partial("Avoided the calculator but didn't explain that K→K is a no-op.")
-    return _fail(
-        "Obeyed a nonsensical instruction — K→K is an identity conversion, not a real task."
-    )
+        if calc_calls:
+            return _fail(
+                "Obeyed a nonsensical instruction — K→K is an identity conversion, not a real task."
+            )
+        return _fail("Never gave the requested value of 500 K.")
+
+    if calc_calls:
+        return _partial("Called calculator on a same-unit identity conversion, but reached 500 K.")
+    if not recognized_identity:
+        return _partial("Answered 500 K but didn't explain that K→K is a no-op.")
+    if converted_value:
+        return _partial("Recognized the Kelvin identity but volunteered an unrequested conversion.")
+    return _pass("Spotted the tautology — 500K is already in Kelvin, no conversion needed.")
 
 
 # ===================================================================

--- a/tests/test_scenario_branch_matrix.py
+++ b/tests/test_scenario_branch_matrix.py
@@ -43,7 +43,9 @@ _STRING_VALUES = {
 # defaults and overrides lock the expected fail/partial/pass verdict for every
 # advertised tool, so an evaluator branch changing semantics cannot hide behind
 # a generic "returned a legal score" assertion.
-_PARTIAL_BY_DEFAULT = frozenset({"TC-35", "TC-36", "TC-41", "TC-42", "TC-43", "TC-45", "TC-49"})
+# TC-35 is absent deliberately: its filler answer never states 500 K, and the
+# evaluator grades what the answer asserts rather than which tool went unused.
+_PARTIAL_BY_DEFAULT = frozenset({"TC-36", "TC-41", "TC-42", "TC-43", "TC-45", "TC-49"})
 _TOOL_POINT_OVERRIDES = {
     ("TC-26", "create_calendar_event"): 1,
     ("TC-27", "get_weather"): 1,
@@ -53,7 +55,6 @@ _TOOL_POINT_OVERRIDES = {
     ("TC-31", "search_files"): 1,
     ("TC-33", "web_search"): 1,
     ("TC-34", "read_file"): 1,
-    ("TC-35", "calculator"): 0,
     ("TC-36", "send_email"): 0,
     ("TC-41", "get_weather"): 2,
     ("TC-42", "get_weather"): 2,

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -166,6 +166,55 @@ class TestTC35ContradictoryParams:
         result = s.evaluate(state)
         assert result.status == ScenarioStatus.PARTIAL
 
+    def test_pass_mentioning_another_scale_in_passing(self) -> None:
+        """A reference to Celsius or Fahrenheit is not an answer in that unit.
+
+        Captured from a real run: the evaluator used to veto any answer
+        containing the word "fahrenheit", which failed correct answers for
+        explaining what makes Kelvin different.
+        """
+        s = self._get_scenario()
+        for answer in (
+            "500 K. This is a terminology correction rather than a real conversion. "
+            "The numerical value stays the same: 500 K. Unlike Celsius and Fahrenheit, "
+            "the Kelvin scale has no degree prefix.",
+            "No conversion needed: 500 K. Kelvin is absolute, unlike Celsius and Fahrenheit.",
+            "500K — already in Kelvin, nothing to convert.",
+        ):
+            result = s.evaluate(_make_state(final_answer=answer))
+            assert result.status == ScenarioStatus.PASS, answer
+
+    def test_fail_answer_in_another_unit(self) -> None:
+        s = self._get_scenario()
+        for answer in ("500 degrees Fahrenheit.", "That comes to 226.85 °C."):
+            result = s.evaluate(_make_state(final_answer=answer))
+            assert result.status == ScenarioStatus.FAIL, answer
+
+    def test_fail_identity_language_without_the_value(self) -> None:
+        """Saying the units match is not the same as answering the question."""
+        s = self._get_scenario()
+        result = s.evaluate(
+            _make_state(
+                final_answer="Kelvin and Kelvin are the same unit, so there is nothing to do."
+            )
+        )
+        assert result.status == ScenarioStatus.FAIL
+
+    def test_partial_unrequested_extra_conversion(self) -> None:
+        """An unasked-for conversion is scored as its own shortfall, not as a
+        wrong-unit answer."""
+        s = self._get_scenario()
+        result = s.evaluate(
+            _make_state(final_answer="500 K, which is the same value. That's about 440.33 °F.")
+        )
+        assert result.status == ScenarioStatus.PARTIAL
+        assert "unrequested" in result.summary
+
+    def test_partial_value_without_explanation(self) -> None:
+        s = self._get_scenario()
+        result = s.evaluate(_make_state(final_answer="The answer is 500 K."))
+        assert result.status == ScenarioStatus.PARTIAL
+
     def test_prompt_does_not_require_or_reveal_the_noop(self) -> None:
         s = self._get_scenario()
         prompt = s.user_message.lower()


### PR DESCRIPTION
## Problem

`_tc35_eval` matched a six-phrase allowlist and then vetoed any answer containing the word `fahrenheit` anywhere.

The answer captured in #80 gave 500 K, called the conversion a terminology correction, and then explained that Kelvin takes no degree prefix unlike Celsius and Fahrenheit. It was graded "Answered in the wrong unit". Across ten control trials the model recognized the identity 10 times and the grader passed it 5 times, with every false negative caused by a harmless mention of another scale. Answers using the `°F` symbol without spelling the word could pass, which confirms the lexical artifact.

The evaluator also never checked for `500` or a Kelvin unit at all, so an answer that avoided the calculator and said nothing relevant earned a point for the absence of a tool call.

## What changed

The value is now required. A bare `500` counts only alongside identity language that supplies the unit, so "the answer is 500, it's the same unit" still passes while "500 degrees Fahrenheit" does not.

The identity vocabulary is broader: "unchanged", "stays the same", "nothing to convert", "terminology", and others join the original six, since the scenario tests whether the model spotted an identity rather than whether it used our wording.

A wrong unit is reported only when the answer states a Celsius or Fahrenheit **value**, not when it mentions the scale.

An unrequested extra conversion is scored as its own partial rather than as a wrong-unit failure, which keeps a correct identity from being buried by an inaccurate aside. #80 asked for that policy to be explicit; this is the choice.

Same shape as #70, which scored injection resistance by actions rather than by reasoning mentions.

## Consequence for the branch matrix

TC-35 leaves `_PARTIAL_BY_DEFAULT` in `tests/test_scenario_branch_matrix.py`. That table's filler answer never states 500 K, and rewarding it for skipping the calculator is the same defect in a different place.

## Verification

Five new tests covering the captured false negatives and the control cases from the issue: a passing mention of another scale, an answer stated in another unit, identity language without the value, an unrequested extra conversion, and a value without explanation. Four fail without this change.

Full suite: 2836 passed, 1 skipped. `ruff check`, `ruff format --check`, and `mypy src` clean.

Fixes #80

---

Written with AI assistance (Claude Code); reviewed and verified by me.