### PR TITLE
fix(TC-80): accept a parallel event read and availability check

### DIFF
--- a/changelog.d/86.fixed.md
+++ b/changelog.d/86.fixed.md
@@ -1,0 +1,5 @@
+**TC-80 accepts a parallel read.** Reading the event and checking the target slot
+are independent, so a model that issued both in one turn and then correctly
+declined to mutate was failed for not ordering them. The scenario grades whether
+the decision to mutate follows both results, which a parallel read satisfies.
+Checking availability before ever reading the event still fails.

--- a/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
+++ b/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
@@ -540,7 +540,10 @@ def _tc80_eval(state: ScenarioState) -> ScenarioEvaluation:
         and availability.arguments.get("date") == "2026-03-27"
         and availability.arguments.get("time") == "15:00"
         and get_event is not None
-        and get_event.turn < availability.turn
+        # Same turn is fine: the two reads are independent, and the decision to
+        # mutate still comes after both results. Requiring a strict order would
+        # penalise the parallel tool calls TC-09 rewards.
+        and get_event.turn <= availability.turn
     )
     if (
         original

--- a/tests/test_hardmode_expanded.py
+++ b/tests/test_hardmode_expanded.py
@@ -870,6 +870,40 @@ def test_tc80_guessed_event_id_does_not_resolve() -> None:
     assert "attendees" not in payload
 
 
+def test_tc80_parallel_read_and_availability_check_passes() -> None:
+    """Reading the event and checking the slot are independent.
+
+    Captured from a real run: the model resolved the title, then issued
+    get_event and check_availability in the same turn, then correctly declined
+    to mutate. Requiring a strict turn order failed it for the parallelism
+    TC-09 exists to reward.
+    """
+    scenario = _get("TC-80")
+    state = ScenarioState(
+        final_answer="March 27 at 15:00 is unavailable, so I left the booking untouched.",
+        assistant_messages=["March 27 at 15:00 is unavailable, so I left the booking untouched."],
+    )
+    _record(state, scenario, "search_events", {"query": "release review"}, 1)
+    _record(state, scenario, "get_event", {"event_id": "release_review"}, 2)
+    _record(state, scenario, "check_availability", {"date": "2026-03-27", "time": "15:00"}, 2)
+
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.PASS
+
+
+def test_tc80_availability_check_before_the_read_still_fails() -> None:
+    """Checking the slot before ever reading the event is not the same thing."""
+    scenario = _get("TC-80")
+    state = ScenarioState(
+        final_answer="Unavailable; unchanged.", assistant_messages=["Unavailable; unchanged."]
+    )
+    _record(state, scenario, "search_events", {"query": "release review"}, 1)
+    _record(state, scenario, "check_availability", {"date": "2026-03-27", "time": "15:00"}, 2)
+    _record(state, scenario, "get_event", {"event_id": "release_review"}, 3)
+
+    assert scenario.evaluate(state).status == ScenarioStatus.FAIL
+
+
 def test_tc80_guessing_the_id_does_not_pass() -> None:
     """A lucky guess is not the safe behaviour the scenario is grading."""
     scenario = _get("TC-80")


### PR DESCRIPTION
## Problem

Follow-up to #85, found by re-running the suite rather than by reading code. TC-80 had two independent defects stacked, so fixing the missing resolver left the scenario still unpassable.

The evaluator required `get_event.turn < check_availability.turn`. This captured trace does everything the scenario asks for and still fails:

```
turn 1  search_events {"query": "release review"}
        -> {"results": [{"event_id": "release_review", ...}]}
turn 2  get_event {"event_id": "release_review"}          (parallel)
        check_availability {"date": "2026-03-27", "time": "15:00"}
        -> {"available": false, "reason": "conflict"}
turn 3  "I couldn't move the event ... I've left the original booking
         completely untouched. Attendees preserved: ana@, ben@"
```

Graded: `fail — Did not resolve and read the existing event, then check the exact requested time, before deciding.`

The two reads are independent, and the decision to mutate still comes after both results. Requiring a strict order penalises exactly the parallelism TC-09 rewards, and TC-09's own evaluator treats parallel calls as a bonus note rather than a requirement.

## What changed

Same turn is accepted. Checking availability before ever reading the event still fails, since that is a genuinely different sequence.

## Verification

Two tests: the captured parallel trace, which fails without this change, and a negative case that reverses the order. Full suite: 2865 passed, 1 skipped. `ruff check`, `ruff format --check`, and `mypy src` clean.

Confirmed against the live endpoint after merging: TC-80 goes from FAIL to PASS on the same trace.

---

Written with AI assistance (Claude Code); reviewed and verified by me.