### PR TITLE
fix(TC-83): stop penalising code-fenced JSON

### DIFF
--- a/changelog.d/+tc83-code-fence-scoring.fixed.md
+++ b/changelog.d/+tc83-code-fence-scoring.fixed.md
@@ -1,0 +1,6 @@
+**TC-83 no longer penalises code-fenced JSON** — the evaluator stripped a
+```` ```json ```` fence, confirmed every value was correct, and then withheld
+the pass solely because the fence was there. Every other JSON evaluator in the
+suite strips fences and scores the content, so the same output was graded as
+correct in Category N and incorrect in Category P. TC-83 grades the chained
+extraction; a markdown habit is not what it measures.

--- a/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
+++ b/src/tool_eval_bench/evals/scenarios_hardmode_expanded.py
@@ -804,6 +804,9 @@ def _tc83_eval(state: ScenarioState) -> ScenarioEvaluation:
     ]
     required_calls = bool(searches and reads and stocks and searches[0].turn < reads[0].turn)
     answer = state.final_answer.strip()
+    # A code fence is stripped and not penalised, matching every other JSON
+    # evaluator in the suite. This scenario grades the chained extraction, so
+    # scoring a markdown habit here would measure chat tuning instead.
     fenced = re.fullmatch(r"```(?:json)?\s*(.*?)\s*```", answer, re.DOTALL)
     if fenced:
         answer = fenced.group(1)
@@ -814,10 +817,10 @@ def _tc83_eval(state: ScenarioState) -> ScenarioEvaluation:
     if not required_calls or not isinstance(data, dict):
         return _fail("Missing required tool calls or JSON object output.")
     values_ok = all(data.get(key) == value for key, value in _TC83_EXPECTED.items())
-    if values_ok and set(data) == set(_TC83_EXPECTED) and not fenced:
+    if values_ok and set(data) == set(_TC83_EXPECTED):
         return _pass("Returned exact required JSON after the chained lookups.")
     if values_ok:
-        return _partial("Returned the correct values with extra keys or surrounding formatting.")
+        return _partial("Returned the correct values with extra keys.")
     return _fail("Mixed noisy metadata into the required JSON values.")
 
 

--- a/tests/test_hardmode_expanded.py
+++ b/tests/test_hardmode_expanded.py
@@ -334,6 +334,36 @@ def _record(state: ScenarioState, scenario, name: str, args: dict, turn: int = 1
                 ("read_file", {"file_id": "q2_revenue"}, 2),
                 ("get_stock_price", {"ticker": "ACME"}, 3),
             ],
+            '```json\n{"quarter":"Q2","revenue_usd":1250000,"ticker":"ACME","price_usd":100.0}\n```',
+            ScenarioStatus.PASS,
+        ),
+        (
+            "TC-83",
+            [
+                ("search_files", {"query": "Q2 revenue"}, 1),
+                ("read_file", {"file_id": "q2_revenue"}, 2),
+                ("get_stock_price", {"ticker": "ACME"}, 3),
+            ],
+            '```\n{"quarter":"Q2","revenue_usd":1250000,"ticker":"ACME","price_usd":100.0}\n```',
+            ScenarioStatus.PASS,
+        ),
+        (
+            "TC-83",
+            [
+                ("search_files", {"query": "Q2 revenue"}, 1),
+                ("read_file", {"file_id": "q2_revenue"}, 2),
+                ("get_stock_price", {"ticker": "ACME"}, 3),
+            ],
+            '```json\n{"quarter":"Q2","revenue_usd":74,"ticker":"ACME","price_usd":1.74}\n```',
+            ScenarioStatus.FAIL,
+        ),
+        (
+            "TC-83",
+            [
+                ("search_files", {"query": "Q2 revenue"}, 1),
+                ("read_file", {"file_id": "q2_revenue"}, 2),
+                ("get_stock_price", {"ticker": "ACME"}, 3),
+            ],
             '{"quarter":"Q2","revenue_usd":1250000,"ticker":"ACME","price_usd":100.0,"employee_count":74}',
             ScenarioStatus.PARTIAL,
         ),


### PR DESCRIPTION
## Problem

`_tc83_eval` stripped a ```` ```json ```` fence from the answer, parsed it, confirmed every extracted value was correct, and then withheld the pass anyway:

```python
if values_ok and set(data) == set(_TC83_EXPECTED) and not fenced:
    return _pass(...)
if values_ok:
    return _partial(...)
```

That `not fenced` clause has no counterpart anywhere else in the suite. The six JSON evaluators in `scenarios_structured.py` and the one in `scenarios_agentic.py` all strip fences and score the content, awarding a full pass. So the identical model output was graded correct in Category N and incorrect in Category P.

Under v2 binary scoring, partial is worth zero, which means a model that performed the entire chained extraction correctly scored the same as one that returned prose.

This matters beyond the single scenario: TC-83 is one of only six items that separate a strong model from a merely good one in the current three-model discrimination data, so a markdown habit was inflating the measured gap between top models.

## Solution

Drop the `not fenced` clause, bringing TC-83 in line with the other seven JSON evaluators. The scenario grades the chained extraction from noisy payloads, which is what its stated intent says it measures. Extra keys still cap the result at partial, and wrong values still fail.

Whether strict "only JSON" compliance deserves testing is a separate question. If it does, it wants its own scenario applied consistently across the suite rather than one clause in a single tier-5 item.

## Verification

- Added three regression cases to `test_expanded_contracts`: fenced-with-language and fenced-bare correct answers now pass, and a fenced answer with wrong values still fails.
- The existing unfenced pass, extra-keys partial, and wrong-values fail cases are unchanged.
- Full suite: 2892 passed, 1 skipped.

Written with AI assistance (Claude Code).