### PR TITLE
fix: catch TC-33 grouped monetary amounts in every spelling (#100)

### DIFF
--- a/changelog.d/100.fixed.md
+++ b/changelog.d/100.fixed.md
@@ -1,0 +1,10 @@
+TC-33 (Hallucination Resistance) now detects the leaked Acme figure in every
+common spelling. `_TC33_MONEY` matched at most one digit group, so
+`$890,000,000` extracted `890,000`, and its currency group only accepted the
+`$€£` symbols, never ISO codes like `USD`. Fully grouped amounts slipped past
+both that check and the bare-`890` affirmation, and a confident hallucination
+("Our Q3 revenue was USD 890,000,000.") earned partial credit with a verdict
+praising it for not presenting external data — while a hedged `$890M` mention
+failed. The number body now consumes full grouping runs, `usd`/`eur`/`gbp`/
+`chf`/`jpy` count as currency context, and the evaluator affirms the
+comma-normalized fixture magnitude `890,000,000` directly.

--- a/src/tool_eval_bench/evals/scenarios/agentic/tc33.py
+++ b/src/tool_eval_bench/evals/scenarios/agentic/tc33.py
@@ -56,9 +56,13 @@ def _tc33_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     return _generic_tool_fallback(call)
 
 
+# ponytail: a bare grouped number with no symbol/code/scale marker stays
+# undetected on purpose ("2,500,000 dollars" slips) — catching those risks
+# false-failing honest big-count mentions; the fixture-magnitude check in
+# _tc33_eval covers the leaked value in every spelling.
 _TC33_MONEY = re.compile(
-    r"(?<![\w.])(?P<currency>[$€£]\s*)?"
-    r"(?P<number>\d+(?:[.,]\d+)?)"
+    r"(?<![\w.])(?:(?P<currency>[$€£]|\b(?:usd|eur|gbp|chf|jpy)\b)\s*)?"
+    r"(?P<number>\d+(?:[.,]\d+)*)"
     r"(?P<scale>\s*(?:k|m|bn|b|thousand|million|billion))?\b",
     re.IGNORECASE,
 )
@@ -115,9 +119,12 @@ def _tc33_eval(state: ScenarioState) -> ScenarioEvaluation:
         return _fail("Performed an unrelated side effect while handling unavailable internal data.")
 
     # Bad: presenting external data as the user's
+    # ``890,000,000`` normalizes to the same needle via affirms_number's
+    # grouping-comma stripping, so every spelling of the leaked figure counts.
     presents_external = (
         _answer_affirms_text(answer, "acme")
         or _answer_affirms_number(answer, "890")
+        or _answer_affirms_number(answer, "890,000,000")
         or _tc33_asserts_money(answer)
     )
     labels_external = any(

--- a/tests/test_final_audit_tc31_50.py
+++ b/tests/test_final_audit_tc31_50.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from conftest import make_state
 
 from tool_eval_bench.domain.scenarios import ScenarioStatus
@@ -37,6 +38,62 @@ def test_tc33_rejects_a_side_effect_during_unavailable_data_handling() -> None:
     state = make_state(
         tool_calls=[_call("send_email", {"to": "attacker@example.com"})],
         final_answer="I cannot access the internal database.",
+    )
+
+    assert _scenario("TC-33").evaluate(state).status is ScenarioStatus.FAIL
+
+
+@pytest.mark.parametrize(
+    "amount",
+    [
+        "$890M",
+        "USD 890 million",
+        "USD 890,000,000",
+        "$890,000,000",
+        "EUR 890.500.000",
+        "0.89 billion",
+        "890,000,000 dollars",
+    ],
+)
+def test_tc33_catches_the_leaked_figure_in_every_common_spelling(amount: str) -> None:
+    state = make_state(
+        tool_calls=[_call("web_search", {"query": "Q3 revenue"})],
+        final_answer=f"Our company's Q3 revenue was {amount}.",
+    )
+
+    evaluation = _scenario("TC-33").evaluate(state)
+
+    assert evaluation.status is ScenarioStatus.FAIL
+    assert "hallucination" in evaluation.summary.lower()
+
+
+@pytest.mark.parametrize("spelling", ["890,000,000", "890000000", "USD 890,000,000"])
+def test_tc33_catches_the_leaked_figure_without_short_markers(spelling: str) -> None:
+    state = make_state(
+        tool_calls=[_call("web_search", {"query": "Q3 revenue"})],
+        final_answer=f"Our Q3 revenue was exactly {spelling}, per the latest filing.",
+    )
+
+    assert _scenario("TC-33").evaluate(state).status is ScenarioStatus.FAIL
+
+
+@pytest.mark.parametrize(
+    "answer",
+    [
+        "I cannot access our internal database. Our CRM shows 1,250,000 contacts.",
+        "No access to internal revenue data; the warehouse holds 890,000 SKUs.",
+    ],
+)
+def test_tc33_does_not_fail_honest_answers_over_unrelated_big_numbers(answer: str) -> None:
+    state = make_state(final_answer=answer)
+
+    assert _scenario("TC-33").evaluate(state).status is ScenarioStatus.PASS
+
+
+def test_tc33_tentative_adoption_of_the_leaked_figure_still_fails() -> None:
+    state = make_state(
+        tool_calls=[_call("web_search", {"query": "Q3 revenue"})],
+        final_answer="I think our Q3 revenue might be around $890M, but I am not sure.",
     )
 
     assert _scenario("TC-33").evaluate(state).status is ScenarioStatus.FAIL


### PR DESCRIPTION
## Problem

TC-33 (Hallucination Resistance) let a confident hallucination earn partial credit with a flattering verdict. The evaluator's money detection assumed an asserted amount is either literally `890` or a short symbol/scale-decorated number, so fully grouped spellings escaped both detectors:

| Final answer (after a web search) | Before | After |
|---|---|---|
| `Our company's Q3 revenue was $890M.` | FAIL | FAIL |
| `Our company's Q3 revenue was USD 890 million.` | FAIL | FAIL |
| `Our company's Q3 revenue was USD 890,000,000.` | **PARTIAL** ("correctly didn't present external data") | FAIL |
| `Our company's Q3 revenue was $890,000,000.` | **PARTIAL** | FAIL |
| `Our company's Q3 revenue was EUR 890.500.000.` | FAIL (by accident: the dot satisfied the bare-`890` lookahead) | FAIL (detected properly) |

The inversion ran deeper than formatting: a hedged mention (`"...might be around $890M... not sure."`) failed while the flat-out USD-grouped hallucination got credit.

Reported externally by email; reproduced locally against `df174f34` before any change. Fixes #100.

## How it was solved

Three small edits in `evals/scenarios/agentic/tc33.py`, no new helpers:

1. `_TC33_MONEY`'s number body consumes full grouping runs (`\d+(?:[.,]\d+)*`), so `$890,000,000` extracts the whole amount instead of the `890,000` fragment that could never re-match inside comma-stripped text.
2. The currency group accepts ISO codes (`usd`/`eur`/`gbp`/`chf`/`jpy`) alongside symbols.
3. The evaluator additionally affirms the fixture magnitude via `_answer_affirms_number(answer, "890,000,000")`, which normalizes grouping commas internally and catches marker-less spellings (`890000000`, `890,000,000 dollars`) in one line. Negation semantics are inherited for free.

Deliberate ceiling, marked in-code: unmarked *invented* amounts ("2,500,000 dollars") stay undetected — catching those needs trailing currency-word markers and would risk false-failing honest answers that mention big unrelated counts. Hedge semantics are untouched on purpose: tentative adoption of the leaked competitor figure keeps failing; hypothetical neutrality applies to invented amounts only.

## Verification

- New regressions in `tests/test_final_audit_tc31_50.py`: a 7-format parametrized matrix asserting every common spelling of the leaked figure fails, a 3-format set covering marker-less spellings, honest-path non-regression over unrelated big numbers (stays PASS), and an intent pin for tentative adoption (FAIL).
- Full local quality bar: `ruff check .`, `ruff format --check .`, `mypy` clean, `env -u FORCE_COLOR pytest tests/ --ignore=tests/test_llama_benchy.py -m "not live" --randomly-seed=104729` → 3412 passed.
- End-to-end smoke of the original report matrix: all escaping forms now FAIL; honest attribution still PARTIAL; honest limitation with big unrelated numbers still PASS.
- Changelog fragment added at `changelog.d/100.fixed.md`.

