### PR TITLE
fix: read a clock written with periods in TC-63 and TC-75 (#102)

### DIFF
--- a/changelog.d/102.fixed.md
+++ b/changelog.d/102.fixed.md
@@ -1,0 +1,11 @@
+TC-63 (Accumulating Constraints) and TC-75 (Missing Required Parameter) now read
+a clock written with periods. `3 p.m.` matched neither `_TC63_CLOCK` nor
+`_TC75_CONCRETE_VALUE`, although `_TC63_PAST_CUTOFF` in the same file and
+TC-03's reader both accept it, and the two misses ran in opposite directions: a
+model that recommended a restaurant "open until 11 p.m." lost the open-late
+constraint and scored 3/4 instead of passing, while a model that pencilled an
+interview in for "3 p.m." before asking for the real time scored PASS under a
+verdict reading "without guessing". `11:30 p.m.` was read as 11:30 in the
+morning, because the 24-hour branch matched the clock portion on its own.
+Closing exactly at 22:00 still fails, since the request was for somewhere open
+*past* 10pm.

--- a/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
@@ -85,8 +85,11 @@ _TC75_REQUEST_MARKER = (
 )
 
 
+# The periods in "3 p.m." are punctuation, not a different time. Without them
+# a model that pencilled a slot in *and* asked for the real one read as though
+# it had guessed nothing.
 _TC75_CONCRETE_VALUE = re.compile(
-    r"\b(?:\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}|\d{1,2}\s?(?:am|pm))\b",
+    r"\b(?:\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}|\d{1,2}\s?[ap]\.?m\.?)\b",
     re.IGNORECASE,
 )
 

--- a/src/tool_eval_bench/evals/scenarios/planning/tc63.py
+++ b/src/tool_eval_bench/evals/scenarios/planning/tc63.py
@@ -109,7 +109,10 @@ _TC63_PAST_CUTOFF = re.compile(r"\b(?:past|after|later than|beyond)\s+10(?!\d)\s
 _TC63_PRICE = re.compile(r"\$\s?(\d{1,3})")
 
 
-_TC63_CLOCK = re.compile(r"\b(\d{1,2})(?::(\d{2}))?\s*(am|pm)\b|\b(\d{1,2}):(\d{2})\b")
+# `p.m.` is the same time as `pm`. `_TC63_PAST_CUTOFF` above already accepts
+# the periods and so does TC-03's clock reader, so an answer that wrote
+# "open until 11 p.m." lost the constraint here and nowhere else.
+_TC63_CLOCK = re.compile(r"\b(\d{1,2})(?::(\d{2}))?\s*([ap])\.?m\.?\b|\b(\d{1,2}):(\d{2})\b")
 
 
 def _tc63_within_budget(answer: str) -> bool:
@@ -137,9 +140,10 @@ def _tc63_affirms_phrase(answer: str, phrase: str) -> bool:
 def _tc63_open_late(answer: str) -> bool:
     """True when the answer names a closing time at or after the late cutoff.
 
-    Accepts "11pm", "11 PM", "23:00", and "open until 11:30pm" alike, plus the
-    user's own phrasing ("open past 10"). Closing at 22:00 exactly does not
-    count, since the request was for somewhere open *past* 10pm.
+    Accepts "11pm", "11 PM", "11 p.m.", "23:00", and "open until 11:30pm"
+    alike, plus the user's own phrasing ("open past 10"). Closing at 22:00
+    exactly does not count, since the request was for somewhere open *past*
+    10pm.
     """
     cutoff = _TC63_PAST_CUTOFF.search(answer)
     if cutoff:
@@ -152,7 +156,7 @@ def _tc63_open_late(answer: str) -> bool:
         if re.search(r"\b(?:not|never|no|without)\b(?:\W+\w+){0,4}\W*$", prefix):
             continue
         if meridiem:
-            hour, minute = int(hour12) % 12 + (12 if meridiem == "pm" else 0), int(minute12 or 0)
+            hour, minute = int(hour12) % 12 + (12 if meridiem == "p" else 0), int(minute12 or 0)
         else:
             hour, minute = int(hour24), int(minute24 or 0)
         if (hour, minute) > (_TC63_LATE_HOUR, 0):

--- a/tests/test_lexical_grader_sweep.py
+++ b/tests/test_lexical_grader_sweep.py
@@ -93,6 +93,90 @@ def test_tc63_reads_price_and_closing_time_as_numbers(answer, budget, late):
 
 
 @pytest.mark.parametrize(
+    "closing",
+    ["11pm", "11 PM", "11 p.m.", "11 P.M.", "11:30 p.m.", "11:30pm", "23:00"],
+)
+def test_tc63_reads_a_late_closing_time_in_every_spelling(closing):
+    """The periods in "11 p.m." are punctuation, not a different time.
+
+    `_TC63_PAST_CUTOFF` and TC-03's clock reader both accept them already, so an
+    answer that named a qualifying closing time in the most ordinary English
+    spelling lost the constraint in this evaluator alone.
+    """
+    from tool_eval_bench.evals.scenarios.planning.tc63 import _tc63_open_late
+
+    answer = f"Trattoria Bella, downtown, $22 per person, open until {closing}."
+    assert _tc63_open_late(answer.lower()) is True, closing
+
+
+@pytest.mark.parametrize("closing", ["closes at 10pm", "closes at 10 p.m.", "closes at 22:00"])
+def test_tc63_still_rejects_a_closing_time_that_is_not_past_the_cutoff(closing):
+    """The request was for somewhere open *past* 10pm; 22:00 exactly is not."""
+    from tool_eval_bench.evals.scenarios.planning.tc63 import _tc63_open_late
+
+    answer = f"Trattoria Bella, downtown, $22 per person, {closing}."
+    assert _tc63_open_late(answer.lower()) is False, closing
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "trattoria bella has 2 pms on staff",
+        "the 1 amount shown is per person",
+        "the dining room is 40 sq.m. and seats 20",
+        "table for 12 among the regulars",
+    ],
+)
+def test_tc63_does_not_read_ordinary_prose_as_a_closing_time(phrase):
+    """A looser meridiem must not turn a stray letter after a number into a clock."""
+    from tool_eval_bench.evals.scenarios.planning.tc63 import _tc63_open_late
+
+    assert _tc63_open_late(phrase) is False, phrase
+
+
+@pytest.mark.parametrize("closing", ["11pm", "11 p.m.", "23:00"])
+def test_tc63_scores_the_same_recommendation_the_same_way(closing):
+    """Spelling the closing hour differently is not dropping a constraint."""
+    scenario = _scenario("TC-63")
+    state = make_state(
+        tool_calls=[
+            {
+                "name": "web_search",
+                "arguments": {"query": "italian restaurant downtown under $30 open late"},
+            }
+        ],
+        final_answer=f"Trattoria Bella - Italian, downtown, $22 per person, open until {closing}.",
+    )
+    assert scenario.evaluate(state).status == ScenarioStatus.PASS, closing
+
+
+@pytest.mark.parametrize("guess", ["3pm", "15:00", "3:00 p.m.", "3 p.m.", "3 P.M."])
+def test_tc75_spots_a_guessed_time_in_every_spelling(guess):
+    """Asking for the time while naming one is a guess in any spelling.
+
+    `3 p.m.` matched no concrete-value form, so the answer scored PASS under a
+    verdict that reads "without guessing" — about an answer that guessed.
+    """
+    scenario = _scenario("TC-75")
+    state = make_state(
+        final_answer=(
+            f"I have pencilled the panel in for {guess}. "
+            "Could you please provide the date and time you want?"
+        )
+    )
+    assert scenario.evaluate(state).status == ScenarioStatus.PARTIAL, guess
+
+
+def test_tc75_still_passes_an_answer_that_names_no_time_at_all():
+    """The guard must not fire on the clean clarification it is meant to pass."""
+    scenario = _scenario("TC-75")
+    state = make_state(
+        final_answer="Could you please provide the date and time you want for the panel?"
+    )
+    assert scenario.evaluate(state).status == ScenarioStatus.PASS
+
+
+@pytest.mark.parametrize(
     "phrasing",
     [
         "Mitte Brasserie is shut on Sundays.",


### PR DESCRIPTION
## Summary

`3 p.m.` was invisible to two evaluators, in opposite directions, and each produced a verdict that
asserted something the model had not done. `_TC63_CLOCK` and `_TC75_CONCRETE_VALUE` matched only a
bare `am`/`pm`, although `_TC63_PAST_CUTOFF` two statements above the first, and `_tc03_time_3pm`
(`core/tc03.py:69`), both already accept the periods.

| Final answer | Before | After |
|---|---|---|
| TC-63 · `…open until 11pm.` / `23:00` | PASS | PASS |
| TC-63 · `…open until 11 p.m.` | **PARTIAL** ("Met 3/4 constraints — close but dropped one") | PASS |
| TC-63 · `…open until 11:30 p.m.` | **PARTIAL** | PASS |
| TC-75 · pencils in `3pm` / `3:00 p.m.`, then asks | PARTIAL | PARTIAL |
| TC-75 · pencils in `3 p.m.`, then asks | **PASS** ("…without guessing") | PARTIAL |

`11:30 p.m.` failed for a second reason: with the meridiem branch dead, the 24-hour branch matched
`11:30` alone, so `tc63.py:157-158` read it as 11:30 in the *morning*.

Follows on from the TC-33 note I sent by email. Reproduced locally against `c32027f` before any
change. Fixes #102.

## Changes

Two regexes and one comparison, no new helpers:

1. `_TC63_CLOCK`'s meridiem group becomes `([ap])\.?m\.?`, and the hour arithmetic tests
   `meridiem == "p"`. The regex carries no `IGNORECASE` and `_tc63_eval` lowercases at
   `tc63.py:174`, so `11 PM` is unaffected.
2. `_TC75_CONCRETE_VALUE` takes the same form.
3. The `_tc63_open_late` docstring gains `11 p.m.` in its list of accepted spellings.

**Deliberate ceiling.** TC-75 has always scored a model that names a time only to rule it out
(*"I will not assume 3pm"*) as having guessed it, because `_tc75_eval` tests the pattern raw. This
change makes that blind spot spelling-consistent rather than spelling-dependent, and I deliberately
did not fold a fix in, because the obvious one is a regression: routing the match through
`_is_negated` makes an answer whose clause reads *"There are no conflicts at 3pm, so I have pencilled the
panel in there"* — alongside the request that gets it past the first branch — score PASS under the
"without guessing" verdict. `_is_negated` approximates government by splitting on the
nearest clause boundary and then looking four content words back, so a negation in a neighbouring
clause is correctly ignored — but any negation token *inside* the same clause counts, whatever it
governs. That is tolerable where the result only gates an affirmation, and it already bites where
the result gates a detector: `tc35.py:102` feeds `converted_value`, so
*"500 K is already Kelvin, and without rounding it is 440.33 F."* scores PASS while
*"500 K is already Kelvin, and it is 440.33 F."* scores PARTIAL. Putting a fifth call site on
the TC-75 PASS boundary would widen that rather than narrow it, so it wants its own change and its
own tests.

**One thing this surfaced that I have not touched.** Both `constraints_met == 4` branches in
`_tc63_eval` also require `searched`, and there is no `== 4` branch without it, so a 4/4 answer that
never called `web_search` falls through to `_fail("Final answer doesn't reflect any of the
accumulated constraints.")`. For that input — with a qualifying search the table above
holds — widening the clock reader moves `11 p.m.` answers off `3/4` and onto that path. For ordinary
phrasings the undotted spelling already lands there (the fixture in
`test_tc63_all_constraints_without_search_are_not_perfect` scores FAIL at `c32027f`), so that is
spelling parity rather than a cost; the only exception I could construct needs a second dotted clock
inside a negated clause, where `p.m.` tokenises as three word-runs and `pm` as one, which moves the
bare twin out of the negation window.

And it is not only the verdict string. Without a qualifying search a 4/4 answer scores FAIL / 0
points while a 1/4 answer scores PARTIAL / 1, so on that path meeting three more constraints costs a
point. That test asserts `!= PASS` and does not pin the summary, so this is a separate change — I
can file it if that is useful.

## Validation

- Focused: `tests/test_lexical_grader_sweep.py` — 47 passed, 23 of them new.
- **Mutation-proven:** with the source change reverted and the tests kept, **6 of the new cases
  fail** — `11 p.m.`, `11 P.M.`, `11:30 p.m.`, the TC-63 end-to-end `11 p.m.` row, and TC-75's
  `3 p.m.` and `3 P.M.`. Every one is a dotted spelling; nothing else moves.
- **False positives checked mechanically rather than by eye:** compiling the old and the new
  patterns and scanning **every tracked file in the repo (428) at `c32027f`**, the only string the
  new patterns match that the old ones did not is `3 p.m` — in `CHANGELOG.md` and in
  `core/tc03.py`, the reader that already accepts it. Tests also pin prose that must not read as a
  clock: *"2 pms on staff"*, *"the 1 amount shown"*, *"40 sq.m."*, *"table for 12 among the
  regulars"*.
- Required suite at all three CI seeds (`104729`, `130363`, `155921`): **3435 passed, 1
  deselected** each. Baseline on the same machine before the change: 3412 passed.
- Changelog fragment added under `changelog.d/`.

- [x] Focused tests pass.
- [x] `.venv/bin/ruff check .` passes. — *All checks passed*
- [x] `.venv/bin/ruff format --check .` passes. — *327 files already formatted*
- [x] `.venv/bin/mypy` passes. — *Success: no issues found in 216 source files*
- [x] Required pytest suite passes. — *3435 passed, 1 deselected, all three CI seeds*
- [x] Live-server testing is not required — lexical evaluators only, no backend or transport path.

## Contributor checklist

- [x] This PR contains one focused, logically related change.
- [x] Regression or behavior tests were added or updated where appropriate.
- [x] Positive and negative/false-positive cases are covered for evaluator changes.
- [x] `README.md` and/or `CHANGELOG.md` is updated when applicable. — fragment added;
      `CHANGELOG.md` itself is generated and untouched.
- [x] No credentials, live endpoints, generated run artifacts, or unrelated formatting changes.