### PR TITLE
fix: score a TC-63 answer that kept every constraint without searching

### DIFF
--- a/changelog.d/+tc63-perfect-answer-without-search.fixed.md
+++ b/changelog.d/+tc63-perfect-answer-without-search.fixed.md
@@ -1,0 +1,8 @@
+TC-63 (Accumulating Constraints) no longer scores an answer that kept all four
+constraints below one that kept a single constraint. Both PASS branches require
+a qualifying `web_search` call, and nothing handled 4/4 without one, so such an
+answer fell past every count branch to the closing failure. It scored 0 points
+under a summary reading "Final answer doesn't reflect any of the accumulated
+constraints", while a 1/4 answer scored 1. It now scores PARTIAL, and the
+summary says what the model actually did: it satisfied all four constraints but
+never searched for a match.

--- a/src/tool_eval_bench/evals/scenarios/planning/tc63.py
+++ b/src/tool_eval_bench/evals/scenarios/planning/tc63.py
@@ -209,6 +209,13 @@ def _tc63_eval(state: ScenarioState) -> ScenarioEvaluation:
         if _has_unexpected_tools(state, {"web_search"}):
             return _partial("Found a matching restaurant but also called an unrelated tool.")
         return _pass("Final recommendation satisfies all 4 accumulated constraints.")
+    # Both PASS branches above require a qualifying search, and without one a
+    # 4/4 answer would otherwise fall past every count branch to the closing
+    # _fail — scoring 0 against 1 for a 1/4 answer, under a summary saying it
+    # reflected none of the constraints. It kept all four; it just never looked
+    # them up.
+    if constraints_met == 4:
+        return _partial("Satisfies all 4 constraints but never searched for a match.")
     if constraints_met == 3:
         return _partial(f"Met {constraints_met}/4 constraints — close but dropped one.")
     if constraints_met == 2:

--- a/tests/test_final_audit_tc51_69.py
+++ b/tests/test_final_audit_tc51_69.py
@@ -249,6 +249,35 @@ def test_tc63_all_constraints_without_search_are_not_perfect() -> None:
     assert _scenario("TC-63").evaluate(state).status != ScenarioStatus.PASS
 
 
+def test_tc63_all_constraints_without_search_are_partial_not_a_blank_miss() -> None:
+    """4/4 without a search kept every constraint; it just never looked them up.
+
+    The two PASS branches both require the search, so this answer used to fall
+    past every count branch to the closing _fail, whose summary says it
+    reflected none of the constraints.
+    """
+    state = make_state(
+        final_answer="An Italian restaurant downtown costs $22 per person and is open until 11pm."
+    )
+    evaluation = _scenario("TC-63").evaluate(state)
+    assert evaluation.status is ScenarioStatus.PARTIAL
+    assert "never searched" in evaluation.summary
+
+
+def test_tc63_meeting_more_constraints_without_a_search_never_scores_lower() -> None:
+    """Meeting three more constraints must not cost a point."""
+    answers = [
+        "You should eat something Italian tonight.",
+        "An Italian restaurant downtown is a good pick.",
+        "An Italian restaurant downtown costs $22 per person.",
+        "An Italian restaurant downtown costs $22 per person and is open until 11pm.",
+    ]
+    points = [
+        _scenario("TC-63").evaluate(make_state(final_answer=answer)).points for answer in answers
+    ]
+    assert points == sorted(points), points
+
+
 def test_tc65_explicit_weather_result_mismatch_is_not_perfect() -> None:
     payload = {
         "location": "Tokyo",


### PR DESCRIPTION
## Problem

Both PASS branches in `_tc63_eval` require a qualifying `web_search` call, and no branch handled
`constraints_met == 4` without one. A 4/4 answer with no search fell past every count branch to the
closing `_fail`, so meeting three more constraints cost a point:

| Answer, no `web_search` call | Status | Points | Summary |
|---|---|---|---|
| 1/4 constraints | PARTIAL | 1 | "Only retained 1/4 constraints — significant context drift." |
| 4/4 constraints | **FAIL** | **0** | "Final answer doesn't reflect any of the accumulated constraints." |

The summary is also false about the answer. It kept all four constraints. It never looked them up.

Surfaced by @zorionarrillaga in #103, which correctly left it alone as a separate change.

## Solution

One branch, after the two `== 4 and searched` branches:

```python
if constraints_met == 4:
    return _partial("Satisfies all 4 constraints but never searched for a match.")
```

PARTIAL is 1 point, which makes the no-search path monotonic and gives a summary that says what the
model actually did. The existing `test_tc63_all_constraints_without_search_are_not_perfect` asserts
`!= PASS` and does not pin the summary, so it keeps passing unchanged.

## Verification

- Two tests added next to that existing one: the 4/4-no-search answer scores PARTIAL with a summary
  naming the missing search, and a monotonicity test walking 1/4 through 4/4 asserting points never
  decrease. The second is the one that pins the defect, since the old code scored 4/4 below 1/4.
- **Mutation-proven:** reverting the source with the tests kept fails exactly those two new cases.
  Nothing else moves.
- Required suite after rebasing onto #103: 3437 passed, 1 deselected, coverage 86.88%. On the
  pre-#103 base it was 3414 at all three CI seeds (104729, 130363, 155921).
- `ruff check`, `ruff format --check`, and `mypy` all clean.
- Changelog fragment added under `changelog.d/` using the `+slug` form for a change with no issue
  number. `CHANGELOG.md` itself is generated and untouched.

Only the no-search path changes, so this does not interact with #103's clock reading beyond what
that PR described.

Drafted with AI assistance (Claude Code); reviewed and verified by me.