### PR TITLE
fix: scope a negation to what it governs, and use it in TC-75

### DIFF
--- a/changelog.d/+negation-scope.fixed.md
+++ b/changelog.d/+negation-scope.fixed.md
@@ -1,0 +1,16 @@
+The shared negation check now asks whether a negation actually governs the
+value it sits near. It previously counted any negation token within four
+content words of the match, so "500 K is already Kelvin, and without rounding
+it is 440.33 F" read as a denial of the conversion the sentence states, and
+TC-35 scored it as though no other scale had been named. Clausal negations
+("not", "never", "n't") still carry across the rest of the predicate, so
+"could not find a price of 187" is still a denial. Determiners and
+prepositions ("no", "neither", "nor", "without") now reach only their own
+complement and stop at the first word that opens a new phrase.
+
+TC-75 (Missing Required Parameter) uses that check as a result. A model that
+names a time only to rule it out ("I will not assume 3pm") no longer scores as
+having guessed one. A model that picks a time in a clause that happens to
+contain a negation ("There are no conflicts at 3pm, so I have pencilled the
+panel in there") still does, because the negation governs the conflicts rather
+than the time.

--- a/src/tool_eval_bench/evals/helpers.py
+++ b/src/tool_eval_bench/evals/helpers.py
@@ -104,13 +104,43 @@ _NEGATION_STOPWORDS = frozenset(
     "a an the of any some that this it its is are was were be been to in at on for".split()
 )
 _NEGATION_WINDOW_WORDS = 4
+# "not", "never" and "n't" negate the verb, so they carry across the rest of the
+# predicate: "could not find a price of 187" denies the 187.  The rest are
+# determiners and prepositions, which reach only their own complement.  "There
+# are no conflicts at 3pm" denies conflicts, not 3pm, and "without rounding it
+# is 440.33 F" denies rounding, not the conversion.
+_CONSTITUENT_NEGATION = frozenset({"no", "neither", "nor", "without"})
+# A constituent negation stops at the first word that opens a new phrase: any
+# preposition other than "of", which stays inside the noun phrase ("no price of
+# 187"), or a verb, which starts a new predicate.
+_SCOPE_BREAKERS = frozenset(
+    "at in on for to from by with near around before after until past over under into onto than as "
+    "is are was were be been being am has have had will would shall should can could may might must "
+    "do does did".split()
+)
 
 
 def _is_negated(prefix: str) -> bool:
-    """Return whether text immediately following ``prefix`` sits under a negation."""
+    """Return whether text immediately following ``prefix`` sits under a negation.
+
+    Walks back from the value to the nearest clause boundary. A negation counts
+    only when its scope actually reaches the value, which for a determiner or
+    preposition means no new phrase has opened in between.
+    """
     clause = _CLAUSE_BOUNDARY.split(prefix.lower())[-1]
-    words = [word for word in clause.split() if word.strip("'\"") not in _NEGATION_STOPWORDS]
-    return any(_NEGATION.search(word) for word in words[-_NEGATION_WINDOW_WORDS:])
+    content_words = 0
+    phrase_opened = False
+    for token in reversed(clause.split()):
+        bare = token.strip("'\"")
+        if _NEGATION.search(token) and not (bare in _CONSTITUENT_NEGATION and phrase_opened):
+            return True
+        if bare in _SCOPE_BREAKERS:
+            phrase_opened = True
+        if bare not in _NEGATION_STOPWORDS:
+            content_words += 1
+            if content_words >= _NEGATION_WINDOW_WORDS:
+                return False
+    return False
 
 
 def answer_affirms_number(answer: str, value: str) -> bool:

--- a/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
@@ -14,10 +14,11 @@ from tool_eval_bench.domain.scenarios import (
     ToolCallRecord,
 )
 from tool_eval_bench.evals.helpers import (
-    fail_eval as _fail,
+    _is_negated,
+    full_assistant_transcript,
 )
 from tool_eval_bench.evals.helpers import (
-    full_assistant_transcript,
+    fail_eval as _fail,
 )
 from tool_eval_bench.evals.helpers import (
     partial_eval as _partial,
@@ -95,6 +96,20 @@ _TC75_CONCRETE_VALUE = re.compile(
 
 
 _TC75_LIST_MARKER = re.compile(r"(?m)^[ \t]*(?:[-*]|\d{1,3}[.)])[ \t]+")
+
+
+def _tc75_guessed_a_value(transcript: str) -> bool:
+    """True when the answer asserts a concrete date or time of its own.
+
+    Naming a value only to rule it out ("I will not assume 3pm") is the
+    opposite of guessing, so the match has to survive the negation check
+    before it counts against an otherwise clean clarification.
+    """
+    low = transcript.lower()
+    return any(
+        not _is_negated(low[max(0, match.start() - 120) : match.start()])
+        for match in _TC75_CONCRETE_VALUE.finditer(low)
+    )
 
 
 _TC75_PARAGRAPH_BREAK = re.compile(r"(.?)[ \t]*\n[ \t]*\n\s*")
@@ -187,7 +202,7 @@ def _tc75_eval(state: ScenarioState) -> ScenarioEvaluation:
     requests_date = _tc75_requested_parameter(transcript, "date")
     requests_time = _tc75_requested_parameter(transcript, "time")
     if requests_date and requests_time:
-        if _TC75_CONCRETE_VALUE.search(transcript):
+        if _tc75_guessed_a_value(transcript):
             return _partial(
                 "Asked for the missing details but also guessed a concrete date or time."
             )

--- a/tests/test_evaluator_audit_regressions.py
+++ b/tests/test_evaluator_audit_regressions.py
@@ -1432,3 +1432,108 @@ def test_tc13_retry_accepts_exact_document_name_without_file_id():
     result = scenario.evaluate(state)
     assert result.status == ScenarioStatus.PASS
     assert result.summary == "Retried after the empty result and recovered."
+
+
+# ---------------------------------------------------------------------------
+# Negation scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "the reading is not ",
+        "it never reached ",
+        "it doesn't equal ",
+        "i could not find a price of ",
+        "we found no price of ",
+        "neither option costs ",
+    ],
+)
+def test_is_negated_still_catches_a_negation_that_governs_the_value(prefix):
+    """Clausal negation carries across the predicate; a determiner over its own noun."""
+    from tool_eval_bench.evals.helpers import _is_negated
+
+    assert _is_negated(prefix) is True, prefix
+
+
+@pytest.mark.parametrize(
+    ("prefix", "why"),
+    [
+        ("500 k is already kelvin, and without rounding it is ", "without governs rounding"),
+        ("there are no conflicts at ", "no governs conflicts"),
+        ("the price without tax is ", "without governs tax"),
+        ("there is no rain today berlin is ", "no governs rain"),
+    ],
+)
+def test_is_negated_ignores_a_negation_that_governs_something_else(prefix, why):
+    """A determiner or preposition reaches only its own complement.
+
+    Counting any negation token in the window made "without rounding it is
+    440.33 F" read as a denial of the conversion it states.
+    """
+    from tool_eval_bench.evals.helpers import _is_negated
+
+    assert _is_negated(prefix) is False, why
+
+
+def test_tc35_reads_a_conversion_stated_without_rounding_as_a_conversion():
+    """The wrong-unit detector must see a conversion its own sentence asserts."""
+    scenario = _SCENARIOS["TC-35"]
+    state = make_state(final_answer="500 K is already Kelvin, and without rounding it is 440.33 F.")
+
+    assert scenario.evaluate(state).status is not ScenarioStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# TC-75: naming a value to rule it out is not guessing
+# ---------------------------------------------------------------------------
+
+
+_TC75_REQUEST = " Could you please provide the date and time you want?"
+
+
+@pytest.mark.parametrize(
+    "ruled_out",
+    [
+        "I will not assume 3pm.",
+        "I will not assume 3 p.m.",
+        "I won't guess 3pm.",
+        "I am not assuming 2026-01-05.",
+    ],
+)
+def test_tc75_naming_a_value_only_to_rule_it_out_is_not_a_guess(ruled_out):
+    """Refusing to assume a time is the opposite of guessing one."""
+    scenario = _SCENARIOS["TC-75"]
+    state = make_state(final_answer=ruled_out + _TC75_REQUEST)
+
+    result = scenario.evaluate(state)
+    assert result.status is ScenarioStatus.PASS, ruled_out
+    assert result.summary == "Asked for the missing interview date and time without guessing."
+
+
+@pytest.mark.parametrize(
+    "guess",
+    [
+        "I have pencilled the panel in for 3pm.",
+        "I have pencilled the panel in for 3 p.m.",
+        "The interview is on 2026-01-05.",
+        # The negation here governs "conflicts". The answer still picked a time.
+        "There are no conflicts at 3pm, so I have pencilled the panel in there.",
+        "There are no conflicts at 3 p.m., so I have pencilled it in there.",
+    ],
+)
+def test_tc75_still_spots_a_guess_a_neighbouring_negation_does_not_govern(guess):
+    """Routing the match through the negation check must not open this hole.
+
+    A negation token sitting in the same clause as the guess is exactly the
+    case that made this change look unsafe before the scope rule landed.
+    """
+    scenario = _SCENARIOS["TC-75"]
+    state = make_state(final_answer=guess + _TC75_REQUEST)
+
+    result = scenario.evaluate(state)
+    assert result.status is ScenarioStatus.PARTIAL, guess
+    assert result.summary == (
+        "Asked for the missing details but also guessed a concrete date or time."
+    )


### PR DESCRIPTION
## Problem

Two items #103 named and deliberately left alone. They are one change, because the second is unsafe
until the first lands.

**1. `_is_negated` counts a negation that governs something else.** The helper takes the last clause
and asks whether any negation token sits within four content words of the match, regardless of what
that token actually negates. At `tc35.py:102` the result gates a wrong-unit detector, so:

| Answer | Before | Why |
|---|---|---|
| `500 K is already Kelvin, and it is 440.33 F.` | PARTIAL | conversion detected |
| `500 K is already Kelvin, and without rounding it is 440.33 F.` | **PASS** | "without" read as denying the conversion |

The second answer states the same conversion as the first. `without` governs `rounding`.

The helper's own docstring example has the same hole. `No rain today, Berlin is 8°C` only works
because the dash splits the clause; written without one, `_is_negated("there is no rain today
berlin is ")` returned `True`.

**2. TC-75 tests the concrete-value pattern raw**, so a model that names a time only to rule it out
(`I will not assume 3pm`) scored as having guessed it. The obvious fix, routing the match through
`_is_negated`, was a regression while item 1 stood: `There are no conflicts at 3pm, so I have
pencilled the panel in there` would have scored PASS under the "without guessing" verdict.

## Solution

Split the negation words by how they scope, which is the distinction the old code was missing:

- **Clausal** (`not`, `never`, `n't`) negate the verb and carry across the rest of the predicate.
  `could not find a price of 187` is still a denial. Unchanged.
- **Constituent** (`no`, `neither`, `nor`, `without`) are determiners and prepositions that reach
  only their own complement. They now stop at the first word opening a new phrase: a preposition
  other than `of`, or a verb. `of` stays inside the noun phrase, so `no price of 187` is still a
  denial.

With scope fixed, item 2 is a two-line change, and the counterexample resolves on its own: `no`
governs `conflicts`, `at` ends its scope, so the guess still counts.

| Answer, plus a request for the real date and time | Before | After |
|---|---|---|
| `I will not assume 3pm.` | PASS, "without guessing" | PASS |
| `I have pencilled the panel in for 3pm.` | PARTIAL | PARTIAL |
| `There are no conflicts at 3pm, so I have pencilled the panel in there.` | PARTIAL | PARTIAL |

## Verification

- 20 tests added in `tests/test_evaluator_audit_regressions.py`, split between cases that must
  change and guard cases that must not. The guard set is the point: six prefixes that must stay
  negated, and five TC-75 answers that must still read as guesses, including both counterexamples.
- **Mutation-proven:** reverting either source file with the tests kept fails 9 of the new cases and
  passes every guard.
- Required suite at all three CI seeds (104729, 130363, 155921): 3457 passed, 1 deselected. It was
  3437 before, so nothing that existed changed verdict.
- `ruff check`, `ruff format --check`, and `mypy` all clean.
- Changelog fragment added under `changelog.d/`.

## What this does not fix

The scope rule is a heuristic over token lists, not a parser. It ends a constituent negation's scope
at a closed list of prepositions and verbs, so `there are no results for 187` now reads 187 as
affirmed. That is the same trade the rule makes deliberately elsewhere, and it is the direction that
loses correct answers less often, but it is a trade rather than a free win.

Drafted with AI assistance (Claude Code); reviewed and verified by me.