### PR TITLE
fix: remove exponential backtracking from the Prometheus label parser

### DIFF
--- a/changelog.d/+redos-label-parser.fixed.md
+++ b/changelog.d/+redos-label-parser.fixed.md
@@ -1,0 +1,8 @@
+The Prometheus label parser behind the live speculative-decoding monitor no
+longer backtracks exponentially. In `(?:\\.|[^"])*` the negated class also
+matched a backslash, so every escape had two possible parses and a label that
+opened a quote without closing it took time doubling with each repetition:
+roughly half a second at 22 escapes, and unbounded past that. Metrics text
+arrives from whatever server the run points at, so the input is reachable.
+Excluding the backslash from the negated class leaves one parse and identical
+results on well-formed input.

--- a/src/tool_eval_bench/runner/spec_live.py
+++ b/src/tool_eval_bench/runner/spec_live.py
@@ -205,7 +205,12 @@ _MODEL_NAME_LABEL = re.compile(
 )
 
 
-_LABEL_PATTERN = re.compile(r'([A-Za-z_][A-Za-z0-9_]*)="((?:\\.|[^"])*)"')
+# `[^"]` also matches a backslash, so `(?:\\.|[^"])*` gave the engine two ways
+# to consume every escape and exponential backtracking to work through on a
+# label that never closes its quote. Excluding the backslash from the negated
+# class leaves exactly one parse. Metrics text comes off the wire from whatever
+# server the run points at, so this is reachable input.
+_LABEL_PATTERN = re.compile(r'([A-Za-z_][A-Za-z0-9_]*)="((?:[^"\\]|\\.)*)"')
 
 
 def _parse_labels(raw_labels: str | None) -> dict[str, str]:

--- a/tests/test_spec_live.py
+++ b/tests/test_spec_live.py
@@ -15,6 +15,7 @@ import pytest
 from tool_eval_bench.runner.spec_live import (
     MetricsSnapshot,
     SpecLiveDelta,
+    _parse_labels,
     _parse_snapshot,
     compute_delta,
     metrics_url_from_base,
@@ -1948,3 +1949,39 @@ class TestHighKPositionScaling:
         assert "p0" in text
         assert "p19" in text
         assert "Per-Position" in text
+
+
+# ---------------------------------------------------------------------------
+# Label parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('model_name="gpt-4", method="eagle"', {"model_name": "gpt-4", "method": "eagle"}),
+        (r'a="x\"y"', {"a": 'x"y'}),  # the escape is unwrapped
+        ('a=""', {"a": ""}),
+        ('a="unclosed', {}),
+        ("", {}),
+    ],
+)
+def test_parse_labels_reads_prometheus_label_sets(raw, expected):
+    assert _parse_labels(raw) == expected
+
+
+def test_parse_labels_does_not_backtrack_exponentially_on_an_unclosed_label():
+    """A label that opens a quote and never closes it must not hang the monitor.
+
+    `[^"]` also matched a backslash, so every escape had two possible parses and
+    a non-matching tail took exponential time. Metrics text arrives from
+    whatever server the run points at, so this input is reachable. The old
+    pattern needed roughly half a second at 22 repetitions and doubled with
+    each one after that; the ceiling here is loose enough to be stable on a
+    loaded CI runner while still failing outright on exponential behaviour.
+    """
+    hostile = 'A="' + "\\!" * 64
+
+    start = time.perf_counter()
+    assert _parse_labels(hostile) == {}
+    assert time.perf_counter() - start < 1.0


### PR DESCRIPTION
## Problem

`_LABEL_PATTERN` in `runner/spec_live.py` parsed a label value as `(?:\\.|[^"])*`. The negated class
`[^"]` also matches a backslash, so the engine had two ways to consume every escape and an
exponential number of paths to work through before failing on a label that opens a quote and never
closes it.

Measured on the old pattern with input `A="` followed by N repetitions of `\!`:

| N | Time |
|---:|---|
| 18 | 0.028s |
| 20 | 0.111s |
| 22 | 0.440s |

It doubles with each further repetition. The regression test uses 64, which hangs the old pattern
past a 45 second timeout.

This is reachable rather than theoretical: `_parse_labels` reads Prometheus text served by whatever
inference endpoint the run points at, so a malformed or hostile `/metrics` body stalls the live
monitor.

CodeQL reports it as `py/redos`. It is the only one of the 102 open alerts carrying a security
severity.

## Solution

Exclude the backslash from the negated class, so a backslash can only be consumed by the escape
branch and every input has exactly one parse:

```diff
-r'([A-Za-z_][A-Za-z0-9_]*)="((?:\\.|[^"])*)"'
+r'([A-Za-z_][A-Za-z0-9_]*)="((?:[^"\\]|\\.)*)"'
```

## Verification

- Both patterns produce identical output on every well-formed label set I could construct, including
  escaped quotes, escaped backslashes, empty values, multiple labels, and an unterminated label.
  The parametrized test pins that behaviour, and note it asserts the value after `_parse_labels`
  unescapes, not the raw capture.
- **Mutation-proven:** reverting the source with the tests kept makes the backtracking test hang
  until killed, exit code 124.
- Required suite: 3463 passed, 1 deselected, coverage 86.91%. `ruff` and `mypy` clean.
- Changelog fragment added under `changelog.d/`.

The remaining 101 alerts are quality-suite findings with no security severity. They need a different
change, and I'll send that separately rather than mix it with a security fix.

Drafted with AI assistance (Claude Code); reviewed and verified by me.