### PR TITLE
chore: make code scanning report findings worth acting on

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -5,6 +5,13 @@ name: tool-eval-bench
 queries:
   - uses: security-and-quality
 
+# Every filter below was checked against the alerts it suppresses, and each one
+# is a rule this repository's own conventions make structurally wrong rather
+# than a finding being waved through. The quality queries earn their place: the
+# same audit that produced these filters found dead assignments in
+# `cli/leaderboard.py` and an always-true guard in `runner/orchestrator.py`.
+# The point is to keep those visible instead of burying them under a hundred
+# results nobody can act on.
 query-filters:
   # `py/incomplete-url-substring-sanitization` fires on the prompt-injection
   # scenarios, where an evaluator asks "did the model's answer repeat the
@@ -16,3 +23,60 @@ query-filters:
   # which this repository does not do for a linter's benefit.
   - exclude:
       id: py/incomplete-url-substring-sanitization
+
+  # The `...` body of a `Protocol` method is the way to declare a structural
+  # type, not a statement someone forgot to finish. Every alert was one of
+  # these, in `domain/measurement.py`, `domain/adapters.py`, `domain/plugin.py`
+  # and `adapters/measurement.py`.
+  - exclude:
+      id: py/ineffectual-statement
+
+  # Private module constants shared between sibling modules. `_STRING` in
+  # `hardmode_expanded/_shared.py` has 84 uses; the query counts none of them,
+  # because it does not follow `from ._shared import _STRING`. It also cannot
+  # see through `cli/bench.py`, which rebinds itself to `cli/dispatch` via
+  # `sys.modules`, so `_HIDDEN_ARGS` reads as dead while a drift-detection test
+  # imports it, or through test-only readers like `_SCHEMA_VERSION`.
+  - exclude:
+      id: py/unused-global-variable
+
+  # `ruff format` wraps a long string literal across lines, which is exactly
+  # the shape this query reports. Every alert was a wrapped Markdown line in a
+  # report writer, each with its trailing space intact.
+  - exclude:
+      id: py/implicit-string-concatenation-in-list
+
+  # Import placement, duplicate imports, and re-exports. `ruff` already
+  # enforces this (I001, F401) and understands the conventions this repository
+  # uses to re-export a name: `# noqa: F401 — public re-export`, the PEP 484
+  # `as` alias form, and `__all__`. CodeQL reads all three as unused.
+  - exclude:
+      id: py/unused-import
+  - exclude:
+      id: py/import-and-import-from
+  - exclude:
+      id: py/repeated-import
+
+  # Every alert was a narrow, typed `except` with the fallback assigned before
+  # the `try` or supplied by the branch below it: `except (KeyError, IndexError)`
+  # over a response shape, `except json.JSONDecodeError` falling through to a
+  # FAIL verdict, `except KeyboardInterrupt` before a return. None are bare
+  # `except:`. Turn on ruff's S110 if this should be enforced as policy.
+  - exclude:
+      id: py/empty-except
+
+  # Iterating an `Enum` class (`for cat in Category`) is not iterating a
+  # non-iterable; the query does not model `EnumMeta.__iter__`.
+  - exclude:
+      id: py/non-iterable-in-for-loop
+
+  # `argparse.ArgumentParser.error` is `NoReturn`, which typeshed knows and
+  # this query does not, so the assignment after it reads as skippable.
+  - exclude:
+      id: py/uninitialized-local-variable
+
+  # Directly contradicts the type checker. Both alerts are the final `return`
+  # of a function whose earlier branches happen to be exhaustive; deleting
+  # either one makes mypy fail with "Missing return statement".
+  - exclude:
+      id: py/unreachable-statement

--- a/changelog.d/+codeql-signal.changed.md
+++ b/changelog.d/+codeql-signal.changed.md
@@ -1,0 +1,15 @@
+Code scanning now reports findings the project can act on. The quality queries
+were producing 102 open alerts, 101 of them without a security severity, which
+buried the one that had one: an exponential-backtracking regex in the
+Prometheus label parser. Auditing all 102 found two real defects, both fixed
+here, and showed the rest to be rules this codebase's conventions make
+structurally wrong: `...` in a `Protocol` body, private constants shared
+between sibling modules, deliberate re-exports, `ruff format`'s string
+wrapping, iterating an `Enum`, and a final `return` that mypy requires and
+CodeQL calls unreachable. Those rules are now excluded, each with the reason
+recorded next to it in `.github/codeql/codeql-config.yml`.
+
+The two real defects: the leaderboard's grouping loop assigned
+`scenario_count` and `backend` and never read them, and the orchestrator
+guarded its parallel-path warning with `if concurrency > 1` on a path the
+sequential branch has already returned from.

--- a/src/tool_eval_bench/cli/leaderboard.py
+++ b/src/tool_eval_bench/cli/leaderboard.py
@@ -226,8 +226,6 @@ def _extract_leaderboard_rows(
         if run_type != "tool_eval" or not _is_rank_eligible(run, config, scores):
             continue
 
-        scenario_count = config.get("scenario_count", len(scores.get("scenario_results", [])))
-        backend = config.get("backend", "?")
         fingerprint = config.get("config_fingerprint") or build_config_fingerprint(
             {
                 "config": config,

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -699,15 +699,15 @@ async def run_all_scenarios(
     # Parallel path with semaphore-bounded concurrency
     import asyncio
 
-    if concurrency > 1:
-        logger.warning(
-            "Running %d scenarios concurrently (--parallel %d). "
-            "Server saturation under load can cause timeouts that are recorded as FAIL "
-            "even when the model reasoned correctly. "
-            "Use --parallel 1 for reproducible quality scores.",
-            total,
-            concurrency,
-        )
+    # `concurrency <= 1` returned above, so every run reaching here is parallel.
+    logger.warning(
+        "Running %d scenarios concurrently (--parallel %d). "
+        "Server saturation under load can cause timeouts that are recorded as FAIL "
+        "even when the model reasoned correctly. "
+        "Use --parallel 1 for reproducible quality scores.",
+        total,
+        concurrency,
+    )
 
     sem = asyncio.Semaphore(concurrency)
     ordered_results: list[ScenarioResult | None] = [None] * total


### PR DESCRIPTION
## Problem

102 open CodeQL alerts. 101 carry no security severity, and the volume hid the one that did: the
ReDoS in the Prometheus label parser, fixed in #106.

I read all 102 rather than assuming the quality queries were noise. They are not: they found two
real defects. But the ratio makes the list unusable, so nobody reads it, so the one alert that
mattered sat there.

| Rule | Alerts | Verdict |
|---|---:|---|
| `py/redos` | 1 | **Real, security.** Fixed in #106 |
| `py/multiple-definition` | 2 | **Real.** Dead assignments, fixed here |
| `py/redundant-comparison` | 1 | **Real.** Always-true guard, fixed here |
| `py/ineffectual-statement` | 23 | `...` in a `Protocol` body |
| `py/unused-global-variable` | 18 | private constants shared across modules |
| `py/implicit-string-concatenation-in-list` | 12 | `ruff format`'s string wrapping |
| `py/import-and-import-from`, `py/repeated-import`, `py/unused-import` | 23 | import style and re-exports, ruff's job |
| `py/empty-except` | 9 | narrow typed excepts with a real fallback |
| `py/non-iterable-in-for-loop` | 3 | iterating an `Enum` |
| `py/unreachable-statement` | 2 | a final `return` mypy requires |
| `py/uninitialized-local-variable` | 1 | `argparse`'s `NoReturn` `error()` |
| remainder | 7 | left open, genuinely arguable |

## Solution

**The two real defects.**

`cli/leaderboard.py` assigned `scenario_count` and `backend` inside the grouping loop and never read
them. The second loop recomputes both from the winning run. Two dead lines.

`runner/orchestrator.py` guarded its parallel-path warning with `if concurrency > 1`, on a path the
`concurrency <= 1` branch has already returned from. Always true.

**The config.** Exclusions for the rules this codebase's conventions make structurally wrong, each
one recorded next to the alerts it was checked against.

I kept `security-and-quality` rather than dropping to security-only, because the quality queries are
what found the two defects above. The goal is a list short enough that the next real finding gets
noticed.

## What I checked rather than assumed

Three findings looked real and were not, which is why the exclusions name their causes:

- `_HIDDEN_ARGS` reads as dead because `cli/bench.py` rebinds itself to `cli/dispatch` through
  `sys.modules`. `tests/test_api.py:151` imports it through that alias.
- `_SCHEMA_VERSION` reads as dead because its only reader is `tests/test_storage_migrations.py:38`.
  I nearly deleted it; it is the assertion's source of truth for the migration ladder.
- The two `py/unreachable-statement` alerts are unfixable by design. Deleting either one makes mypy
  fail with `Missing return statement`, which I confirmed by doing it.

## Verification

- Required suite: 3457 passed, 1 deselected, coverage 86.90%. `ruff` and `mypy` clean.
- Config parses as YAML. The alert counts above come from the code-scanning API, not the web UI.
- No test changes: both fixes delete code that nothing reads, so the existing suite passing
  unchanged is the evidence.
- Changelog fragment added under `changelog.d/`.

## Open question for you

The ~7 remaining are judgment calls I did not want to make unilaterally: two defensive `content = ""`
assignments in plugin error branches, two `py/cyclic-import`, `py/mixed-returns` in `cli/history.py`,
and two test-file findings including a deliberate `del` inside a test named `test_del_safety_net`.
Say the word and I'll either fix them or dismiss them in the UI with reasons.

Drafted with AI assistance (Claude Code); reviewed and verified by me.