### PR TITLE
fix: allow for coarse clock granularity in the pacing tests

### DIFF
--- a/changelog.d/+windows-clock-granularity.fixed.md
+++ b/changelog.d/+windows-clock-granularity.fixed.md
@@ -1,0 +1,7 @@
+The adaptive-pacing tests no longer fail on Windows. Both asserted a
+wall-clock lower bound equal to the nominal sleep total, but `asyncio.sleep`
+returns fractionally early against a clock that ticks about every 15.6ms
+there, so three paced acquires measured 0.187 against an asserted 0.2. The CI
+matrix pins the Windows runner's seed, so this failed on every run rather than
+intermittently. Both assertions now allow one clock tick per sleep, which
+still leaves them failing by four orders of magnitude when pacing is removed.

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -271,6 +271,17 @@ class TestRateLimitRetries:
         await adapter.aclose()
 
 
+# `asyncio.sleep` schedules against the event loop clock and can return
+# fractionally early. On Windows that clock ticks about every 15.6ms, so a run
+# of N sleeps measures up to N ticks short of the nominal total: the pacing
+# assertion below saw 0.187 against a nominal 0.2 on every windows-latest run,
+# because the CI matrix pins that runner's seed.
+#
+# These two assertions are about whether pacing happened at all. Without it
+# both measure roughly zero, so allowing one tick per sleep costs them nothing.
+_CLOCK_SLACK_SECONDS = 0.016
+
+
 class TestAdaptivePacing:
     @pytest.mark.asyncio
     async def test_pacing_stays_off_until_a_rate_limit_is_seen(self) -> None:
@@ -320,7 +331,7 @@ class TestAdaptivePacing:
         await asyncio.gather(*(coordinator.acquire() for _ in range(4)))
         waited = asyncio.get_running_loop().time() - started
 
-        assert waited >= 0.25
+        assert waited >= 0.25 - _CLOCK_SLACK_SECONDS
 
     @pytest.mark.asyncio
     async def test_paced_requests_are_spaced_out(self) -> None:
@@ -332,7 +343,9 @@ class TestAdaptivePacing:
             await coordinator.acquire()
         elapsed = asyncio.get_running_loop().time() - started
 
-        assert elapsed >= 0.2  # first is free, the next two wait one step each
+        # First acquire is free, the next two wait one step each. Two sleeps, so
+        # the measurement can fall two ticks short of the nominal 0.2.
+        assert elapsed >= 0.2 - 2 * _CLOCK_SLACK_SECONDS
 
 
 class TestDisplayReporting:


### PR DESCRIPTION
## Problem

`main` is red on Windows, and has been since the runner was added in #93.

`TestAdaptivePacing::test_paced_requests_are_spaced_out` asserts that three paced acquires on a 0.1s
step take at least the nominal `0.2`. `asyncio.sleep` schedules against the event loop clock and can
return fractionally early; on Windows that clock ticks roughly every 15.6ms, so two sleeps measured
`0.18699999999989814` and the assertion failed.

This is not flake. The CI matrix pins the `windows-latest` seed to `199933` (`ci.yml:56`), so it
reproduces on every run, with the same measured value:

| Run | Branch | Commit | Result |
|---|---|---|---|
| 32994423573 | `main` | `0fd93d1` | 0.187 >= 0.2 fails |
| 32997044842 | `chore/codeql-signal-and-dead-code` | | identical failure |

It surfaced while landing #107, which does not touch this code. Every PR inherits it.

## Solution

Allow one clock tick of slack per sleep, with the reason recorded next to the constant.

`test_pause_holds_concurrent_requests_together` has the same shape and the same latent failure. It
only survives because it waits on one sleep rather than two, so it is one tick from the same fate.
It gets the same treatment rather than waiting to be found on a future run.

## Verification

- **The assertions still do their job.** With the pacing sleep removed from
  `RateLimitCoordinator.acquire`, the paced test measures `3.2e-05` against a floor of `0.168`. The
  slack costs four orders of magnitude of margin, not the test's meaning.
- Full suite at the Windows seed `199933` locally: 3463 passed, 1 deselected. `ruff` and `mypy` clean.
- The real check is this PR's own `windows-latest` job, which runs the pinned seed.
- Changelog fragment added under `changelog.d/`.

## What I did not do

The deeper fix is to assert on the coordinator's own pacing accounting rather than on wall-clock
elapsed, which would remove the timing dependence entirely. That is a rewrite of what these two
tests check, so it wants its own change and its own review. This one unblocks CI.

Drafted with AI assistance (Claude Code); reviewed and verified by me.