### PR TITLE
chore: clear the last CodeQL alerts worth acting on

### DIFF
--- a/changelog.d/+unread-error-branch-assignments.changed.md
+++ b/changelog.d/+unread-error-branch-assignments.changed.md
@@ -1,0 +1,4 @@
+The IFEval and MMLU plugins no longer assign a `content` fallback in their
+per-item error branches. Nothing read it: an item that raises sets
+`is_error`, and `content` is only read on the path that requires `is_error` to
+be false. Removing it means one less branch to trace to establish that.

--- a/changelog.d/+unread-error-branch-assignments.changed.md
+++ b/changelog.d/+unread-error-branch-assignments.changed.md
@@ -1,4 +1,6 @@
 The IFEval and MMLU plugins no longer assign a `content` fallback in their
 per-item error branches. Nothing read it: an item that raises sets
 `is_error`, and `content` is only read on the path that requires `is_error` to
-be false. Removing it means one less branch to trace to establish that.
+be false. Removing it means one less branch to trace to establish that. The
+migration test also drops a `try`/`finally` that closed a repository the
+`open_repository` helper already closes through an autouse fixture.

--- a/src/tool_eval_bench/plugins/ifeval/plugin.py
+++ b/src/tool_eval_bench/plugins/ifeval/plugin.py
@@ -138,7 +138,6 @@ class IFEvalPlugin(BenchmarkPlugin):
                 is_error = False
             except Exception as exc:
                 logger.debug("Error on prompt %d: %s", item.key, exc)
-                content = ""
                 is_error = True
                 error_count += 1
 

--- a/src/tool_eval_bench/plugins/mmlu/plugin.py
+++ b/src/tool_eval_bench/plugins/mmlu/plugin.py
@@ -161,7 +161,6 @@ class MMLUPlugin(BenchmarkPlugin):
                 is_error = False
             except Exception as exc:
                 logger.debug("Error on question %d: %s", item.index, exc)
-                content = ""
                 is_error = True
                 error_count += 1
 

--- a/tests/test_storage_migrations.py
+++ b/tests/test_storage_migrations.py
@@ -26,28 +26,25 @@ def test_old_database_is_migrated_to_current_schema(tmp_path: Path) -> None:
         conn.execute("PRAGMA user_version = 0")
 
     repo = open_repository(db_path=str(db_path))
-    try:
-        with sqlite3.connect(db_path) as conn:
-            columns = {row[1] for row in conn.execute("PRAGMA table_info(scenario_runs)")}
-            version = conn.execute("PRAGMA user_version").fetchone()[0]
-            tables = {
-                row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-            }
-        assert {"run_type", "report_path"} <= columns
-        assert {"run_checkpoints", "scenario_traces"} <= tables
-        assert version == _SCHEMA_VERSION
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(scenario_runs)")}
+        version = conn.execute("PRAGMA user_version").fetchone()[0]
+        tables = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    assert {"run_type", "report_path"} <= columns
+    assert {"run_checkpoints", "scenario_traces"} <= tables
+    assert version == _SCHEMA_VERSION
 
-        repo.upsert_scenario_run(
-            {
-                "run_id": "migrated",
-                "status": "completed",
-                "config": {"model": "test"},
-                "scores": {},
-                "report_path": "runs/migrated.md",
-            }
-        )
-        stored = repo.get("migrated")
-        assert stored is not None
-        assert stored["report_path"] == "runs/migrated.md"
-    finally:
-        repo.close()
+    repo.upsert_scenario_run(
+        {
+            "run_id": "migrated",
+            "status": "completed",
+            "config": {"model": "test"},
+            "scores": {},
+            "report_path": "runs/migrated.md",
+        }
+    )
+    stored = repo.get("migrated")
+    assert stored is not None
+    assert stored["report_path"] == "runs/migrated.md"


### PR DESCRIPTION
## Problem

The seven CodeQL alerts left open after #107. I proposed dismissing five and fixing two. Auditing
them properly turned up **three** worth fixing, not two.

## Solution

**1. Two `content` assignments no branch reads** (`py/unused-local-variable`). The IFEval and MMLU
plugins assign `content = ""` when an item raises, then route on `is_error` to a branch that never
reads `content`. The only reader is the success branch, which requires `is_error` to be false.

The argument against removing them is real: if a future error branch did read `content`, it would
see the previous iteration's value instead of `""`. I think that is the better failure. A stale
value that reads as plausible is worse than one that is obviously wrong, and the branch currently
costs every reader a trace through two paths to learn the value does not matter.

**2. A redundant `try`/`finally`** (`py/should-use-with`) in `test_storage_migrations.py`. **I had
this queued for dismissal as "test-only" and was wrong twice.** `RunRepository` does implement
`__enter__`/`__exit__`, so `with` was available; and better still, `open_repository` already
registers every repository with an autouse fixture that closes them after the test, and `close()`
is idempotent. The block guarded nothing. Deleting it beats converting it.

## Verification

- Required suite at the Windows seed `199933`: 3463 passed, 1 deselected. `ruff` and `mypy` clean,
  including that neither `content` reader became possibly-unbound.
- No test changes for the plugin fix: it deletes code nothing reads, so the suite passing unchanged
  is the evidence. The migration test still passes, now relying on the fixture that was already
  doing the work.
- Changelog fragment added under `changelog.d/`.

## The four dismissed, with reasons recorded on each alert

- **2 × `py/cyclic-import`.** A real cycle, not a false positive: `runner/speculative.py:30` imports
  from `runner/throughput.py` at module level and `throughput.py:984` imports back inside a
  function, which is what stops it forming at runtime. Untangling it means extracting
  `ThroughputSample`, `TokenizerConfig`, `_build_messages` and `_stream_one` into a shared module.
  That is an architectural change wanting its own decision, so: won't fix, not wrong.
- **`py/mixed-returns`** in `cli/history.py:316`. False positive. Every non-return path in
  `_resolve` ends in `sys.exit(1)`, which typeshed types `NoReturn` and the query does not model.
  Same cause as the `parser.error` alert excluded in #107.
- **`py/unnecessary-delete`** in `test_del_safety_net`, where the `del` is the subject of the test.

Drafted with AI assistance (Claude Code); reviewed and verified by me.