### PR TITLE
fix: guard TC-62's revision check against an empty qualifying-email list

### DIFF
--- a/changelog.d/111.fixed.md
+++ b/changelog.d/111.fixed.md
@@ -1,0 +1,5 @@
+TC-62 no longer crashes with `IndexError` when the model sends an email that
+does not qualify — wrong recipient, or a missing subject or body. The revision
+check indexed the list of qualifying sends without guarding it for emptiness,
+so a gradable run was scored as an evaluator error (FAIL, 0/2) instead of the
+partial credit it had earned.

--- a/src/tool_eval_bench/evals/scenarios/planning/tc62.py
+++ b/src/tool_eval_bench/evals/scenarios/planning/tc62.py
@@ -198,8 +198,12 @@ def _tc62_eval(state: ScenarioState) -> ScenarioEvaluation:
         word in body_lower for word in ("optimistic", "improve", "growth", "positive", "expect")
     )
     phase_data_present = any(call.user_phase is not None for call in state.tool_calls)
-    email_after_revision = not phase_data_present or (
-        email_calls[-1].user_phase is not None and email_calls[-1].user_phase >= 4
+    # `email_calls` holds only the *qualifying* sends — right recipient, subject,
+    # body, and a "sent" result. A model that emails the wrong address, or omits
+    # a subject, leaves it empty while still producing phase data, so this must
+    # be guarded the way `email_after_research` below already is.
+    email_after_revision = not phase_data_present or bool(
+        email_calls and email_calls[-1].user_phase is not None and email_calls[-1].user_phase >= 4
     )
     research_indices = [
         *[_call_index(state, call) for call in corrected_file_calls],

--- a/tests/test_planning_scenarios.py
+++ b/tests/test_planning_scenarios.py
@@ -1658,6 +1658,133 @@ class TestTC61EdgeCases:
         assert result.status == ScenarioStatus.FAIL
 
 
+class TestTC62PhaseDataWithoutQualifyingEmail:
+    """Regression for #111: a non-qualifying email must not crash the evaluator.
+
+    ``email_calls`` holds only sends that pass every check — CFO recipient,
+    non-empty subject and body, "sent" result. A model that misses any of those
+    leaves it empty while still producing ``user_phase`` data, which used to
+    make the revision check index an empty list.
+    """
+
+    sc = _get("TC-62")
+
+    def _state(self, email_arguments: dict | None) -> ScenarioState:
+        calls = [
+            {
+                "name": "web_search",
+                "arguments": {"query": "quarterly performance"},
+                "turn": 1,
+                "user_phase": 0,
+            }
+        ]
+        if email_arguments is not None:
+            calls.append(
+                {"name": "send_email", "arguments": email_arguments, "turn": 6, "user_phase": 4}
+            )
+        return _make_state(
+            tool_calls=calls,
+            assistant_messages=["Looked it up.", "Sent a summary."],
+            final_answer="Sent a summary.",
+        )
+
+    def test_email_to_the_wrong_recipient_is_graded_not_crashed(self) -> None:
+        result = self.sc.evaluate(
+            self._state({"to": "team@company.com", "subject": "Analysis", "body": "Revenue up."})
+        )
+        assert result.status == ScenarioStatus.PARTIAL
+
+    def test_email_missing_a_subject_is_graded_not_crashed(self) -> None:
+        result = self.sc.evaluate(
+            self._state({"to": "cfo@company.com", "subject": "", "body": "Revenue up."})
+        )
+        assert result.status == ScenarioStatus.PARTIAL
+
+    def test_email_missing_a_body_is_graded_not_crashed(self) -> None:
+        result = self.sc.evaluate(
+            self._state({"to": "cfo@company.com", "subject": "Analysis", "body": ""})
+        )
+        assert result.status == ScenarioStatus.PARTIAL
+
+    def test_no_email_at_all_with_phase_data_is_graded_not_crashed(self) -> None:
+        assert self.sc.evaluate(self._state(None)).status == ScenarioStatus.FAIL
+
+
+class TestTC62RevisionOrdering:
+    """The revision check still discriminates once a qualifying email exists."""
+
+    sc = _get("TC-62")
+
+    def _state(self, email_phase: int) -> ScenarioState:
+        body = (
+            "Our Q3 revenue was $4.15M vs Acme's $3.8M. We outperformed by $350K. "
+            "We expect Q4 to improve further."
+        )
+        return _make_state(
+            tool_calls=[
+                {"name": "search_files", "arguments": {"query": "Q3"}, "turn": 2, "user_phase": 1},
+                {
+                    "name": "read_file",
+                    "arguments": {"file_id": "q3_latest"},
+                    "turn": 3,
+                    "user_phase": 1,
+                },
+                {
+                    "name": "web_search",
+                    "arguments": {"query": "Acme Corp Q3 revenue"},
+                    "turn": 4,
+                    "user_phase": 2,
+                },
+                {"name": "get_contacts", "arguments": {"query": "CFO"}, "turn": 5, "user_phase": 3},
+                {
+                    "name": "send_email",
+                    "arguments": {
+                        "to": "cfo@company.com",
+                        "subject": "Competitive Analysis",
+                        "body": body,
+                    },
+                    "turn": 6,
+                    "user_phase": email_phase,
+                },
+            ],
+            tool_results=[
+                {
+                    "call_id": "call_0",
+                    "name": "search_files",
+                    "result": {"results": [{"file_id": "q3_latest"}]},
+                },
+                {
+                    "call_id": "call_1",
+                    "name": "read_file",
+                    "result": {"content": "Q3 Report (CORRECTED) Revenue: 4150000 corrected"},
+                },
+                {
+                    "call_id": "call_2",
+                    "name": "web_search",
+                    "result": {"results": [{"snippet": "Acme Corp Q3 revenue: $3.8m"}]},
+                },
+                {
+                    "call_id": "call_3",
+                    "name": "get_contacts",
+                    "result": {"results": [{"email": "cfo@company.com"}]},
+                },
+                {"call_id": "call_4", "name": "send_email", "result": {"status": "sent"}},
+            ],
+            assistant_messages=[
+                "The corrected Q3 revenue is $4,150,000.",
+                "Acme Corp's Q3 revenue was $3.8M.",
+                "Sent the analysis to the CFO.",
+            ],
+            final_answer="Sent the analysis to the CFO.",
+        )
+
+    def test_email_sent_after_the_revision_passes(self) -> None:
+        assert self.sc.evaluate(self._state(4)).status == ScenarioStatus.PASS
+
+    def test_email_sent_before_the_revision_does_not_pass(self) -> None:
+        assert self.sc.evaluate(self._state(2)).status == ScenarioStatus.PARTIAL
+
+
 class TestTC62EdgeCases:
     sc = _get("TC-62")
 


### PR DESCRIPTION
Fixes #111.

## Problem

TC-62 crashed for @gilesco with:

```
File "src/tool_eval_bench/evals/scenarios/planning/tc62.py", line 202, in _tc62_eval
    email_calls[-1].user_phase is not None and email_calls[-1].user_phase >= 4
IndexError: list index out of range
```

`email_calls` holds only the *qualifying* sends — CFO recipient, non-empty subject and body, and a `"sent"` result. `email_attempts` holds any `send_email`. A model that emails the wrong address, or omits a subject, leaves `email_calls` empty while still producing `user_phase` data, and the revision check indexed it unguarded.

The two neighbouring expressions already guard for exactly this case — `email_body` on line 190 and `email_after_research` on line 209 — so this line was the outlier rather than a new hazard.

This misgraded rather than merely logging. The orchestrator converts an evaluator error into `FAIL 0/2`, so a run that had earned partial credit scored zero. Reproducing the reported trace, it now grades `PARTIAL 1/2`.

## Solution

One guard, matching the shape `email_after_research` already uses:

```python
email_after_revision = not phase_data_present or bool(
    email_calls and email_calls[-1].user_phase is not None and email_calls[-1].user_phase >= 4
)
```

No outcome changes for runs that did not crash. The PASS branch already requires `email_after_research`, which is false whenever `email_calls` is empty, so the guarded expression cannot produce a verdict the old one did not.

**Why no test caught it:** none of the existing TC-62 tests set `user_phase`, so `phase_data_present` was always false and the crash path was unreachable.

**Swept for the same shape elsewhere.** Six other evaluators index a filtered list at `[-1]`; all are safe: tc57 and tc58 guard via `bool()` of the same list, tc25/tc28/tc88 have early returns, and tc87 short-circuits because `complete` requires `len(pages) == 4`. TC-62 was the only reachable one.

## Verification

- Reproduced the exact `IndexError` from the report before fixing
- Six new tests: four crash variants (wrong recipient, missing subject, missing body, no email at all) plus two pinning that the revision check still discriminates — phase 4 passes, phase 2 drops to partial
- The four crash tests fail with the reported `IndexError` at line 202 when the fix is reverted, and pass with it
- `ruff check`, `ruff format --check`, `mypy` clean
- Full suite on all three CI seeds (104729, 130363, 155921): 3525 passed

---

Written with AI assistance; reviewed before opening.
