### PR TITLE
feat: distinguish timeouts from failures, and bound unstreamed turns by measurement

### DIFF
--- a/changelog.d/+timeout-diagnostics.changed.md
+++ b/changelog.d/+timeout-diagnostics.changed.md
@@ -1,0 +1,11 @@
+Timed-out scenarios no longer render as `FAIL 0/2`. They show as `⏱ TIMEOUT` with
+`–/2` points and a reason, because an infrastructure failure leaves the scenario
+out of both the numerator and the denominator rather than scoring it zero. When a
+run has timeouts, it now also prints what to change, using the slowest turn it
+measured and the timeout that was in force.
+
+Turns after the first are given a timeout scaled from turn 1's measured latency.
+Only turn 1 is streamed, so on later turns the read timeout bounds the whole
+generation instead of the gap between tokens, and a slow reasoning model could
+blow it on turn 2 without having slowed down. A hung endpoint never completes
+turn 1, so it still fails at the configured timeout.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -50,18 +50,45 @@ tool-eval-bench run --no-preflight
 
 ## Timeouts on thinking models
 
-Models with reasoning enabled routinely exceed the 60-second default. Raise it:
+A timed-out scenario shows as `⏱  TIMEOUT` with `–/2` points, not as a failure. It is excluded from
+both the numerator and the denominator, so the run says nothing about the model on that scenario.
+Check `completion_rate` before comparing the score to anything.
+
+The run prints what to change, computed from the slowest turn it actually measured. Take that
+suggestion first.
+
+Reasoning models routinely exceed the 120-second default. Raise it:
 
 ```bash
-tool-eval-bench run --timeout 120
+tool-eval-bench run --timeout 600
 ```
 
-Thinking is also worth disabling outright for a first check, since it changes both the latency and
-the tool-calling behavior you are measuring:
+Or shorten what the model generates, which fixes the cause rather than the symptom:
 
 ```bash
-tool-eval-bench run --no-think
+tool-eval-bench run --no-think                                    # reasoning off entirely
+tool-eval-bench run --backend-kwargs '{"reasoning_effort": "low"}'  # if your server honours it
+tool-eval-bench run --backend-kwargs '{"max_tokens": 1024}'         # hard cap on generation
 ```
+
+`--no-think` changes both the latency and the tool-calling behavior you are measuring, so it is a
+diagnostic rather than a setting to keep. Scenarios that score provider-exposed reasoning, such as
+TC-88, cannot reach a pass without it.
+
+### Why a later turn times out when the first one did not
+
+Only the first turn of a scenario is streamed. On a streamed turn the read timeout measures the gap
+between tokens, so a long generation never trips it. Every later turn arrives as one response, which
+makes the same number bound the whole generation instead.
+
+A model that comfortably finished turn 1 in 150 seconds under a 120-second timeout will therefore
+die on turn 2 without having slowed down at all. To stop that, later turns are given a multiple of
+what turn 1 actually took, so a model that has demonstrated it is slow gets room while a hung
+endpoint still fails at the configured timeout. Raising `--timeout` further is still the fix when
+even that is not enough.
+
+Eleven of the 88 scenarios have follow-up turns, so on a slow deployment this shows up as a handful
+of exclusions rather than a whole-run failure.
 
 ## Rate limits against a hosted endpoint
 

--- a/src/tool_eval_bench/cli/display.py
+++ b/src/tool_eval_bench/cli/display.py
@@ -21,8 +21,10 @@ from rich.table import Table
 from rich.text import Text
 
 from tool_eval_bench.adapters.openai_compat import RateLimitStatus
+from tool_eval_bench.cli.timeout_advice import infrastructure_note, timeout_advice
 from tool_eval_bench.domain.scenarios import (
     Category,
+    FailureKind,
     ModelScoreSummary,
     ScenarioDefinition,
     ScenarioResult,
@@ -42,6 +44,17 @@ STATUS_LABELS = {
     ScenarioStatus.PARTIAL: ("⚠️  PARTIAL", "yellow"),
     ScenarioStatus.FAIL: ("❌ FAIL", "red"),
 }
+
+# Infrastructure failures carry their own labels because they are not verdicts.
+# Rendering a timeout as "FAIL 0/2" states two things that are untrue: that the
+# model got it wrong, and that it scored zero. The scenario is dropped from the
+# numerator and the denominator, so it scored nothing at all.
+INFRA_LABELS = {
+    FailureKind.TIMEOUT: ("⏱  TIMEOUT", "yellow"),
+    FailureKind.CONNECTION_ERROR: ("🔌 NO CONN", "yellow"),
+    FailureKind.SERVER_ERROR: ("🛑 SERVER", "yellow"),
+}
+INFRA_FALLBACK_LABEL = ("⚠  INFRA", "yellow")
 
 CATEGORY_COLORS = {
     Category.A: "cyan",
@@ -205,7 +218,14 @@ class BenchmarkDisplay:
     def _format_result_line(self, scenario: ScenarioDefinition, result: ScenarioResult) -> str:
         """Format a single scenario result as a compact one-line log entry."""
         cat_color = CATEGORY_COLORS.get(scenario.category, "white")
-        label, status_color = STATUS_LABELS.get(result.status, ("?", "white"))
+        infrastructure = result.is_infrastructure_failure
+        if infrastructure:
+            label, status_color = INFRA_LABELS.get(result.failure_kind or "", INFRA_FALLBACK_LABEL)
+            # An en dash, not 0: the scenario left the denominator too.
+            points = "–"
+        else:
+            label, status_color = STATUS_LABELS.get(result.status, ("?", "white"))
+            points = str(result.points)
         dur = f"{result.duration_seconds:.1f}s"
 
         # Latency info
@@ -220,13 +240,17 @@ class BenchmarkDisplay:
         line = (
             f"  [{cat_color}]●[/] {scenario.id}  {scenario.title:<30s}"
             f"  [{status_color}]{label}[/]"
-            f"  [bold]{result.points}[/]/2"
+            f"  [bold]{points}[/]/2"
             f"  [dim]{dur:>5s}[/]"
             f"{latency_str}"
         )
 
         # Append summary for non-pass results
-        if result.status != ScenarioStatus.PASS:
+        if infrastructure:
+            # The evaluator never ran, so there is no summary to show. Say why
+            # the line is here instead of leaving it to trail off blank.
+            line += f"  [{status_color}]{infrastructure_note(result)}[/]"
+        elif result.status != ScenarioStatus.PASS:
             line += f"  [{status_color}]{result.summary}[/]"
         else:
             line += f"  [dim]{result.summary}[/]"
@@ -358,10 +382,17 @@ def _print_final_panel(
     )
 
     if summary.excluded_scenarios:
+        excluded = ", ".join(summary.excluded_scenarios)
         content += (
             f"\n  [yellow]⚠  {len(summary.excluded_scenarios)} scenario(s) excluded "
-            f"(infrastructure failure) — completion rate {summary.completion_rate}%[/]"
+            f"(infrastructure failure), completion rate {summary.completion_rate}%[/]"
+            f"\n  [dim]     {excluded}[/]"
         )
+        for advice in timeout_advice(
+            summary,
+            timeout_seconds=getattr(run_context, "timeout_seconds", None),
+        ):
+            content += f"\n  [yellow]   {advice}[/]"
 
     # Deployability composite (only when latency data is present)
     if summary.deployability is not None and summary.responsiveness is not None:

--- a/src/tool_eval_bench/cli/timeout_advice.py
+++ b/src/tool_eval_bench/cli/timeout_advice.py
@@ -1,0 +1,99 @@
+"""Explain infrastructure failures, and say what to change.
+
+A timeout is not a verdict. It leaves the scenario out of both the numerator and
+the denominator, so the run says nothing about the model on that scenario. The
+display still has to put *something* on the line, and "FAIL 0/2" followed by an
+empty summary reads exactly like a model that got the answer wrong.
+
+These helpers supply the missing half: what happened, and the flag that fixes it.
+The advice is computed from the run's own measurements rather than canned, so it
+names the timeout that was in force and the turn latency that overran it.
+"""
+
+from __future__ import annotations
+
+from tool_eval_bench.domain.scenarios import (
+    FailureKind,
+    ModelScoreSummary,
+    ScenarioResult,
+)
+
+_KIND_NOTES = {
+    FailureKind.TIMEOUT: "excluded from scoring (request timed out)",
+    FailureKind.CONNECTION_ERROR: "excluded from scoring (connection failed)",
+    FailureKind.SERVER_ERROR: "excluded from scoring (server error)",
+}
+_FALLBACK_NOTE = "excluded from scoring (infrastructure failure)"
+
+# Headroom over the slowest observed turn. A model that needed 151s for one turn
+# will not reliably fit in 151s on the next, so the suggestion has to clear the
+# measurement rather than match it.
+_SUGGESTION_HEADROOM = 2.5
+
+# Round suggestions up to this many seconds so the advice reads like a setting
+# somebody would type.
+_SUGGESTION_STEP = 60
+
+
+def infrastructure_note(result: ScenarioResult) -> str:
+    """One-line reason for a scenario that never reached the evaluator."""
+    if result.summary:
+        return result.summary
+    return _KIND_NOTES.get(result.failure_kind or "", _FALLBACK_NOTE)
+
+
+def suggested_timeout(slowest_turn_ms: float, configured_seconds: float) -> int:
+    """Return a timeout that clears the slowest turn actually observed."""
+    target = max(configured_seconds, slowest_turn_ms / 1000 * _SUGGESTION_HEADROOM)
+    steps = int(target // _SUGGESTION_STEP) + 1
+    return steps * _SUGGESTION_STEP
+
+
+def timeout_advice(
+    summary: ModelScoreSummary,
+    *,
+    timeout_seconds: float | None = None,
+) -> list[str]:
+    """Return advice lines for timed-out scenarios, or an empty list.
+
+    Only timeouts get advice. A connection error or a 5xx is a different
+    problem, and telling somebody to raise ``--timeout`` would send them the
+    wrong way.
+    """
+    timed_out = [
+        r
+        for r in summary.scenario_results
+        if r.is_infrastructure_failure and r.failure_kind == FailureKind.TIMEOUT
+    ]
+    if not timed_out:
+        return []
+
+    lines = [
+        f"{len(timed_out)} scenario(s) timed out and were excluded from scoring, "
+        "so this run does not measure the model on them.",
+    ]
+
+    multi_turn = [r for r in timed_out if r.turn_latencies_ms]
+    slowest = max((max(r.turn_latencies_ms) for r in multi_turn), default=0.0)
+
+    if slowest > 0:
+        lines.append(
+            f"Slowest completed turn: {slowest / 1000:.0f}s. "
+            "Only the first turn is streamed, so on later turns the timeout "
+            "bounds the whole generation rather than the gap between tokens."
+        )
+
+    if timeout_seconds and slowest > 0:
+        suggestion = suggested_timeout(slowest, timeout_seconds)
+        lines.append(
+            f"Retry with --timeout {suggestion} (currently {timeout_seconds:.0f}), "
+            "or shorten generation with --no-think or "
+            "--backend-kwargs '{\"max_tokens\": 1024}'."
+        )
+    else:
+        lines.append(
+            "Retry with a higher --timeout, or shorten generation with --no-think "
+            "or --backend-kwargs '{\"max_tokens\": 1024}'."
+        )
+
+    return lines

--- a/src/tool_eval_bench/domain/timeouts.py
+++ b/src/tool_eval_bench/domain/timeouts.py
@@ -1,0 +1,36 @@
+"""How long a turn is allowed to take.
+
+The orchestrator streams the first turn of a scenario and no others. That one
+detail decides what a request timeout actually bounds, so the rule for turns
+after the first lives here rather than being inlined at the call site.
+"""
+
+from __future__ import annotations
+
+# Headroom applied to turn 1's measured latency when bounding a later,
+# unstreamed turn. Later turns carry a longer prompt and, for reasoning models,
+# often more to say, so matching turn 1 exactly would leave no margin.
+UNSTREAMED_TURN_HEADROOM = 2.5
+
+
+def unstreamed_turn_timeout(configured_seconds: float, first_turn_ms: float) -> float:
+    """Return the timeout to allow for a turn that is not streamed.
+
+    ``httpx``'s read timeout measures the gap between reads, not total elapsed
+    time. On a streamed turn, tokens keep arriving and a long generation never
+    trips it. On an unstreamed turn the whole response arrives at once, so the
+    same number bounds the entire generation. A model comfortably inside the
+    timeout on turn 1 can therefore blow it on turn 2 without having slowed
+    down at all.
+
+    Turn 1 is a free measurement of this model's speed on this exact prompt, and
+    being streamed it cannot time out spuriously, so later turns get a multiple
+    of what turn 1 actually took. A hung endpoint never completes turn 1, so it
+    still fails at the configured timeout instead of being handed more rope.
+
+    Returns ``configured_seconds`` unchanged when turn 1 produced no usable
+    measurement.
+    """
+    if first_turn_ms <= 0:
+        return configured_seconds
+    return max(configured_seconds, first_turn_ms / 1000 * UNSTREAMED_TURN_HEADROOM)

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -45,6 +45,7 @@ from tool_eval_bench.domain.scenarios import (
     compute_deployability,
     rating_for_score,
 )
+from tool_eval_bench.domain.timeouts import unstreamed_turn_timeout
 from tool_eval_bench.domain.tools import (
     BENCHMARK_REFERENCE_DATE,
     BENCHMARK_REFERENCE_DAY,
@@ -426,6 +427,18 @@ async def run_scenario(
             if state.tool_calls and scenario.tool_choice_after_first_call is not None:
                 active_tool_choice = scenario.tool_choice_after_first_call
 
+            # Turns after the first are not streamed, so the read timeout bounds
+            # the whole generation instead of the gap between tokens. Scale it
+            # from what turn 1 actually took. See domain.timeouts.
+            turn_timeout = (
+                timeout_seconds
+                if use_stream
+                else unstreamed_turn_timeout(
+                    timeout_seconds,
+                    turn_latencies[0] if turn_latencies else 0.0,
+                )
+            )
+
             result = await adapter.chat_completion(
                 model=model,
                 messages=messages,
@@ -433,7 +446,7 @@ async def run_scenario(
                 tool_choice=active_tool_choice if scenario_tools else None,
                 temperature=temperature,
                 max_tokens=4096,
-                timeout_seconds=timeout_seconds,
+                timeout_seconds=turn_timeout,
                 api_key=api_key,
                 base_url=base_url,
                 extra_params=extra,

--- a/tests/test_timeout_diagnostics.py
+++ b/tests/test_timeout_diagnostics.py
@@ -1,0 +1,213 @@
+"""Infrastructure failures: how they render, what they advise, how they are bounded.
+
+Covers the three halves of the timeout problem. A scenario dropped from scoring
+must not render as a verdict, the run must say what to change, and a turn that
+is not streamed must be bounded by what the model actually demonstrated rather
+than by a number calibrated for a streamed turn.
+"""
+
+from __future__ import annotations
+
+import pytest
+from rich.console import Console
+
+from tool_eval_bench.cli.display import BenchmarkDisplay
+from tool_eval_bench.cli.timeout_advice import (
+    infrastructure_note,
+    suggested_timeout,
+    timeout_advice,
+)
+from tool_eval_bench.domain.scenarios import (
+    FailureKind,
+    ModelScoreSummary,
+    ScenarioResult,
+    ScenarioStatus,
+)
+from tool_eval_bench.domain.timeouts import unstreamed_turn_timeout
+from tool_eval_bench.evals.scenarios import ALL_SCENARIOS_WITH_HARDMODE
+
+
+def _result(
+    *,
+    kind: str | None = FailureKind.TIMEOUT,
+    status: ScenarioStatus = ScenarioStatus.FAIL,
+    summary: str = "",
+    latencies: list[float] | None = None,
+    points: int = 0,
+) -> ScenarioResult:
+    return ScenarioResult(
+        scenario_id="TC-88",
+        status=status,
+        points=points,
+        summary=summary,
+        failure_kind=kind,
+        duration_seconds=271.3,
+        ttft_ms=490.2,
+        turn_count=1,
+        turn_latencies_ms=latencies if latencies is not None else [151199.4],
+    )
+
+
+def _summary(results: list[ScenarioResult]) -> ModelScoreSummary:
+    return ModelScoreSummary(
+        scenario_results=results,
+        category_scores=[],
+        final_score=0,
+        total_points=0,
+        max_points=0,
+        rating="★ Poor",
+        excluded_scenarios=[r.scenario_id for r in results if r.is_infrastructure_failure],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Result line
+# ---------------------------------------------------------------------------
+
+
+class TestResultLine:
+    def _line(self, result: ScenarioResult) -> str:
+        scenario = next(s for s in ALL_SCENARIOS_WITH_HARDMODE if s.id == "TC-88")
+        display = BenchmarkDisplay("m", "vllm", "http://x", scenarios=[scenario])
+        console = Console(record=True, width=200)
+        console.print(display._format_result_line(scenario, result))
+        return console.export_text()
+
+    def test_timeout_is_not_labelled_a_failure(self) -> None:
+        line = self._line(_result())
+        assert "TIMEOUT" in line
+        assert "FAIL" not in line
+
+    def test_timeout_does_not_claim_zero_points(self) -> None:
+        # 0/2 would say the scenario scored zero. It left the denominator too.
+        line = self._line(_result())
+        assert "0/2" not in line
+        assert "–/2" in line
+
+    def test_timeout_states_why_the_line_is_there(self) -> None:
+        assert "excluded from scoring" in self._line(_result())
+
+    @pytest.mark.parametrize(
+        ("kind", "expected"),
+        [
+            (FailureKind.TIMEOUT, "TIMEOUT"),
+            (FailureKind.CONNECTION_ERROR, "NO CONN"),
+            (FailureKind.SERVER_ERROR, "SERVER"),
+        ],
+    )
+    def test_each_infrastructure_kind_has_its_own_label(self, kind: str, expected: str) -> None:
+        assert expected in self._line(_result(kind=kind))
+
+    def test_model_failure_still_renders_as_a_failure(self) -> None:
+        line = self._line(
+            _result(
+                kind=FailureKind.MISSING_STEP, summary="Returned extra text.", latencies=[286.5]
+            )
+        )
+        assert "FAIL" in line
+        assert "0/2" in line
+        assert "Returned extra text." in line
+
+    def test_pass_is_untouched(self) -> None:
+        line = self._line(
+            _result(kind=None, status=ScenarioStatus.PASS, points=2, summary="Did the thing.")
+        )
+        assert "PASS" in line
+        assert "2/2" in line
+
+
+# ---------------------------------------------------------------------------
+# Advice
+# ---------------------------------------------------------------------------
+
+
+class TestInfrastructureNote:
+    def test_falls_back_to_a_reason_when_there_is_no_summary(self) -> None:
+        assert infrastructure_note(_result()) == "excluded from scoring (request timed out)"
+
+    def test_a_real_summary_wins(self) -> None:
+        assert infrastructure_note(_result(summary="Server said no.")) == "Server said no."
+
+    def test_unknown_kind_still_gets_a_note(self) -> None:
+        assert "excluded from scoring" in infrastructure_note(_result(kind="something_new"))
+
+
+class TestTimeoutAdvice:
+    def test_silent_when_nothing_timed_out(self) -> None:
+        clean = _result(kind=None, status=ScenarioStatus.PASS, points=2, summary="ok")
+        assert timeout_advice(_summary([clean]), timeout_seconds=120) == []
+
+    def test_silent_for_a_connection_error(self) -> None:
+        # Raising --timeout would not help, so do not suggest it.
+        conn = _result(kind=FailureKind.CONNECTION_ERROR)
+        assert timeout_advice(_summary([conn]), timeout_seconds=120) == []
+
+    def test_names_the_observed_latency_and_current_timeout(self) -> None:
+        text = " ".join(timeout_advice(_summary([_result()]), timeout_seconds=120))
+        assert "151s" in text
+        assert "currently 120" in text
+
+    def test_suggests_a_timeout_that_clears_the_slowest_turn(self) -> None:
+        text = " ".join(timeout_advice(_summary([_result()]), timeout_seconds=120))
+        assert "--timeout 420" in text
+
+    def test_offers_a_way_to_shorten_generation(self) -> None:
+        text = " ".join(timeout_advice(_summary([_result()]), timeout_seconds=120))
+        assert "--no-think" in text
+        assert "max_tokens" in text
+
+    def test_explains_the_streaming_asymmetry(self) -> None:
+        text = " ".join(timeout_advice(_summary([_result()]), timeout_seconds=120))
+        assert "first turn is streamed" in text
+
+    def test_works_without_a_known_timeout(self) -> None:
+        text = " ".join(timeout_advice(_summary([_result()]), timeout_seconds=None))
+        assert "higher --timeout" in text
+
+    def test_works_without_latency_data(self) -> None:
+        text = " ".join(timeout_advice(_summary([_result(latencies=[])]), timeout_seconds=120))
+        assert text
+        assert "--timeout" in text
+
+    def test_counts_every_timed_out_scenario(self) -> None:
+        text = " ".join(timeout_advice(_summary([_result(), _result()]), timeout_seconds=120))
+        assert "2 scenario(s) timed out" in text
+
+
+class TestSuggestedTimeout:
+    def test_clears_the_observed_turn(self) -> None:
+        assert suggested_timeout(151_199, 120) >= 151 * 2
+
+    def test_rounds_to_a_typeable_number(self) -> None:
+        assert suggested_timeout(151_199, 120) % 60 == 0
+
+    def test_never_suggests_lowering_the_configured_value(self) -> None:
+        assert suggested_timeout(1_000, 600) >= 600
+
+
+# ---------------------------------------------------------------------------
+# Unstreamed turn budget
+# ---------------------------------------------------------------------------
+
+
+class TestUnstreamedTurnTimeout:
+    def test_slow_first_turn_widens_the_budget(self) -> None:
+        # 151s on turn 1 must not leave turn 2 bounded by 120s.
+        assert unstreamed_turn_timeout(120, 151_199) == pytest.approx(151.199 * 2.5)
+
+    def test_fast_first_turn_keeps_the_configured_timeout(self) -> None:
+        assert unstreamed_turn_timeout(120, 300) == 120
+
+    def test_never_narrows_the_configured_timeout(self) -> None:
+        assert unstreamed_turn_timeout(600, 1_000) == 600
+
+    @pytest.mark.parametrize("first_turn_ms", [0.0, -1.0])
+    def test_no_measurement_leaves_the_timeout_alone(self, first_turn_ms: float) -> None:
+        assert unstreamed_turn_timeout(120, first_turn_ms) == 120
+
+    def test_the_reported_case_now_fits(self) -> None:
+        # All three GLM-5.3-Flash runs: turn 1 between 131s and 180s, turn 2
+        # killed at exactly the 120s default.
+        for turn_one_seconds in (131.4, 151.2, 179.9):
+            budget = unstreamed_turn_timeout(120, turn_one_seconds * 1000)
+            assert budget > turn_one_seconds, "turn 2 must get more room than turn 1 took"


### PR DESCRIPTION
A timed-out scenario rendered as `❌ FAIL 0/2` followed by an empty summary, which is indistinguishable from a model that got the answer wrong. Both halves were untrue: the evaluator never ran, and the scenario left the denominator as well as the numerator, so it scored nothing rather than zero.

Found while investigating a GLM-5.3-Flash run where TC-88 looked like a model failure. It was a timeout, already correctly excluded from scoring, and the display gave no way to tell.

## Solution

Three changes, in increasing blast radius.

### 1. Infrastructure failures are not verdicts

They get their own labels and `–/2` points, plus a reason drawn from the failure kind now that there is no evaluator summary to show.

```
before:  ● TC-88  Preserved Reasoning...  ❌ FAIL     0/2  271.3s  ttft=490ms
after:   ● TC-88  Preserved Reasoning...  ⏱  TIMEOUT  –/2  271.3s  ttft=490ms  excluded from scoring (request timed out)
```

`ScenarioResult.is_infrastructure_failure` already existed and was simply unused by the display. Model failures are untouched.

### 2. The run says what to change

Computed from the run's own measurements rather than canned:

```
⚠  1 scenario(s) excluded (infrastructure failure), completion rate 0.0%
     TC-88
   1 scenario(s) timed out and were excluded from scoring, so this run does not measure the model on them.
   Slowest completed turn: 151s. Only the first turn is streamed, so on later turns the timeout
   bounds the whole generation rather than the gap between tokens.
   Retry with --timeout 420 (currently 120), or shorten generation with --no-think or
   --backend-kwargs '{"max_tokens": 1024}'.
```

Only timeouts get advice. Suggesting a higher `--timeout` after a connection error would send someone the wrong way.

### 3. Unstreamed turns are bounded by measurement

This is the actual fix, and the part that moves scores.

Only turn 1 is streamed (`orchestrator.py:412`), and `httpx`'s read timeout measures the gap between reads. On a streamed turn a long generation never trips it; on an unstreamed turn the same number bounds the whole generation. A model that finished turn 1 in 151 s under a 120 s timeout therefore died on turn 2 without having slowed down at all.

Turn 1 is a free measurement of this model's speed on this exact prompt, and being streamed it cannot time out spuriously, so later turns now get a multiple of what turn 1 actually took. A hung endpoint never completes turn 1 and still fails at the configured timeout, so this does not weaken protection against a dead server.

The rule lives in `domain/timeouts.py` rather than beside the advice, because `runner` may not import `cli`.

**I did not raise the default `--timeout`.** 120 s is right for a streamed turn and for most models; bumping it globally would make every dead-endpoint run five times slower to fail. The asymmetry was the bug, not the number.

## Trade-off worth a second opinion

This changes results. Runs previously excluded on slow models become scored, so both completion rate and score move. `config_fingerprint` already covers code identity, so old and new runs do not group on the leaderboard, but a slow model's numbers will not match what it produced last week.

Eleven of the 88 scenarios have follow-up turns, so the reach is about an eighth of a full run, and only on deployments slow enough to have been hitting this.

## Verification

- `ruff check`, `ruff format --check`, `mypy` clean
- Full suite on all three CI seeds (104729, 130363, 155921): 3577 passed
- Module coverage floors hold; `cli/timeout_advice.py` and `domain/timeouts.py` are both at 100%
- 29 new tests covering the result line, the advice, and the turn budget, including that a connection error stays silent and that a model failure still renders as one
- Confirmed end to end against a mock reproducing the reported shape. With a 2 s timeout and a 4 s unstreamed turn 2, the scenario now reaches the evaluator and returns a real verdict. With turn 2 pushed past the scaled budget, the run prints the timeout label and the advice shown above.

Also corrected `docs/troubleshooting.md`, which quoted a 60-second default that has been 120 for some time.

---

Written with AI assistance; reviewed before opening.
