### PR TITLE
ci: cut a pull request from thirteen checks to six

### DIFF
--- a/.coveragerc.perf
+++ b/.coveragerc.perf
@@ -1,0 +1,15 @@
+# Coverage config for the llama-benchy integration gate only.
+#
+# The project's own config omits runner/llama_benchy.py, because the module is
+# unreachable without the `perf` extra and counting it would depress the floor
+# for everyone who does not install it. This file exists so that one job can
+# measure it without that omission.
+#
+# Passing `--cov-config=/dev/null` used to serve the same purpose, and it also
+# silently broke the gate: combined with a dotted `--cov` target, pytest-cov
+# 7.1.0 printed "FAIL Required test coverage ... not reached" and still exited
+# 0, so the threshold never failed a build. A real config file keeps the exit
+# code honest.
+[run]
+branch = true
+source = src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,114 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Single-version jobs pin 3.13. The supported floor (3.11) and Windows are
+# covered by test-extended on main.
+
 jobs:
-  lint-and-test:
+  # Ruff and mypy are version-independent — mypy is pinned to
+  # python_version = "3.11" in pyproject regardless of the interpreter it runs
+  # on — so running them once says everything running them per matrix entry
+  # would. They use the locked toolchain rather than pre-commit's pinned
+  # mirror, which is a minor version behind and would disagree on the margins.
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: '0.10.8'
+
+      - name: Install from the committed lock
+        run: uv sync --locked --extra dev --python 3.13
+
+      - name: Ruff lint
+        run: uv run ruff check .
+
+      - name: Ruff format
+        run: uv run ruff format --check .
+
+      - name: Mypy
+        run: uv run mypy
+
+  # The gating test run. One interpreter, with the perf extra installed so the
+  # llama-benchy integration is covered here rather than in its own job.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # setuptools-scm derives the version from tags; a shallow clone would
+          # make every CI build report an unattributable version.
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: '0.10.8'
+
+      # The lock is what the Docker image and a `uv tool install` resolve to.
+      # Installing from it here means CI tests the same versions users get, and
+      # an upstream release cannot turn a green branch red with no repo change.
+      - name: Install from the committed lock
+        run: uv sync --locked --extra dev --extra perf --python 3.13
+
+      - name: Pytest
+        run: >
+          uv run pytest --tb=short -q
+          --ignore=tests/test_llama_benchy.py
+          -m "not live"
+          --randomly-seed=104729
+          --cov=tool_eval_bench --cov-report=term-missing --cov-report=json
+          --cov-fail-under=80
+
+      - name: Critical module coverage
+        run: uv run python scripts/check_module_coverage.py coverage.json
+
+      # A separate invocation because llama_benchy.py is omitted from the
+      # project's coverage config: it is unreachable without the perf extra, so
+      # counting it in the main run would depress the floor for everyone. Its
+      # own gate is stricter than the project's, and .coveragerc.perf is what
+      # lifts the omission for this one step.
+      - name: Test llama-benchy integration
+        run: >
+          uv run pytest --tb=short -q
+          tests/test_llama_benchy.py tests/test_llama_benchy_redaction.py
+          -m "not live" --randomly-seed=181081
+          --cov=tool_eval_bench.runner.llama_benchy
+          --cov-config=.coveragerc.perf --cov-report=term-missing --cov-fail-under=95
+
+      - name: Upload coverage report
+        # A reviewer cannot see what a pull request did to coverage without it.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-ubuntu-py3.13
+          path: coverage.json
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # Post-merge only. Windows has caught real product bugs here — filler seeded
+  # from a clock that ticks every 15.6ms, durations measured with
+  # time.monotonic(), a missing tzdata that changed TC-17's score — so it stays
+  # in CI. It runs after merge rather than on every PR because those bugs were
+  # found by running the suite at all, not by gating each change on it. 3.11 is
+  # the supported floor and rides along.
+  test-extended:
+    if: github.event_name == 'push'
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -33,24 +139,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # A different seed per entry, so the randomised order is exercised
-        # broadly rather than three machines repeating one permutation.
         include:
           - os: ubuntu-latest
             python-version: '3.11'
-            random-seed: '104729'
-          - os: ubuntu-latest
-            python-version: '3.12'
             random-seed: '130363'
-          - os: ubuntu-latest
-            python-version: '3.13'
-            random-seed: '155921'
           # storage/db.py resolves its path from Path.cwd() and runs SQLite in
           # WAL mode, and Windows opens files as cp1252 and refuses to delete
           # one that is still open. Those are the differences that bite.
-          - os: macos-latest
-            python-version: '3.12'
-            random-seed: '181081'
           - os: windows-latest
             python-version: '3.12'
             random-seed: '199933'
@@ -59,8 +154,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          # setuptools-scm derives the version from tags; a shallow clone would
-          # make every CI build report an unattributable version.
           fetch-depth: 0
 
       - name: Setup Python ${{ matrix.python-version }}
@@ -68,9 +161,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # The lock is what the Docker image and a `uv tool install` resolve to.
-      # Installing from it here means CI tests the same versions users get, and
-      # an upstream release cannot turn a green branch red with no repo change.
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -79,63 +169,31 @@ jobs:
       - name: Install from the committed lock
         run: uv sync --locked --extra dev --python ${{ matrix.python-version }}
 
-      - name: Ruff lint
-        if: matrix.os == 'ubuntu-latest'
-        run: uv run ruff check .
-
-      - name: Ruff format
-        if: matrix.os == 'ubuntu-latest'
-        run: uv run ruff format --check .
-
-      - name: Mypy
-        if: matrix.os == 'ubuntu-latest'
-        run: uv run mypy
-
+      # No coverage gate. The keypress reader is POSIX-only and its tests skip
+      # on Windows, so coverage there is structurally lower and not comparable
+      # to the floors. What these runners are for is whether the tests pass.
       - name: Pytest
-        if: matrix.os != 'windows-latest'
         run: >
           uv run pytest --tb=short -q
           --ignore=tests/test_llama_benchy.py
           -m "not live"
           --randomly-seed=${{ matrix.random-seed }}
-          --cov=tool_eval_bench --cov-report=term-missing --cov-report=json
-          --cov-fail-under=80
-
-      # The keypress reader is POSIX-only and its tests skip here, so Windows
-      # coverage is structurally lower and not comparable to the floors. What
-      # this runner is for is whether the tests pass, not what they cover.
-      - name: Pytest (no coverage gate)
-        if: matrix.os == 'windows-latest'
-        run: >
-          uv run pytest --tb=short -q
-          --ignore=tests/test_llama_benchy.py
-          -m "not live"
-          --randomly-seed=${{ matrix.random-seed }}
-
-      - name: Critical module coverage
-        if: matrix.os != 'windows-latest'
-        run: uv run python scripts/check_module_coverage.py coverage.json
-
-      - name: Upload coverage report
-        # A reviewer cannot see what a pull request did to coverage without it.
-        if: always() && matrix.os != 'windows-latest'
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-${{ matrix.os }}-py${{ matrix.python-version }}
-          path: coverage.json
-          if-no-files-found: ignore
-          retention-days: 14
 
   pre-commit:
     # The hooks are the local feedback loop; without this they rot silently and
     # only bite the next contributor who installs them.
     runs-on: ubuntu-latest
+    env:
+      # Ruff already ran in `lint`, from the locked version rather than the
+      # mirror's pin. Running it twice per pull request only invites the two to
+      # disagree.
+      SKIP: ruff,ruff-format
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup Python 3.13
+      - name: Setup Python
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'
@@ -147,34 +205,9 @@ jobs:
           # `stages: [pre-push]` and need the project venv, so they skip here.
           extra_args: --all-files
 
-  dependency-audit:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Setup Python 3.13
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.13'
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: '0.10.8'
-
-      - name: Audit dependencies for known vulnerabilities
-        # Audits the locked dependency set rather than an installed environment.
-        # That is what users resolve, and it sidesteps --strict failing on the
-        # project itself, which is not published to PyPI.
-        run: |
-          uv export --frozen --no-emit-project --no-dev \
-            --format requirements.txt -o requirements-audit.txt
-          python -m pip install --upgrade pip pip-audit
-          pip-audit --strict --desc -r requirements-audit.txt
-
-  docker-build:
+  # Both halves of "does this ship": the image and the wheel. They were separate
+  # jobs; nothing about them ran in parallel that mattered.
+  packaging:
     runs-on: ubuntu-latest
 
     steps:
@@ -184,6 +217,11 @@ jobs:
           # setuptools-scm derives the version from tags; a shallow clone would
           # make every CI build report an unattributable version.
           fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
 
       - name: Build image
         run: docker build -t tool-eval-bench:ci .
@@ -221,49 +259,6 @@ jobs:
             --build-arg BUILD_VERSION="0.0.0+g$(git -C "$worktree" rev-parse --short HEAD)" \
             -t tool-eval-bench:worktree "$worktree"
           docker run --rm tool-eval-bench:worktree --version | grep -F '+g'
-
-  optional-perf-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          # setuptools-scm derives the version from tags; a shallow clone would
-          # make every CI build report an unattributable version.
-          fetch-depth: 0
-
-      - name: Setup Python 3.13
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.13'
-
-      - name: Install with optional performance dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e '.[dev,perf]'
-
-      - name: Test llama-benchy integration
-        run: >
-          pytest --tb=short -q tests/test_llama_benchy.py
-          -m "not live" --randomly-seed=181081
-          --cov=tool_eval_bench.runner.llama_benchy
-          --cov-config=/dev/null --cov-report=term-missing --cov-fail-under=95
-
-  wheel-smoke:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          # setuptools-scm derives the version from tags; a shallow clone would
-          # make every CI build report an unattributable version.
-          fetch-depth: 0
-
-      - name: Setup Python 3.13
-        uses: actions/setup-python@v7
-        with:
-          python-version: '3.13'
 
       - name: Build isolated wheel
         run: |
@@ -308,7 +303,7 @@ jobs:
           # make every CI build report an unattributable version.
           fetch-depth: 0
 
-      - name: Setup Python 3.13
+      - name: Setup Python
         uses: actions/setup-python@v7
         with:
           python-version: '3.13'

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,49 @@
+name: Dependency audit
+
+# The locked dependency set only changes when the lock changes, so auditing it
+# on every pull request spends a check to re-confirm yesterday's answer. What
+# does change without any commit is the vulnerability database, and a schedule
+# is the thing that catches that.
+on:
+  schedule:
+    # Mondays, 06:00 UTC.
+    - cron: '0 6 * * 1'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'uv.lock'
+      - 'pyproject.toml'
+      - '.github/workflows/dependency-audit.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: '0.10.8'
+
+      - name: Audit dependencies for known vulnerabilities
+        # Audits the locked dependency set rather than an installed environment.
+        # That is what users resolve, and it sidesteps --strict failing on the
+        # project itself, which is not published to PyPI.
+        run: |
+          uv export --frozen --no-emit-project --no-dev \
+            --format requirements.txt -o requirements-audit.txt
+          python -m pip install --upgrade pip pip-audit
+          pip-audit --strict --desc -r requirements-audit.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,9 @@ Before claiming completion:
 3. `.venv/bin/mypy`
 4. `.venv/bin/python -m pytest tests/ --ignore=tests/test_llama_benchy.py -m "not live" --randomly-seed=104729`
 
-CI repeats the required suite with seeds `104729`, `130363`, and `155921`
-across Python 3.11–3.13, and enforces the configured branch-coverage floor.
+A pull request runs the suite once, on Python 3.13 with seed `104729`, and
+enforces the branch-coverage floor plus the per-module floors. Python 3.11 and
+Windows run after merge, in `test-extended`, each with a different seed.
 
 **Pre-commit hooks** enforce both checks automatically:
 
@@ -94,7 +95,10 @@ a false sense of coverage.
 
 Tests that require the `llama-benchy` package (`test_llama_benchy.py`) should be
 excluded from the default run unless the `[perf]` optional group is installed.
-CI installs `[dev,perf]` and runs them in a dedicated Python 3.13 job.
+CI installs `[dev,perf]` in the `test` job and covers them in a second step,
+gated at 95% against `.coveragerc.perf`. That config exists because the
+project's coverage settings omit `runner/llama_benchy.py`, which is unreachable
+without the extra.
 
 Note: `test_adapter.py` uses deterministic httpx mocks and does **not** require
 a live inference server — it must be included in all test runs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,10 +73,15 @@ it can cause Rich rendering tests to emit ANSI codes into captured output.
 The project venv is important: using system Python can silently skip async test
 support and produce misleading results.
 
-CI repeats the required suite with seeds `104729`, `130363`, and `155921` on
-Python 3.11, 3.12, and 3.13. It also builds the Docker image, runs a wheel
-smoke test, checks coverage floors, and runs the optional `llama-benchy` tests.
-Those checks do not require a live inference server.
+A pull request runs the suite once, on Python 3.13 with seed `104729`, together
+with lint, type checking, the coverage floors, the optional `llama-benchy`
+tests, and the packaging smoke tests for the Docker image and the wheel. None of
+them need a live inference server.
+
+Python 3.11 and Windows run after merge rather than on the pull request, in the
+`test-extended` job, each with its own seed. A regression that only shows up
+there lands on `main` before anyone sees it, so check the run on `main` after
+merging something that touches paths, timing, or file handling.
 
 The live canary is separate and requires an OpenAI-compatible endpoint. Use it
 only when you have an authorized test server:

--- a/README.md
+++ b/README.md
@@ -234,8 +234,8 @@ External tools can validate configuration against the published schema via
 
 ## Contributing
 
-Every push runs the suite on Python 3.11–3.13 on Linux plus 3.12 on macOS, each
-with a different random seed, against the committed `uv.lock`. The same gate,
+A pull request runs lint, type checking, and the suite on Python 3.13 against
+the committed `uv.lock`. Python 3.11 and Windows run after merge. The same gate,
 locally:
 
 ```bash

--- a/changelog.d/+perf-coverage-gate.fixed.md
+++ b/changelog.d/+perf-coverage-gate.fixed.md
@@ -1,0 +1,7 @@
+The `llama-benchy` coverage gate fails the build again. Passing
+`--cov-config=/dev/null` alongside a dotted `--cov` target made pytest-cov 7.1.0
+print `FAIL Required test coverage of 95% not reached` and still exit 0, so the
+threshold had stopped gating anything. Coverage of `runner/llama_benchy.py` had
+already slipped to 94.97% behind it. The step now uses a real config file
+(`.coveragerc.perf`) and also runs `test_llama_benchy_redaction.py`, which covers
+the URL-redaction helpers, restoring it to 96.65%.

--- a/changelog.d/+slim-ci.changed.md
+++ b/changelog.d/+slim-ci.changed.md
@@ -1,0 +1,15 @@
+CI runs five checks on a pull request instead of thirteen. Ruff and mypy now run
+once rather than four and three times: both are version-independent, and mypy is
+pinned to `python_version = "3.11"` whatever interpreter it runs on. The macOS
+runner is gone, having recorded no finding of its own. The Docker and wheel smoke
+tests share a `packaging` job, and the `llama-benchy` tests fold into the main
+`test` job.
+
+Python 3.11 and Windows moved to a `test-extended` job that runs after merge
+rather than on every pull request. Windows stays in CI because it has caught real
+product bugs, but those came from running the suite there at all rather than from
+gating each change on it.
+
+The dependency audit moved to its own workflow, on a weekly schedule and on pull
+requests that touch `uv.lock` or `pyproject.toml`. The locked set does not change
+between those, but the vulnerability database does.


### PR DESCRIPTION
Thirteen checks per pull request, several of them re-running identical work.

## What was actually redundant

Ruff ran **four times** per PR and mypy **three**, because both were steps inside the `lint-and-test` matrix gated on `matrix.os == 'ubuntu-latest'` — and there were three ubuntu entries — plus a fourth ruff in the `pre-commit` job. Neither tool is version-dependent, and mypy is pinned to `python_version = "3.11"` in pyproject whatever interpreter it runs on, so those extra runs produced byte-identical results.

That waste was invisible because it lived inside a matrix rather than as separate checks.

## After

| | before | after |
|---|---|---|
| Checks on a PR | 13 | **6** |
| ruff runs | 4 | 1 |
| mypy runs | 3 | 1 |

PR jobs: `lint`, `test`, `pre-commit`, `packaging`, plus CodeQL's two.

- `lint` runs ruff and mypy once, from the **locked** toolchain rather than pre-commit's mirror, which sits a minor version behind (lock has ruff 0.16.1, the mirror pins 0.16.0). `pre-commit` now runs with `SKIP=ruff,ruff-format` so the two cannot disagree, while still verifying the hooks themselves have not rotted.
- `test` is one interpreter (3.13) with the `perf` extra, so the llama-benchy tests fold in instead of owning a job.
- `packaging` merges the Docker and wheel smoke tests.
- `dependency-audit` moved to its own workflow: weekly, plus PRs touching `uv.lock` or `pyproject.toml`. The locked set does not change between those; the vulnerability database does.

## What moved rather than went away

**macOS is gone.** Added in `+ci-hardening`, no recorded finding of its own, and ubuntu already covers POSIX.

**Windows stays, but post-merge.** I pushed back on cutting it, because per the changelog it caught product bugs rather than test quirks:

- context-pressure filler seeded from `time.time_ns()`, which ticks ~15.6 ms there, so two builds inside one tick produced byte-identical filler and handed the server the warm prefix cache that noise exists to defeat
- durations measured with `time.monotonic()` instead of `time.perf_counter()`
- missing `tzdata` made TC-17 score PASS where it should score PARTIAL, a benchmark score varying by host OS

Those came from running the suite there at all, not from gating every change on it, so Windows and Python 3.11 now run in `test-extended` on pushes to `main`.

**Trade-off:** a platform regression lands on `main` before anyone sees it. `CONTRIBUTING.md` now says to check the `main` run after merging anything touching paths, timing, or file handling.

## A broken gate found along the way

While folding the perf job in, its coverage gate turned out to be decorative. This is from **PR #114's own CI log**, on a job GitHub reported as successful:

```
FAIL Required test coverage of 95% not reached. Total coverage: 94.97%
optional-perf-tests: success
```

Passing `--cov-config=/dev/null` alongside a dotted `--cov` target makes pytest-cov 7.1.0 print the failure and still exit 0. Bisected:

| invocation | exit |
|---|---|
| `--cov=tool_eval_bench.runner.llama_benchy --cov-config=/dev/null` | **0** |
| `--cov=tool_eval_bench.runner.llama_benchy` (default config) | 1 |
| `--cov=src/...//llama_benchy.py --cov-config=/dev/null` | 1 |
| `--cov=tool_eval_bench --cov-config=/dev/null` | 1 |

Coverage had genuinely slipped to 94.97%, in my own #114: the URL-redaction helpers are tested in `test_llama_benchy_redaction.py`, which that job never ran. Fixed with a real config file (`.coveragerc.perf`, replacing `/dev/null`) and by running both test files, restoring it to **96.65%**. Confirmed the gate now exits 1 at threshold 99 and 0 at 95.

## Verification

Ran every job's steps locally: lint, both `test` steps including the module floors, `pre-commit` with `SKIP=ruff,ruff-format`, and both `test-extended` seeds. 3577 tests pass on the main suite, 92 on the llama-benchy step. Both workflow files parse.

---

Written with AI assistance; reviewed before opening.
