### PR TITLE
fix: keep the perf benchmark working against SGLang

### DIFF
--- a/changelog.d/+sglang-perf-return-token-ids.fixed.md
+++ b/changelog.d/+sglang-perf-return-token-ids.fixed.md
@@ -1,0 +1,7 @@
+`--perf` against SGLang failed with "no usable throughput metrics". SGLang now rejects a streaming
+`/v1/chat/completions` request that carries `return_token_ids` (sgl-project/sglang#30917), which
+llama-benchy sends on every generation request, so every sample came back empty. On an SGLang
+endpoint the field is now switched off through `--extra-body`, and llama-benchy counts tokens from
+the stream's `usage` block instead. `--benchy-args` still wins if it sets the field itself. The
+failure also quotes the server's response now, rather than dropping it with the rest of
+llama-benchy's non-JSON stdout.

--- a/src/tool_eval_bench/cli/dispatch.py
+++ b/src/tool_eval_bench/cli/dispatch.py
@@ -350,6 +350,7 @@ def _run_throughput_mode(target: _Target) -> tuple[list, bool]:
         # save two requests.
         skip_warmup=not args.no_warmup,
         tokenizer=getattr(args, "tokenizer", None),
+        backend=target.backend,
     )
 
     if not args.perf_only:

--- a/src/tool_eval_bench/cli/perf.py
+++ b/src/tool_eval_bench/cli/perf.py
@@ -151,6 +151,7 @@ def run_llama_benchy(
     skip_warmup: bool = False,
     extra_args: list[str] | None = None,
     tokenizer: str | None = None,
+    backend: str | None = None,
 ) -> list:
     """Run llama-benchy externally and display results.
 
@@ -240,6 +241,7 @@ def run_llama_benchy(
                 latency_mode=latency_mode,
                 skip_coherence=skip_coherence,
                 skip_warmup=skip_warmup,
+                backend=backend,
                 extra_args=extra_args,
                 tokenizer=tokenizer,
                 on_progress=on_progress,

--- a/src/tool_eval_bench/runner/llama_benchy.py
+++ b/src/tool_eval_bench/runner/llama_benchy.py
@@ -149,6 +149,26 @@ def _redact_command(cmd: list[str]) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _extra_args_set_return_token_ids(extra_args: list[str] | None) -> bool:
+    """Report whether pass-through args already decide ``return_token_ids``.
+
+    ``--benchy-args`` is the escape hatch for exactly this kind of payload
+    tweak, so a value set there wins over the SGLang default below.
+    """
+    return any("return_token_ids" in arg for arg in extra_args or ())
+
+
+def _failure_hint(output_lines: list[str]) -> str:
+    """Summarise why every benchmark request failed, from llama-benchy's output."""
+    errors = [line for line in output_lines if line.startswith("HTTP ")]
+    if not errors:
+        return "Check endpoint authentication and llama-benchy output."
+    # One shared cause per run, so the distinct set is short; cap it anyway.
+    unique = list(dict.fromkeys(errors))[:3]
+    detail = "\n".join(f"  {line}" for line in unique)
+    return f"The server answered with:\n{detail}"
+
+
 def _build_command(
     base_url: str,
     model: str,
@@ -164,6 +184,7 @@ def _build_command(
     no_cache: bool = True,
     skip_coherence: bool = False,
     skip_warmup: bool = False,
+    backend: str | None = None,
     output_file: str | None = None,
     extra_args: list[str] | None = None,
 ) -> list[str]:
@@ -227,6 +248,16 @@ def _build_command(
     # that add latency without benefit.  Also reduces the tokenizer's role
     # to prompt construction only, where the gpt2 fallback is acceptable.
     cmd.append("--no-adapt-prompt")
+
+    # SGLang answers a streaming request that carries ``return_token_ids`` with
+    # a 400 (sgl-project/sglang#30917 turned the field from ignored-unknown into
+    # recognized-but-unsupported-under-streaming).  llama-benchy sends it on
+    # every generation request, so without this every sample comes back empty.
+    # ``--extra-body`` is merged into the payload after the defaults, so this
+    # switches the field off; llama-benchy then counts tokens from the stream's
+    # ``usage`` block, which SGLang does send.
+    if (backend or "").lower() == "sglang" and not _extra_args_set_return_token_ids(extra_args):
+        cmd.extend(["--extra-body", "return_token_ids=false"])
 
     # JSON output
     cmd.extend(["--format", "json"])
@@ -347,6 +378,7 @@ async def run_llama_benchy(
     no_cache: bool = True,
     skip_coherence: bool = False,
     skip_warmup: bool = False,
+    backend: str | None = None,
     extra_args: list[str] | None = None,
     on_output: Callable[[str], None] | None = None,
     on_progress: Callable[[dict[str, Any]], None] | None = None,
@@ -396,6 +428,7 @@ async def run_llama_benchy(
             no_cache=no_cache,
             skip_coherence=skip_coherence,
             skip_warmup=skip_warmup,
+            backend=backend,
             output_file=output_file,
             extra_args=extra_args,
         )
@@ -450,12 +483,18 @@ async def run_llama_benchy(
                 return
             async for raw_line in proc.stdout:
                 line = raw_line.decode("utf-8", errors="replace").rstrip()
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    # llama-benchy prints per-request failures (``HTTP 400: …``)
+                    # to stdout, alongside the progress JSONL.  Keep them: they
+                    # are the only explanation available when a run finishes
+                    # with every metric empty.
+                    if line:
+                        output_lines.append(line)
+                    continue
                 if on_progress:
-                    try:
-                        event = json.loads(line)
-                        on_progress(event)
-                    except json.JSONDecodeError:
-                        pass  # Non-JSON line on stdout, skip
+                    on_progress(event)
 
         await asyncio.gather(_read_stderr(), _read_stdout())
 
@@ -535,8 +574,9 @@ async def run_llama_benchy(
             )
         if not any(sample.pp_tps > 0 or sample.tg_tps > 0 for sample in result.samples):
             raise RuntimeError(
-                "llama-benchy produced no usable throughput metrics. "
-                "Check endpoint authentication and llama-benchy output."
+                "llama-benchy produced no usable throughput metrics — "
+                "every benchmark request failed.\n"
+                f"{_failure_hint(output_lines)}"
             )
         return result
 

--- a/tests/test_llama_benchy.py
+++ b/tests/test_llama_benchy.py
@@ -10,6 +10,7 @@ import pytest
 
 from tool_eval_bench.runner.llama_benchy import (
     _build_command,
+    _failure_hint,
     _parse_benchmark_entry,
     _redact_command,
     _stat_mean,
@@ -1333,3 +1334,56 @@ class TestCLIFlags:
         """--skip-coherence should exist in CLI help."""
         help_text = self._get_help_text()
         assert "--skip-coherence" in help_text
+
+
+class TestSglangReturnTokenIds:
+    """SGLang 400s a streaming request that carries ``return_token_ids``.
+
+    See sgl-project/sglang#30917: the field went from ignored-unknown to
+    recognized-but-rejected-under-streaming, and llama-benchy sends it on every
+    generation request.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _on_path(self, monkeypatch):
+        monkeypatch.setattr(
+            "tool_eval_bench.runner.llama_benchy.shutil.which",
+            lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
+        )
+
+    def test_sglang_disables_return_token_ids(self):
+        cmd = _build_command("http://localhost:8888/v1", "test-model", backend="sglang")
+        assert cmd[cmd.index("--extra-body") + 1] == "return_token_ids=false"
+
+    def test_backend_label_case_is_ignored(self):
+        cmd = _build_command("http://localhost:8888/v1", "test-model", backend="SGLang")
+        assert "--extra-body" in cmd
+
+    def test_other_backends_keep_token_ids(self):
+        for backend in ("vllm", "llamacpp", None):
+            cmd = _build_command("http://localhost:8888/v1", "test-model", backend=backend)
+            assert "--extra-body" not in cmd, backend
+
+    def test_explicit_pass_through_wins(self):
+        cmd = _build_command(
+            "http://localhost:8888/v1",
+            "test-model",
+            backend="sglang",
+            extra_args=["--extra-body", "return_token_ids=true"],
+        )
+        assert cmd.count("--extra-body") == 1
+        assert cmd[cmd.index("--extra-body") + 1] == "return_token_ids=true"
+
+
+class TestFailureHint:
+    def test_quotes_the_server_error(self):
+        hint = _failure_hint(["Warmup complete.", 'HTTP 400: {"error": "no streaming token_ids"}'])
+        assert 'HTTP 400: {"error": "no streaming token_ids"}' in hint
+
+    def test_deduplicates_repeated_errors(self):
+        hint = _failure_hint(["HTTP 400: bad", "HTTP 400: bad", "HTTP 400: bad"])
+        assert hint.count("HTTP 400: bad") == 1
+
+    def test_falls_back_when_no_http_error_was_seen(self):
+        hint = _failure_hint(["Measuring latency using mode: generation..."])
+        assert "Check endpoint authentication" in hint


### PR DESCRIPTION
## Problem

`--perf` / `--perf-only` against an SGLang endpoint dies with:

```
llama-benchy error: llama-benchy produced no usable throughput metrics.
Check endpoint authentication and llama-benchy output.
```

Reported by a user on the NVIDIA forums, who recalled it working previously. It did: SGLang used to
ignore the unknown `return_token_ids` request field. [sgl-project/sglang#30917][1] (July 2026) made
the field real and rejected it under streaming, so `/v1/chat/completions` with
`stream=true, return_token_ids=true` is now a 400. llama-benchy sends both on every generation
request, so every benchmark request fails, every metric in its JSON report comes back `null`, and our
"no usable metrics" guard fires.

The message was that unhelpful for a second reason: llama-benchy `print()`s per-request failures to
stdout, alongside its `--emit-progress` JSONL. Our stdout reader kept the JSON lines and dropped
everything else, so the server's own explanation was thrown away.

[1]: https://github.com/sgl-project/sglang/pull/30917

## Solution

- On an SGLang endpoint, pass `--extra-body return_token_ids=false`. llama-benchy merges `--extra-body`
  over its payload defaults, so the field goes off the wire; it then takes token counts from the
  stream's `usage` block, which SGLang does send. Other backends keep `return_token_ids`, where it
  gives exact per-chunk counts.
- A `return_token_ids` set through `--benchy-args` still wins, so the existing escape hatch is intact.
- Keep non-JSON stdout from llama-benchy and quote any `HTTP …` lines in the failure, so a run where
  every request failed says why.

The backend label is the one the CLI already probes, so this needed no new detection.

## Verification

- Reproduced end to end against a mock endpoint that mirrors SGLang's guard (400 when `stream` and
  `return_token_ids` are both set): `--perf-only` failed with the original message before the change,
  and completes with a populated results table after it.
- Forcing the field back on (`--benchy-args "--extra-body return_token_ids=true"`) now reports the
  server's 400 text verbatim instead of the generic message.
- New focused tests cover the flag on SGLang, its absence on vLLM/llama.cpp/unknown, the pass-through
  override, and the failure hint.
- `pytest tests` (3691 passed), `ruff check`, `ruff format --check`, `mypy` on the changed module.

Written with AI assistance; reviewed before opening.