### PR TITLE
fix: honor reference date in TC-26 (#119)

### DIFF
--- a/changelog.d/119.fixed.md
+++ b/changelog.d/119.fixed.md
@@ -1,0 +1,1 @@
+TC-26 now grades "tomorrow" against the run's configured reference date instead of the benchmark default.

--- a/src/tool_eval_bench/evals/scenarios/agentic/tc26.py
+++ b/src/tool_eval_bench/evals/scenarios/agentic/tc26.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from datetime import date, timedelta
 from typing import Any
 
 from tool_eval_bench.domain.scenarios import (
@@ -14,9 +13,11 @@ from tool_eval_bench.domain.scenarios import (
     ScenarioState,
     ToolCallRecord,
 )
-from tool_eval_bench.domain.tools import BENCHMARK_REFERENCE_DATE
 from tool_eval_bench.evals.helpers import (
     as_str as _as_str,
+)
+from tool_eval_bench.evals.helpers import (
+    days_after_reference as _days_after_reference,
 )
 from tool_eval_bench.evals.helpers import (
     fail_eval as _fail,
@@ -91,7 +92,7 @@ def _tc26_eval(state: ScenarioState) -> ScenarioEvaluation:
         return _fail("Did not create the calendar event.")
 
     create_call = create_calls[0]
-    expected_date = (date.fromisoformat(BENCHMARK_REFERENCE_DATE) + timedelta(days=1)).isoformat()
+    expected_date = _days_after_reference(state, 1)
     correct_event = (
         _normalize(_as_str(create_call.arguments.get("title"))) == "design review"
         and _as_str(create_call.arguments.get("date")).startswith(expected_date)

--- a/tests/test_reference_date_evaluators.py
+++ b/tests/test_reference_date_evaluators.py
@@ -27,6 +27,7 @@ EXPECTED: dict[str, dict[str, str]] = {
     "TC-05": {MARCH: "2026-03-23", AUGUST: "2026-08-24"},  # next Monday
     "TC-08": {MARCH: "2026-03-21", AUGUST: "2026-08-20"},  # tomorrow
     "TC-17": {MARCH: "2026-03-24", AUGUST: "2026-08-25"},  # next Tuesday
+    "TC-26": {MARCH: "2026-03-21", AUGUST: "2026-08-20"},  # tomorrow
     "TC-74": {MARCH: "2026-03-25", AUGUST: "2026-08-26"},  # next Tuesday, moved to Wednesday
     "TC-79": {MARCH: "2026-03-21", AUGUST: "2026-08-20"},  # tomorrow
     "TC-84": {MARCH: "2026-03-25", AUGUST: "2026-08-26"},  # next Wednesday
@@ -106,6 +107,16 @@ def _tc17_calls(date: str, timezone: str = "Europe/Berlin") -> list[dict]:
     ]
 
 
+def _tc26_calls(date: str) -> list[dict]:
+    return [
+        {
+            "name": "create_calendar_event",
+            "arguments": {"title": "Design Review", "date": date, "time": "15:00"},
+            "turn": 1,
+        }
+    ]
+
+
 @pytest.mark.parametrize("reference", REFERENCES)
 @pytest.mark.parametrize(("sid", "builder"), [("TC-05", _tc05_calls), ("TC-08", _tc08_calls)])
 def test_relative_date_scenarios_follow_the_reference_date(sid, builder, reference):
@@ -131,6 +142,26 @@ def test_tc17_follows_the_reference_date(reference):
 
     wrong = make_state(
         tool_calls=_tc17_calls(_other_date("TC-17", reference)),
+        meta={"reference_date": reference},
+    )
+    assert scenario.evaluate(wrong).status != ScenarioStatus.PASS
+
+
+@pytest.mark.parametrize("reference", REFERENCES)
+def test_tc26_follows_the_reference_date(reference):
+    expected = EXPECTED["TC-26"][reference]
+    scenario = _scenario("TC-26")
+
+    right = make_state(
+        tool_calls=_tc26_calls(expected),
+        final_answer="No attendees were specified for the Design Review.",
+        meta={"reference_date": reference},
+    )
+    assert scenario.evaluate(right).status == ScenarioStatus.PASS
+
+    wrong = make_state(
+        tool_calls=_tc26_calls(_other_date("TC-26", reference)),
+        final_answer="No attendees were specified for the Design Review.",
         meta={"reference_date": reference},
     )
     assert scenario.evaluate(wrong).status != ScenarioStatus.PASS


### PR DESCRIPTION
TC-26 still graded "tomorrow" against the benchmark's default date, so a correct calendar call failed whenever a run used a different reference date.

The evaluator now derives tomorrow from ScenarioState.meta through the shared date helper. The regression test covers both the default and a non-default reference date, and verifies that a date from the other run does not pass.

Verification:

- ruff check .
- ruff format --check .
- mypy
- 2 focused tests passed
- 3,617 non-live tests passed, 1 deselected

Closes #119

Written with AI assistance; reviewed before opening.
