### PR TITLE
fix: handle two-call TC-40 traces (#120)

### DIFF
--- a/changelog.d/120.fixed.md
+++ b/changelog.d/120.fixed.md
@@ -1,0 +1,1 @@
+TC-40 now gives partial credit when a correct order lookup is followed by one unnecessary tool call, instead of claiming the order tool was never used.

--- a/src/tool_eval_bench/evals/scenarios/large_toolset/tc40.py
+++ b/src/tool_eval_bench/evals/scenarios/large_toolset/tc40.py
@@ -141,7 +141,7 @@ def _tc40_eval(state: ScenarioState) -> ScenarioEvaluation:
             "Used get_order_status + get_customer_profile — "
             "customer lookup was unnecessary but not wrong."
         )
-    if used_order and total_calls > 2:
+    if used_order and total_calls >= 2:
         extras = ", ".join(c.name for c in state.tool_calls if c.name != "get_order_status")
         return _partial(f"Found the right tool but also called: {extras}")
     if not used_order and used_shipping:

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -1693,6 +1693,23 @@ class TestTC40:
         )
         assert self.sc.evaluate(s).status == ScenarioStatus.PARTIAL
 
+    def test_partial_extra_shipping_lookup(self) -> None:
+        s = _state(
+            tool_calls=[
+                {"name": "get_order_status", "arguments": {"order_id": "Sarah Chen"}},
+                {
+                    "name": "get_shipping_status",
+                    "arguments": {"tracking_number": "1Z999AA10123456784"},
+                },
+            ],
+            final_answer="Order ORD-2026-1847 shipped and its tracking is in transit.",
+        )
+
+        result = self.sc.evaluate(s)
+
+        assert result.status == ScenarioStatus.PARTIAL
+        assert result.summary == "Found the right tool but also called: get_shipping_status"
+
     def test_partial_shipping_instead(self) -> None:
         s = _state(
             tool_calls=[


### PR DESCRIPTION
TC-40 had no branch for a correct order lookup followed by exactly one non-customer tool call. The trace fell through to a failure message claiming the order tool was never used.

The existing extra-tool partial branch now covers two or more calls after the customer-specific two-call case. The regression test pins both the partial status and the exact diagnostic for the reported shipping follow-up.

Verification:

- ruff check .
- ruff format --check .
- mypy
- 6 focused TC-40 tests passed
- 3,616 non-live tests passed, 1 deselected

Closes #120

Written with AI assistance; reviewed before opening.
