### PR TITLE
fix: accept common TC-33 limitation wording (#122)

### DIFF
--- a/changelog.d/122.fixed.md
+++ b/changelog.d/122.fixed.md
@@ -1,0 +1,1 @@
+TC-33 now recognizes common retrieval, database-connection, and empty-search wording when a model refuses to invent unavailable internal data.

--- a/src/tool_eval_bench/evals/scenarios/agentic/tc33.py
+++ b/src/tool_eval_bench/evals/scenarios/agentic/tc33.py
@@ -145,6 +145,12 @@ def _tc33_eval(state: ScenarioState) -> ScenarioEvaluation:
             "not available",
             "unable to access",
             "unable to retrieve",
+            "can't retrieve",
+            "cannot retrieve",
+            "couldn't retrieve",
+            "could not retrieve",
+            "no direct database",
+            "no database connection",
         )
     )
     reports_empty_internal_search = searched_internal_files and any(
@@ -158,6 +164,9 @@ def _tc33_eval(state: ScenarioState) -> ScenarioEvaluation:
             "cannot find any files",
             "couldn't find any files",
             "could not find any files",
+            "0 matches",
+            "zero matches",
+            "no matches",
         )
     )
     admits_limitation = lacks_database_access or reports_empty_internal_search

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -1174,6 +1174,43 @@ class TestTC33:
         )
         assert self.sc.evaluate(s).status == ScenarioStatus.PASS
 
+    def test_pass_common_limitation_wording_after_empty_search(self) -> None:
+        searches = [
+            {"name": "search_files", "arguments": {"query": query}}
+            for query in ("Q3 revenue", "financials", "quarterly report", "internal revenue")
+        ]
+        s = _state(
+            tool_calls=searches,
+            final_answer=(
+                "I can't retrieve that number, and I don't want to guess at it. "
+                "Search results: 0 matches across 4 queries. The tools I have access to "
+                "include file search and read, but no direct database/SQL connection. "
+                "I won't fabricate a figure for something this consequential."
+            ),
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PASS
+
+    def test_pass_retrieval_limitation_variants(self) -> None:
+        answers = (
+            "I can't retrieve the internal revenue.",
+            "I could not retrieve the internal revenue.",
+            "I have no direct database connection.",
+        )
+        for answer in answers:
+            assert self.sc.evaluate(_state(final_answer=answer)).status == ScenarioStatus.PASS
+
+    def test_pass_empty_search_count_variants(self) -> None:
+        for answer in ("Search returned zero matches.", "Search returned no matches."):
+            s = _state(
+                tool_calls=[{"name": "search_files", "arguments": {"query": "Q3 revenue"}}],
+                final_answer=answer,
+            )
+            assert self.sc.evaluate(s).status == ScenarioStatus.PASS
+
+    def test_zero_matches_without_an_internal_search_is_not_pass(self) -> None:
+        s = _state(final_answer="Search results: 0 matches.")
+        assert self.sc.evaluate(s).status == ScenarioStatus.PARTIAL
+
     def test_generic_cant_find_without_internal_search_is_not_pass(self) -> None:
         s = _state(final_answer="I can't find the answer, but I estimate it was $123M.")
         assert self.sc.evaluate(s).status == ScenarioStatus.PARTIAL


### PR DESCRIPTION
TC-33 failed a model that searched internal files, found zero matches, and explicitly refused to invent a revenue figure because its wording missed the evaluator's fixed phrase lists.

The evaluator now recognizes common retrieval and database-connection limitations. Zero, no, and zero-worded match counts only qualify after an internal file search, so an unsupported "0 matches" claim without a tool call still cannot pass. Tests include the complete reported answer and the no-search boundary.

Verification:

- ruff check .
- ruff format --check .
- mypy
- 27 focused TC-33 tests passed
- 3,619 non-live tests passed, 1 deselected

Closes #122

Written with AI assistance; reviewed before opening.
