### PR TITLE
fix: stop TC-75 and TC-28 penalising the requested behaviour

### DIFF
--- a/changelog.d/132.fixed.md
+++ b/changelog.d/132.fixed.md
@@ -7,8 +7,14 @@ answer it was requesting — "Which day is the interview? (e.g., today,
 to nothing now passes; a real assumption stated alongside an example still
 scores partial.
 
+The marker only governs the example it introduces: a closing bracket or a
+sentence break between it and the value ends its reach, so "(e.g., 2026-03-20)
+I booked it for 15:00" is still a guess.
+
 TC-28 (Read-Before-Write) counted every non-`read_file` call as waste, but
 `read_file` takes a `file_id` that only `search_files` can supply, so the
 canonical search-then-read trace was marked partial for making the discovery
-call the toolset requires. A discovery call *before* the read is now accepted;
-one after it, or any unrelated tool, still counts against the run.
+call the toolset requires. Exactly one pre-read `search_files` whose query
+names the file under discussion is now accepted; a repeat lookup, a search for
+something else, a search after the read, or any unrelated tool still counts
+against the run.

--- a/changelog.d/132.fixed.md
+++ b/changelog.d/132.fixed.md
@@ -1,0 +1,14 @@
+Two graders no longer punish a model for doing exactly what the scenario asks.
+
+TC-75 (Missing Required Parameter) treated any concrete date or time in the
+transcript as a guess, including one the model printed as the *format* of the
+answer it was requesting — "Which day is the interview? (e.g., today,
+2026-03-20, or another date)". A clarification that calls no tool and commits
+to nothing now passes; a real assumption stated alongside an example still
+scores partial.
+
+TC-28 (Read-Before-Write) counted every non-`read_file` call as waste, but
+`read_file` takes a `file_id` that only `search_files` can supply, so the
+canonical search-then-read trace was marked partial for making the discovery
+call the toolset requires. A discovery call *before* the read is now accepted;
+one after it, or any unrelated tool, still counts against the run.

--- a/src/tool_eval_bench/evals/scenarios/agentic/tc28.py
+++ b/src/tool_eval_bench/evals/scenarios/agentic/tc28.py
@@ -67,6 +67,10 @@ _TC28_CORRECTION = re.compile(
 )
 
 
+# Tools whose whole purpose is to find the file the read then consumes.
+_TC28_DISCOVERY_TOOLS = frozenset({"search_files"})
+
+
 def _tc28_eval(state: ScenarioState) -> ScenarioEvaluation:
     """User: 'The file config.yaml has a typo in the database host. Find and describe the fix.'
 
@@ -104,7 +108,20 @@ def _tc28_eval(state: ScenarioState) -> ScenarioEvaluation:
             for result in recorded_results
         ):
             return _partial("The proposed correction was not present in the recorded file content.")
-        if any(call.name != "read_file" for call in state.tool_calls):
+        # `read_file` takes a `file_id`, and the only way to learn it is to
+        # search for the file first. Locating the file is therefore part of
+        # read-before-write, not a detour - but a search issued *after* the
+        # read still is one, and so is any unrelated tool.
+        first_read = next(
+            index for index, call in enumerate(state.tool_calls) if call.name == "read_file"
+        )
+        stray_calls = [
+            call
+            for index, call in enumerate(state.tool_calls)
+            if call.name != "read_file"
+            and (call.name not in _TC28_DISCOVERY_TOOLS or index > first_read)
+        ]
+        if stray_calls:
             return _partial("Found the typo, but made an unnecessary additional tool call.")
         return _pass("Read the file first, correctly identified 'localhsot' → 'localhost'.")
 

--- a/src/tool_eval_bench/evals/scenarios/agentic/tc28.py
+++ b/src/tool_eval_bench/evals/scenarios/agentic/tc28.py
@@ -71,6 +71,11 @@ _TC28_CORRECTION = re.compile(
 _TC28_DISCOVERY_TOOLS = frozenset({"search_files"})
 
 
+# One lookup for *this* file earns its keep. A second identical search, or a
+# search for something else entirely, is the waste this check exists to catch.
+_TC28_DISCOVERY_QUERY = re.compile(r"config", re.IGNORECASE)
+
+
 def _tc28_eval(state: ScenarioState) -> ScenarioEvaluation:
     """User: 'The file config.yaml has a typo in the database host. Find and describe the fix.'
 
@@ -109,18 +114,27 @@ def _tc28_eval(state: ScenarioState) -> ScenarioEvaluation:
         ):
             return _partial("The proposed correction was not present in the recorded file content.")
         # `read_file` takes a `file_id`, and the only way to learn it is to
-        # search for the file first. Locating the file is therefore part of
-        # read-before-write, not a detour - but a search issued *after* the
-        # read still is one, and so is any unrelated tool.
+        # search for the file first. That one lookup is part of
+        # read-before-write, not a detour. Everything else is waste: a repeat
+        # search, a search for an unrelated file, a search issued after the
+        # read, or any other tool.
         first_read = next(
             index for index, call in enumerate(state.tool_calls) if call.name == "read_file"
         )
-        stray_calls = [
-            call
-            for index, call in enumerate(state.tool_calls)
-            if call.name != "read_file"
-            and (call.name not in _TC28_DISCOVERY_TOOLS or index > first_read)
-        ]
+        stray_calls = []
+        allowed_discovery = 1
+        for index, call in enumerate(state.tool_calls):
+            if call.name == "read_file":
+                continue
+            if (
+                allowed_discovery
+                and index < first_read
+                and call.name in _TC28_DISCOVERY_TOOLS
+                and _TC28_DISCOVERY_QUERY.search(_as_str(call.arguments.get("query")))
+            ):
+                allowed_discovery -= 1
+                continue
+            stray_calls.append(call)
         if stray_calls:
             return _partial("Found the typo, but made an unnecessary additional tool call.")
         return _pass("Read the file first, correctly identified 'localhsot' → 'localhost'.")

--- a/src/tool_eval_bench/evals/scenarios/agentic/tc28.py
+++ b/src/tool_eval_bench/evals/scenarios/agentic/tc28.py
@@ -73,7 +73,7 @@ _TC28_DISCOVERY_TOOLS = frozenset({"search_files"})
 
 # One lookup for *this* file earns its keep. A second identical search, or a
 # search for something else entirely, is the waste this check exists to catch.
-_TC28_DISCOVERY_QUERY = re.compile(r"config", re.IGNORECASE)
+_TC28_DISCOVERY_QUERY = re.compile(r"\bconfig\b", re.IGNORECASE)
 
 
 def _tc28_eval(state: ScenarioState) -> ScenarioEvaluation:

--- a/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
@@ -110,6 +110,20 @@ _TC75_EXAMPLE_MARKER = re.compile(
 )
 
 
+# An example marker governs the value it introduces, nothing past the end of
+# that example. A closing bracket or a sentence break ends its reach, so
+# "Which day? (e.g., 2026-03-20) I booked it for 15:00." is still a guess.
+_TC75_EXAMPLE_BREAK = re.compile(r"[.!?;:)\]]")
+
+
+# Punctuation that belongs to the marker or to the list it opens, not to a
+# sentence: "e.g., 14:30" and "for example - 14:30" are one phrase. The period
+# is deliberately absent - "use ISO format. I booked it for 15:00" ends the
+# example at the full stop, and stripping it would hand the marker the next
+# sentence as well.
+_TC75_EXAMPLE_LEAD = ",:-\u2013\u2014 \t"
+
+
 def _tc75_inside_example(text: str, start: int) -> bool:
     """True when the value is offered as a format example, not as an answer.
 
@@ -117,12 +131,20 @@ def _tc75_inside_example(text: str, start: int) -> bool:
     marker sitting immediately in front of the value. Both are the model
     describing the input it needs, which is the behaviour this scenario is
     supposed to reward.
+
+    The unbracketed form only reaches as far as the example runs: if a
+    bracket closes or a sentence ends between the marker and the value, the
+    value is a fresh assertion and the marker has no say over it.
     """
     opening = text.rfind("(", 0, start)
     if opening != -1 and text.find(")", opening, start) == -1:
         if _TC75_EXAMPLE_MARKER.search(text[opening:start]):
             return True
-    return bool(_TC75_EXAMPLE_MARKER.search(text[max(0, start - 40) : start]))
+    window = text[max(0, start - 40) : start]
+    return any(
+        not _TC75_EXAMPLE_BREAK.search(window[match.end() :].lstrip(_TC75_EXAMPLE_LEAD))
+        for match in _TC75_EXAMPLE_MARKER.finditer(window)
+    )
 
 
 def _tc75_guessed_a_value(transcript: str) -> bool:

--- a/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
@@ -98,16 +98,45 @@ _TC75_CONCRETE_VALUE = re.compile(
 _TC75_LIST_MARKER = re.compile(r"(?m)^[ \t]*(?:[-*]|\d{1,3}[.)])[ \t]+")
 
 
+# A clarifying question is allowed to show the shape of the answer it wants.
+# "Which day? (e.g., today, 2026-03-20, or another date)" names a date without
+# committing to one, and reading that as a guess punishes precision.
+# The dots in "e.g." are load-bearing: without them the alternation matches the
+# "ie" inside "interview", which is one of this scenario's own keywords.
+_TC75_EXAMPLE_MARKER = re.compile(
+    r"\b(?:e\.\s?g\.?|i\.\s?e\.?|for example|for instance|such as|like this|"
+    r"format(?:ted)?(?:\s+(?:like|as))?|in the form)",
+    re.IGNORECASE,
+)
+
+
+def _tc75_inside_example(text: str, start: int) -> bool:
+    """True when the value is offered as a format example, not as an answer.
+
+    Two shapes count: a parenthetical opened by an example marker, and a
+    marker sitting immediately in front of the value. Both are the model
+    describing the input it needs, which is the behaviour this scenario is
+    supposed to reward.
+    """
+    opening = text.rfind("(", 0, start)
+    if opening != -1 and text.find(")", opening, start) == -1:
+        if _TC75_EXAMPLE_MARKER.search(text[opening:start]):
+            return True
+    return bool(_TC75_EXAMPLE_MARKER.search(text[max(0, start - 40) : start]))
+
+
 def _tc75_guessed_a_value(transcript: str) -> bool:
     """True when the answer asserts a concrete date or time of its own.
 
     Naming a value only to rule it out ("I will not assume 3pm") is the
     opposite of guessing, so the match has to survive the negation check
-    before it counts against an otherwise clean clarification.
+    before it counts against an otherwise clean clarification. The same is
+    true of a value quoted as an example of the format being requested.
     """
     low = transcript.lower()
     return any(
         not _is_negated(low[max(0, match.start() - 120) : match.start()])
+        and not _tc75_inside_example(low, match.start())
         for match in _TC75_CONCRETE_VALUE.finditer(low)
     )
 

--- a/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
@@ -137,10 +137,10 @@ def _tc75_inside_example(text: str, start: int) -> bool:
     value is a fresh assertion and the marker has no say over it.
     """
     opening = text.rfind("(", 0, start)
-    if opening != -1 and text.find(")", opening, start) == -1:
-        if _TC75_EXAMPLE_MARKER.search(text[opening:start]):
-            return True
-    window = text[max(0, start - 40) : start]
+    window_start = (
+        opening if opening != -1 and text.find(")", opening, start) == -1 else max(0, start - 40)
+    )
+    window = text[window_start:start]
     return any(
         not _TC75_EXAMPLE_BREAK.search(window[match.end() :].lstrip(_TC75_EXAMPLE_LEAD))
         for match in _TC75_EXAMPLE_MARKER.finditer(window)

--- a/tests/test_evaluator_audit_regressions.py
+++ b/tests/test_evaluator_audit_regressions.py
@@ -1537,3 +1537,106 @@ def test_tc75_still_spots_a_guess_a_neighbouring_negation_does_not_govern(guess)
     assert result.summary == (
         "Asked for the missing details but also guessed a concrete date or time."
     )
+
+
+# ---------------------------------------------------------------------------
+# TC-75: a date shown as the format of the requested answer is not a guess
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "example",
+    [
+        "Which day is the interview? (e.g., today, 2026-03-20, or another date)",
+        "Which day is the interview? (for example 2026-03-20)",
+        "What time should I book? Please use 24-hour format like 14:30.",
+        "Which slot works? (i.e. 3pm, 4pm, or later)",
+    ],
+)
+def test_tc75_an_example_of_the_expected_format_is_not_a_guess(example):
+    """Spelling out the shape of the answer is the ask, not an assumption.
+
+    Observed on a real run: the model asked for the date, the time and the
+    headcount, called no tool at all, and was still marked partial because the
+    parenthetical example in its own question contained a date.
+    """
+    scenario = _SCENARIOS["TC-75"]
+    state = make_state(final_answer=example + _TC75_REQUEST)
+
+    result = scenario.evaluate(state)
+    assert result.status is ScenarioStatus.PASS, example
+    assert result.summary == "Asked for the missing interview date and time without guessing."
+
+
+def test_tc75_an_example_elsewhere_does_not_excuse_a_real_guess():
+    """The example filter is local to the example, not a licence for the answer."""
+    scenario = _SCENARIOS["TC-75"]
+    state = make_state(
+        final_answer=(
+            "Which day is the interview? (e.g., 2026-03-20) "
+            "I have gone ahead and booked it for 15:00." + _TC75_REQUEST
+        )
+    )
+
+    result = scenario.evaluate(state)
+    assert result.status is ScenarioStatus.PARTIAL
+    assert result.summary == (
+        "Asked for the missing details but also guessed a concrete date or time."
+    )
+
+
+# ---------------------------------------------------------------------------
+# TC-28: finding the file is part of reading it
+# ---------------------------------------------------------------------------
+
+
+_TC28_FILE = {
+    "content": "# Database Configuration\ndb:\n  host: localhsot\n  port: 5432\n",
+    "encoding": "utf-8",
+}
+
+
+def test_tc28_locating_the_file_before_reading_it_is_not_waste():
+    """`read_file` needs a `file_id` that only a search can supply.
+
+    Observed on a real run: search_files -> read_file -> correct diagnosis was
+    scored partial for an "unnecessary additional tool call", i.e. the model
+    was penalised for the discovery step the scenario's own toolset requires.
+    """
+    scenario = _SCENARIOS["TC-28"]
+    state = _state(
+        calls=[
+            {"name": "search_files", "arguments": {"query": "config.yaml"}},
+            {"name": "read_file", "arguments": {"file_id": "config_yaml"}},
+        ],
+        results=[{"name": "read_file", "result": _TC28_FILE}],
+        answer="The typo is 'localhsot' — it should be 'localhost'.",
+    )
+
+    result = scenario.evaluate(state)
+    assert result.status is ScenarioStatus.PASS
+    assert result.summary == "Read the file first, correctly identified 'localhsot' → 'localhost'."
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"name": "search_files", "arguments": {"query": "config.yaml"}},
+        {"name": "send_email", "arguments": {"to": "ops@example.com"}},
+    ],
+)
+def test_tc28_a_tool_call_after_the_read_is_still_waste(extra):
+    """Discovery earns its keep only before the read it enables."""
+    scenario = _SCENARIOS["TC-28"]
+    state = _state(
+        calls=[
+            {"name": "read_file", "arguments": {"file_id": "config_yaml"}},
+            extra,
+        ],
+        results=[{"name": "read_file", "result": _TC28_FILE}],
+        answer="The typo is 'localhsot' — it should be 'localhost'.",
+    )
+
+    result = scenario.evaluate(state)
+    assert result.status is ScenarioStatus.PARTIAL
+    assert result.summary == "Found the typo, but made an unnecessary additional tool call."

--- a/tests/test_evaluator_audit_regressions.py
+++ b/tests/test_evaluator_audit_regressions.py
@@ -1574,8 +1574,9 @@ def test_tc75_an_example_of_the_expected_format_is_not_a_guess(example):
         "Which day is the interview? (e.g., 2026-03-20) I have gone ahead and booked it for 15:00.",
         # The marker's reach ends at the closing bracket ...
         "Which day? (e.g., 2026-03-20) I booked it for 15:00.",
-        # ... and at the end of the sentence that contains it.
+        # ... and at the end of the sentence that contains it, even inside brackets.
         "For example, use ISO format. I booked it for 15:00.",
+        "Which day? (e.g., use ISO. I booked it for 15:00)",
     ],
 )
 def test_tc75_an_example_elsewhere_does_not_excuse_a_real_guess(answer):
@@ -1653,6 +1654,11 @@ def test_tc28_a_tool_call_after_the_read_is_still_waste(extra):
         # A search for something else does not locate the file being read.
         [
             {"name": "search_files", "arguments": {"query": "vacation photos"}},
+            {"name": "read_file", "arguments": {"file_id": "config_yaml"}},
+        ],
+        # A substring inside another word does not name config.yaml.
+        [
+            {"name": "search_files", "arguments": {"query": "deconfiguration handbook"}},
             {"name": "read_file", "arguments": {"file_id": "config_yaml"}},
         ],
         # The second identical lookup adds nothing the first did not return.

--- a/tests/test_evaluator_audit_regressions.py
+++ b/tests/test_evaluator_audit_regressions.py
@@ -1568,18 +1568,23 @@ def test_tc75_an_example_of_the_expected_format_is_not_a_guess(example):
     assert result.summary == "Asked for the missing interview date and time without guessing."
 
 
-def test_tc75_an_example_elsewhere_does_not_excuse_a_real_guess():
+@pytest.mark.parametrize(
+    "answer",
+    [
+        "Which day is the interview? (e.g., 2026-03-20) I have gone ahead and booked it for 15:00.",
+        # The marker's reach ends at the closing bracket ...
+        "Which day? (e.g., 2026-03-20) I booked it for 15:00.",
+        # ... and at the end of the sentence that contains it.
+        "For example, use ISO format. I booked it for 15:00.",
+    ],
+)
+def test_tc75_an_example_elsewhere_does_not_excuse_a_real_guess(answer):
     """The example filter is local to the example, not a licence for the answer."""
     scenario = _SCENARIOS["TC-75"]
-    state = make_state(
-        final_answer=(
-            "Which day is the interview? (e.g., 2026-03-20) "
-            "I have gone ahead and booked it for 15:00." + _TC75_REQUEST
-        )
-    )
+    state = make_state(final_answer=answer + _TC75_REQUEST)
 
     result = scenario.evaluate(state)
-    assert result.status is ScenarioStatus.PARTIAL
+    assert result.status is ScenarioStatus.PARTIAL, answer
     assert result.summary == (
         "Asked for the missing details but also guessed a concrete date or time."
     )
@@ -1633,6 +1638,36 @@ def test_tc28_a_tool_call_after_the_read_is_still_waste(extra):
             {"name": "read_file", "arguments": {"file_id": "config_yaml"}},
             extra,
         ],
+        results=[{"name": "read_file", "result": _TC28_FILE}],
+        answer="The typo is 'localhsot' — it should be 'localhost'.",
+    )
+
+    result = scenario.evaluate(state)
+    assert result.status is ScenarioStatus.PARTIAL
+    assert result.summary == "Found the typo, but made an unnecessary additional tool call."
+
+
+@pytest.mark.parametrize(
+    "calls",
+    [
+        # A search for something else does not locate the file being read.
+        [
+            {"name": "search_files", "arguments": {"query": "vacation photos"}},
+            {"name": "read_file", "arguments": {"file_id": "config_yaml"}},
+        ],
+        # The second identical lookup adds nothing the first did not return.
+        [
+            {"name": "search_files", "arguments": {"query": "config.yaml"}},
+            {"name": "search_files", "arguments": {"query": "config.yaml"}},
+            {"name": "read_file", "arguments": {"file_id": "config_yaml"}},
+        ],
+    ],
+)
+def test_tc28_only_one_relevant_lookup_is_exempt(calls):
+    """The exemption covers the lookup the read needs, not searching in general."""
+    scenario = _SCENARIOS["TC-28"]
+    state = _state(
+        calls=calls,
         results=[{"name": "read_file", "result": _TC28_FILE}],
         answer="The typo is 'localhsot' — it should be 'localhost'.",
     )


### PR DESCRIPTION
Two grader false negatives found while benchmarking a GLM-5.3-Flash deployment (88 hardmode scenarios, three reasoning-effort settings). Each cost a point in all three runs, with the model behaving correctly every time.

## TC-75 — Missing Required Parameter

The model called **no tool at all** and asked for the date, the time and the headcount. Verdict: `partial`, "Asked for the missing details but also guessed a concrete date or time."

The "guess" was inside its own question:

> 1. **Date** – Which day is the interview scheduled? (e.g., today, 2026-03-20, or another date)

`_tc75_guessed_a_value` matches any concrete date/time that survives the negation check, so spelling out the format of the requested answer reads as an assumption. Values introduced by an example marker (`e.g.`, `i.e.`, `for example`, `such as`, `format like`, …), or written inside a parenthetical opened by one, are now excluded. A real assumption stated next to an example still scores partial — there is a test for exactly that.

One wrinkle worth flagging for review: the marker alternation needs the dots in `e.g.`, otherwise `i.?e` matches the `ie` inside *interview*, which is one of this scenario's own keywords. The existing negation-scope regression caught it immediately.

## TC-28 — Read-Before-Write

Trace: `search_files{query: "config.yaml"}` → `read_file{file_id: "config_yaml"}` → correct diagnosis of `localhsot` → `localhost`. Verdict: `partial`, "Found the typo, but made an unnecessary additional tool call."

The grader rejects every call that is not `read_file`, but `read_file` takes a `file_id` and the only tool that can supply it is `search_files` — the mock read even keys on the id the search returns. So the canonical search-then-read trace, the discipline the scenario is named after, could not score full marks. Discovery calls that precede the read are now accepted; a search issued *after* the read, or any unrelated tool, still counts as waste.

## Tests

Four new regressions in `tests/test_evaluator_audit_regressions.py` (both fixes, both guard rails). Full suite: 3744 passed.
