### PR TITLE
fix: filter TC-05 contacts by query

### DIFF
--- a/changelog.d/+tc05-contact-filter.fixed.md
+++ b/changelog.d/+tc05-contact-filter.fixed.md
@@ -1,0 +1,3 @@
+TC-05's `get_contacts` mock now filters its results by the requested name. A lookup for Alex or
+Jamie returns that contact, a combined lookup returns both, and an unrelated query returns no
+contacts instead of the same hard-coded pair.

--- a/src/tool_eval_bench/evals/scenarios/core/tc05.py
+++ b/src/tool_eval_bench/evals/scenarios/core/tc05.py
@@ -57,15 +57,17 @@ def _tc05_calendar_result_is_created(payload: Any) -> bool:
 
 def _tc05_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     if call.name == "get_contacts":
-        return _noise(
-            {
-                "results": [
-                    {"name": "Alex Stone", "email": "alex.stone@company.com"},
-                    {"name": "Jamie Liu", "email": "jamie.liu@company.com"},
-                ]
-            },
-            "get_contacts",
-        )
+        query = _as_str(call.arguments.get("query")).lower()
+        contacts = [
+            {"name": "Alex Stone", "email": "alex.stone@company.com"},
+            {"name": "Jamie Liu", "email": "jamie.liu@company.com"},
+        ]
+        results = [
+            contact
+            for contact in contacts
+            if re.search(rf"\b{re.escape(contact['name'].split()[0].lower())}\b", query)
+        ]
+        return _noise({"results": results}, "get_contacts")
     if call.name == "create_calendar_event":
         return _noise(
             {

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -175,6 +175,29 @@ class TestTC04:
 class TestTC05:
     sc = _sc("TC-05")
 
+    def _lookup_contacts(self, query: str) -> list[dict]:
+        call = ToolCallRecord(
+            id="contacts_1",
+            name="get_contacts",
+            raw_arguments="{}",
+            arguments={"query": query},
+            turn=1,
+        )
+        return self.sc.handle_tool_call(ScenarioState(), call)["results"]
+
+    def test_contact_lookup_filters_by_name(self) -> None:
+        assert [contact["name"] for contact in self._lookup_contacts("Alex")] == ["Alex Stone"]
+        assert [contact["name"] for contact in self._lookup_contacts("Jamie")] == ["Jamie Liu"]
+
+    def test_contact_lookup_accepts_both_names(self) -> None:
+        assert [contact["name"] for contact in self._lookup_contacts("Alex and Jamie")] == [
+            "Alex Stone",
+            "Jamie Liu",
+        ]
+
+    def test_contact_lookup_returns_empty_for_unknown_name(self) -> None:
+        assert self._lookup_contacts("Pat") == []
+
     def test_pass(self) -> None:
         s = _state(
             tool_calls=[


### PR DESCRIPTION
## Summary

- Filter TC-05 `get_contacts` results by the requested name.
- Preserve combined lookups such as `Alex and Jamie`.
- Return an empty result for unrelated queries.
- Add focused handler tests and a changelog fragment.

## Why

The mock previously returned Alex and Jamie for every query. That made its output independent of the tool arguments and reduced TC-05's contact lookup to a hard-coded response.

## Validation

- `ruff check .`
- `ruff format --check .`
- `mypy`
- `pytest tests/ --ignore=tests/test_llama_benchy.py -m "not live" --randomly-seed=104729` — 3677 passed, 1 deselected
