### PR TITLE
fix: distinguish TC-13 search variants

### DIFF
--- a/changelog.d/+tc13-search-variants.fixed.md
+++ b/changelog.d/+tc13-search-variants.fixed.md
@@ -1,0 +1,3 @@
+TC-13 now treats a changed `file_type` as a distinct retry instead of reporting that the model
+repeated the same search. Its mock also honors the filter, so a PDF search cannot return the DOCX
+fixture.

--- a/src/tool_eval_bench/evals/scenarios/core/tc13.py
+++ b/src/tool_eval_bench/evals/scenarios/core/tc13.py
@@ -47,15 +47,18 @@ from tool_eval_bench.evals.scenarios.core._shared import (
 def _tc13_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
     if call.name == "search_files":
         query = _normalize(_as_str(call.arguments.get("query")))
+        file_type = _normalize(_as_str(call.arguments.get("file_type"))) or "any"
         attempts = int(state.meta.get("search_attempts", 0)) + 1
         state.meta["search_attempts"] = attempts
         if "johnson proposal" in query and attempts == 1:
             return _noise({"results": []}, "search_files")
         if "johnson" in query:
-            return _noise(
-                {"results": [{"file_id": "file_117", "name": "Johnson_Project_Proposal_v2.docx"}]},
-                "search_files",
+            results = (
+                [{"file_id": "file_117", "name": "Johnson_Project_Proposal_v2.docx"}]
+                if file_type in {"any", "docx"}
+                else []
             )
+            return _noise({"results": results}, "search_files")
     return _generic_tool_fallback(call)
 
 
@@ -79,6 +82,13 @@ def _tc13_result_has_document(result: Any) -> bool:
     return False
 
 
+def _tc13_search_signature(call: ToolCallRecord) -> tuple[str, str]:
+    """Return the arguments that determine a file search's result set."""
+    query = _normalize(_as_str(call.arguments.get("query")))
+    file_type = _normalize(_as_str(call.arguments.get("file_type"))) or "any"
+    return query, file_type
+
+
 def _tc13_eval(state: ScenarioState) -> ScenarioEvaluation:
     searches = _tool_calls_by_name(state, "search_files")
     retried = len(searches) >= 2
@@ -87,12 +97,13 @@ def _tc13_eval(state: ScenarioState) -> ScenarioEvaluation:
         explicit_results = [r for r in state.tool_results if r.name == "search_files"]
         if explicit_results and searches[0].turn >= searches[1].turn:
             return _fail("Retried search before receiving the first result.")
-        # Ensure the retry used a meaningfully different query (not just repeating)
-        queries = [_normalize(_as_str(s.arguments.get("query", ""))) for s in searches]
-        if len(queries) >= 2 and any(
-            left == right for left, right in zip(queries, queries[1:], strict=False)
+        # Changing a file-type filter changes the search even when the text stays the same.
+        signatures = [_tc13_search_signature(search) for search in searches]
+        if len(signatures) >= 2 and any(
+            left == right for left, right in zip(signatures, signatures[1:], strict=False)
         ):
-            return _partial("Retried search, but used the exact same query both times.")
+            return _partial("Retried search, but repeated the same arguments.")
+        queries = [signature[0] for signature in signatures]
         if not any(_positive_argument_contains(query, "johnson") for query in queries[1:]):
             return _fail("Retried search without preserving the Johnson document request.")
         if explicit_results:

--- a/tests/test_evaluator_contract.py
+++ b/tests/test_evaluator_contract.py
@@ -919,6 +919,48 @@ class TestTC13Contract:
         )
         assert self.sc.evaluate(s).status == ScenarioStatus.PASS
 
+    def test_pass_retry_same_query_with_different_file_types(self):
+        s = _state(
+            tool_calls=[
+                {
+                    "id": "c0",
+                    "name": "search_files",
+                    "arguments": {"query": "johnson proposal"},
+                    "turn": 1,
+                },
+                {
+                    "id": "c1",
+                    "name": "search_files",
+                    "arguments": {"query": "johnson", "file_type": "pdf"},
+                    "turn": 2,
+                },
+                {
+                    "id": "c2",
+                    "name": "search_files",
+                    "arguments": {"query": "johnson", "file_type": "docx"},
+                    "turn": 2,
+                },
+            ],
+            tool_results=[
+                {"name": "search_files", "call_id": "c0", "result": {"results": []}},
+                {"name": "search_files", "call_id": "c1", "result": {"results": []}},
+                {
+                    "name": "search_files",
+                    "call_id": "c2",
+                    "result": {
+                        "results": [
+                            {
+                                "file_id": "file_117",
+                                "name": "Johnson_Project_Proposal_v2.docx",
+                            }
+                        ]
+                    },
+                },
+            ],
+            final_answer="Found Johnson_Project_Proposal_v2.docx.",
+        )
+        assert self.sc.evaluate(s).status == ScenarioStatus.PASS
+
     def test_pass_asks_clarification(self):
         s = _state(
             tool_calls=[

--- a/tests/test_evaluators_extended.py
+++ b/tests/test_evaluators_extended.py
@@ -396,6 +396,20 @@ class TestTC11:
 class TestTC13:
     sc = _sc("TC-13")
 
+    def test_mock_honors_file_type(self) -> None:
+        state = ScenarioState()
+        first = ToolCallRecord("c0", "search_files", "{}", {"query": "Johnson proposal"}, 1)
+        pdf = ToolCallRecord(
+            "c1", "search_files", "{}", {"query": "Johnson", "file_type": "pdf"}, 2
+        )
+        docx = ToolCallRecord(
+            "c2", "search_files", "{}", {"query": "Johnson", "file_type": "docx"}, 3
+        )
+
+        assert self.sc.handle_tool_call(state, first)["results"] == []
+        assert self.sc.handle_tool_call(state, pdf)["results"] == []
+        assert self.sc.handle_tool_call(state, docx)["results"][0]["file_id"] == "file_117"
+
     def test_pass_retry(self) -> None:
         s = _state(
             tool_calls=[


### PR DESCRIPTION
## Summary

- Treat `search_files` calls with different `file_type` values as distinct TC-13 retries.
- Make the TC-13 mock honor `file_type` so a PDF search cannot return its DOCX fixture.
- Add evaluator and mock regression tests.

## Why

A stored trace retried `Johnson` with `pdf` and `docx`, found and surfaced the target document, but scored PARTIAL as an “exact same query” retry. The evaluator compared only `query` and ignored the filter that changes the search result set.

Re-scoring 106 stored traces against this branch changes only that TC-13 verdict from PARTIAL to PASS. The other 105 verdicts are unchanged.

## Validation

- `ruff check .`
- `ruff format --check .`
- `mypy`
- `pytest tests/ --ignore=tests/test_llama_benchy.py -m "not live" --randomly-seed=104729` — 3676 passed, 1 deselected
