### PR TITLE
fix: make TC-15 calculator requirement explicit (#136)

### DIFF
--- a/changelog.d/136.changed.md
+++ b/changelog.d/136.changed.md
@@ -1,0 +1,1 @@
+TC-15 now states its calculator requirement in the model-visible prompt, matching the existing PASS criteria.

--- a/src/tool_eval_bench/evals/scenarios/core/tc15.py
+++ b/src/tool_eval_bench/evals/scenarios/core/tc15.py
@@ -157,7 +157,10 @@ SCENARIO = ScenarioDefinition(
     id="TC-15",
     title="Conflicting Information",
     category=Category.E,
-    user_message="Search for the population of Iceland and calculate what 2% of it would be.",
+    user_message=(
+        "Search for the population of Iceland, then use the calculator to compute 2% "
+        "of the exact population value you find."
+    ),
     description="Carry the exact searched value into the calculator.",
     handle_tool_call=_tc15_handle,
     evaluate=_tc15_eval,

--- a/tests/test_evaluator_contract.py
+++ b/tests/test_evaluator_contract.py
@@ -1093,6 +1093,12 @@ class TestTC14Contract:
 class TestTC15Contract:
     sc = _get("TC-15")
 
+    def test_prompt_states_calculator_requirement(self):
+        assert self.sc.user_message == (
+            "Search for the population of Iceland, then use the calculator to compute 2% "
+            "of the exact population value you find."
+        )
+
     def test_pass_search_then_calc(self):
         s = _state(
             tool_calls=[


### PR DESCRIPTION
TC-15 currently requires a calculator call for PASS, but its model-visible prompt only asks the model to calculate 2% of the searched population. A model can search, carry the exact value forward, compute the correct answer, and still lose a point for an unstated method.

This change makes the existing calculator requirement explicit in the TC-15 prompt. It keeps the evaluator and TC-11 restraint policy unchanged, adds an exact prompt-contract regression test, and records the scoring-contract clarification in the changelog.

Verification:

- TC-11 and TC-15 contract tests: 10 passed
- Ruff check and format check: passed
- mypy: passed with 222 source files
- Required non-live suite: 3,686 passed, 1 deselected

Closes #136

Written with AI assistance; reviewed before opening.