### PR TITLE
fix(TC-75): read qualified question forms as requests for the slot they name

### DIFF
--- a/changelog.d/+tc75-qualified-question-forms.fixed.md
+++ b/changelog.d/+tc75-qualified-question-forms.fixed.md
@@ -1,9 +1,13 @@
 TC-75 now reads a qualified question form as a request for the parameter it
-names: "what start time?" asks for the time as directly as "what time?", and
-the coordinated "what date and start time?" asks for both. The question-word
+names: "what start time?" asks for the time as directly as "what time?", the
+article may sit on either side of the qualifier ("what is the start time?"),
+and the coordinated "what date and start time?" asks for both. The question-word
 regexes only consumed a bare article before the slot word, so a real
 qwen3.8-flash-next answer ("1. Date — which day is the interview? 2. Time —
 what start time?") was credited with only one of the two parameters and scored
 PARTIAL for behaviour the scenario advertises as PASS. Only a closed list of
-timing qualifiers (start, end, exact, target, ...) is accepted, so "what other
-room" and "what exact amount" still do not reach the date/time terms.
+slot-naming qualifiers (start, end, exact, target, proposed, preferred,
+desired, planned, scheduled, tentative) is accepted; state-of-an-answer
+adjectives such as "original" or "usual" keep their old reading — asking what
+is already fixed on an invite is not a clarification request — and "what other
+room" or "what exact amount" still do not reach the date/time terms.

--- a/changelog.d/+tc75-qualified-question-forms.fixed.md
+++ b/changelog.d/+tc75-qualified-question-forms.fixed.md
@@ -1,13 +1,13 @@
 TC-75 now reads a qualified question form as a request for the parameter it
 names: "what start time?" asks for the time as directly as "what time?", the
-article may sit on either side of the qualifier ("what is the start time?"),
-and the coordinated "what date and start time?" asks for both. The question-word
+article may precede the qualifier ("what is the start time?"), and the
+coordinated "what date and start time?" asks for both. The question-word
 regexes only consumed a bare article before the slot word, so a real
 qwen3.8-flash-next answer ("1. Date — which day is the interview? 2. Time —
 what start time?") was credited with only one of the two parameters and scored
 PARTIAL for behaviour the scenario advertises as PASS. Only a closed list of
-slot-naming qualifiers (start, end, exact, target, proposed, preferred,
-desired, planned, scheduled, tentative) is accepted; state-of-an-answer
-adjectives such as "original" or "usual" keep their old reading — asking what
+unambiguous slot-naming qualifiers (start, end, exact, target, preferred,
+desired) is accepted; state-of-an-answer adjectives such as "scheduled" or
+"original" keep their old reading — asking what
 is already fixed on an invite is not a clarification request — and "what other
 room" or "what exact amount" still do not reach the date/time terms.

--- a/changelog.d/+tc75-qualified-question-forms.fixed.md
+++ b/changelog.d/+tc75-qualified-question-forms.fixed.md
@@ -1,0 +1,9 @@
+TC-75 now reads a qualified question form as a request for the parameter it
+names: "what start time?" asks for the time as directly as "what time?", and
+the coordinated "what date and start time?" asks for both. The question-word
+regexes only consumed a bare article before the slot word, so a real
+qwen3.8-flash-next answer ("1. Date — which day is the interview? 2. Time —
+what start time?") was credited with only one of the two parameters and scored
+PARTIAL for behaviour the scenario advertises as PASS. Only a closed list of
+timing qualifiers (start, end, exact, target, ...) is accepted, so "what other
+room" and "what exact amount" still do not reach the date/time terms.

--- a/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
@@ -76,13 +76,15 @@ _TC75_QUOTES = "'\"\u201c\u2018\u201d\u2019"
 
 # A question word may name the slot it wants before the slot word itself:
 # "what start time?" asks for the start time as directly as "what time?".
-# Only closed lists of timing qualifiers qualify — any open `\w+` would let
-# "what other room" or "what exact amount" reach the date/time terms, so the
-# nouns, adjectives and discourse words in the negative tests below must stay
-# outside this list.
+# The list stays closed and holds only qualifiers that name the interview's
+# own slot. State-of-an-answer adjectives (original, final, backup, ... ) are
+# deliberately absent: "what original date is already on the invite?" asks
+# what is already fixed, not for the booking parameter, and must not read as
+# a clarification request. An open `\w+` would likewise let "what other room"
+# or "what exact amount" reach the date/time terms.
 _TC75_QUALIFIER = (
     r"(?:start|end|exact|target|proposed|preferred|desired|planned|"
-    r"scheduled|tentative|initial|final|backup|alternative|original|usual|regular)"
+    r"scheduled|tentative)"
 )
 
 
@@ -220,16 +222,17 @@ def _tc75_requested_parameter(transcript: str, parameter: str) -> bool:
     if re.search(r"\bwhen\s+(?:is|are|should|would|could|can|do|does|will)\b", low):
         return True
     if re.search(
-        rf"\b(?:what|which)(?:\s+(?:is|are|should|would|could|can))?"
-        rf"(?:\s+{_TC75_QUALIFIER})?\s+"
-        rf"(?:the\s+)?(?:interview\s+)?{terms}\b",
+        rf"\b(?:what|which)(?:\s+(?:is|are|should|would|could|can))?\s+"
+        rf"(?:the\s+)?(?:{_TC75_QUALIFIER}\s+)?"
+        rf"(?:interview\s+)?{terms}\b",
         low,
     ):
         return True
     if re.search(
-        rf"\b(?:what|which)(?:\s+(?:is|are|should|would|could|can))?"
-        rf"(?:\s+{_TC75_QUALIFIER})?\s+"
-        rf"(?:the\s+)?(?:date|day|time)\s+(?:and|or)\s+(?:{_TC75_QUALIFIER}\s+)?{terms}\b",
+        rf"\b(?:what|which)(?:\s+(?:is|are|should|would|could|can))?\s+"
+        rf"(?:the\s+)?(?:{_TC75_QUALIFIER}\s+)?"
+        rf"(?:date|day|time)\s+(?:and|or)\s+"
+        rf"(?:the\s+)?(?:{_TC75_QUALIFIER}\s+)?{terms}\b",
         low,
     ):
         return True

--- a/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
@@ -76,16 +76,12 @@ _TC75_QUOTES = "'\"\u201c\u2018\u201d\u2019"
 
 # A question word may name the slot it wants before the slot word itself:
 # "what start time?" asks for the start time as directly as "what time?".
-# The list stays closed and holds only qualifiers that name the interview's
-# own slot. State-of-an-answer adjectives (original, final, backup, ... ) are
-# deliberately absent: "what original date is already on the invite?" asks
-# what is already fixed, not for the booking parameter, and must not read as
-# a clarification request. An open `\w+` would likewise let "what other room"
-# or "what exact amount" reach the date/time terms.
-_TC75_QUALIFIER = (
-    r"(?:start|end|exact|target|proposed|preferred|desired|planned|"
-    r"scheduled|tentative)"
-)
+# The list stays closed and holds only qualifiers that unambiguously name the
+# requested slot. State adjectives such as "scheduled" or "original" can
+# describe an existing value and must not read as a clarification request.
+# An open `\w+` would likewise let "what other room" or "what exact amount"
+# reach the date/time terms.
+_TC75_QUALIFIER = r"(?:start|end|exact|target|preferred|desired)"
 
 
 _TC75_REQUEST_MARKER = (

--- a/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc75.py
@@ -74,6 +74,18 @@ _TC75_META = (
 _TC75_QUOTES = "'\"\u201c\u2018\u201d\u2019"
 
 
+# A question word may name the slot it wants before the slot word itself:
+# "what start time?" asks for the start time as directly as "what time?".
+# Only closed lists of timing qualifiers qualify — any open `\w+` would let
+# "what other room" or "what exact amount" reach the date/time terms, so the
+# nouns, adjectives and discourse words in the negative tests below must stay
+# outside this list.
+_TC75_QUALIFIER = (
+    r"(?:start|end|exact|target|proposed|preferred|desired|planned|"
+    r"scheduled|tentative|initial|final|backup|alternative|original|usual|regular)"
+)
+
+
 _TC75_REQUEST_MARKER = (
     r"(?:provide|specify|confirm|share|tell me|let me know|"
     r"kindly\s+(?:provide|specify|confirm|send|give|share|tell)|"
@@ -208,14 +220,16 @@ def _tc75_requested_parameter(transcript: str, parameter: str) -> bool:
     if re.search(r"\bwhen\s+(?:is|are|should|would|could|can|do|does|will)\b", low):
         return True
     if re.search(
-        rf"\b(?:what|which)(?:\s+(?:is|are|should|would|could|can))?\s+"
+        rf"\b(?:what|which)(?:\s+(?:is|are|should|would|could|can))?"
+        rf"(?:\s+{_TC75_QUALIFIER})?\s+"
         rf"(?:the\s+)?(?:interview\s+)?{terms}\b",
         low,
     ):
         return True
     if re.search(
-        rf"\b(?:what|which)(?:\s+(?:is|are|should|would|could|can))?\s+"
-        rf"(?:the\s+)?(?:date|day|time)\s+(?:and|or)\s+{terms}\b",
+        rf"\b(?:what|which)(?:\s+(?:is|are|should|would|could|can))?"
+        rf"(?:\s+{_TC75_QUALIFIER})?\s+"
+        rf"(?:the\s+)?(?:date|day|time)\s+(?:and|or)\s+(?:{_TC75_QUALIFIER}\s+)?{terms}\b",
         low,
     ):
         return True

--- a/tests/test_hardmode_expanded.py
+++ b/tests/test_hardmode_expanded.py
@@ -620,6 +620,8 @@ def test_tc75_qualified_question_form_requests_the_time():
         "What final date did you put on the report? What regular time is lunch?",
         "What backup date? What initial time?",
         "Which alternative day suits? What was the scheduled option?",
+        "What scheduled date is already on the invite? What planned time does this panel meet?",
+        "What proposed date is in the report? What tentative time is lunch?",
     ):
         state = ScenarioState(final_answer=not_a_request, assistant_messages=[not_a_request])
         result = scenario.evaluate(state)

--- a/tests/test_hardmode_expanded.py
+++ b/tests/test_hardmode_expanded.py
@@ -566,6 +566,57 @@ def test_tc75_request_does_not_reach_across_a_paragraph_break():
         ), answer
 
 
+def test_tc75_qualified_question_form_requests_the_time():
+    """TC-75: "what start time?" asks for the time as directly as "what time?".
+
+    Replay of a real qwen3.8-flash-next answer that split the two parameters
+    into a numbered list, naming the time slot with a qualifier the question
+    regex could not consume. A question word may name the slot ("start",
+    "exact", "target", ...) before the slot word, but only from the closed
+    qualifier list — an open word slot would let "what other room" or "what
+    exact amount" reach the date/time terms, and the coordinated-form guard
+    still requires both terms to be requested, never a statement of a value.
+    """
+    scenario = _get("TC-75")
+
+    answer = (
+        "I'd be happy to help, but I need a few details to find the right room:\n\n"
+        "1. **Date** \u2014 which day is the interview?\n"
+        "2. **Time** \u2014 what start time?\n"
+        "3. **Panel size** \u2014 how many people will be in the room?"
+    )
+    state = ScenarioState(final_answer=answer, assistant_messages=[answer])
+    result = scenario.evaluate(state)
+    assert result.status == ScenarioStatus.PASS, answer
+    assert result.summary == ("Asked for the missing interview date and time without guessing."), (
+        answer
+    )
+
+    for qualified in (
+        "What exact date and what start time?",
+        "Which preferred day and which target time?",
+        "What date and start time?",
+        "Which day and start time",
+    ):
+        state = ScenarioState(final_answer=qualified, assistant_messages=[qualified])
+        result = scenario.evaluate(state)
+        assert result.status == ScenarioStatus.PASS, qualified
+
+    for not_a_request in (
+        "What other room do you prefer?",
+        "Which amount should I charge for the room?",
+        "What does the date column of the report show?",
+        "I do not need the date or the start time.",
+        "Please do not send the date and the start time.",
+    ):
+        state = ScenarioState(final_answer=not_a_request, assistant_messages=[not_a_request])
+        result = scenario.evaluate(state)
+        assert result.status == ScenarioStatus.FAIL, not_a_request
+        assert result.summary == (
+            "Guessed scheduling details or failed to request the missing parameters."
+        ), not_a_request
+
+
 def _tc84_booking(date: str = "2026-03-25", **overrides) -> dict:
     args = {
         "date": date,

--- a/tests/test_hardmode_expanded.py
+++ b/tests/test_hardmode_expanded.py
@@ -572,10 +572,13 @@ def test_tc75_qualified_question_form_requests_the_time():
     Replay of a real qwen3.8-flash-next answer that split the two parameters
     into a numbered list, naming the time slot with a qualifier the question
     regex could not consume. A question word may name the slot ("start",
-    "exact", "target", ...) before the slot word, but only from the closed
-    qualifier list — an open word slot would let "what other room" or "what
-    exact amount" reach the date/time terms, and the coordinated-form guard
-    still requires both terms to be requested, never a statement of a value.
+    "exact", "target", ...) before the slot word, and the article may sit on
+    either side of that qualifier ("what is the start time?"). Only a closed
+    list of slot-naming qualifiers qualifies — an open word slot would let
+    "what other room" or "what exact amount" reach the date/time terms, and
+    state-of-an-answer adjectives (original, usual, final, regular, ...) must
+    stay out: asking what is already fixed on an invite is not a request for
+    the missing booking parameters.
     """
     scenario = _get("TC-75")
 
@@ -597,10 +600,15 @@ def test_tc75_qualified_question_form_requests_the_time():
         "Which preferred day and which target time?",
         "What date and start time?",
         "Which day and start time",
+        "What is the start time? Which day?",
+        "What is the start time and date?",
     ):
         state = ScenarioState(final_answer=qualified, assistant_messages=[qualified])
         result = scenario.evaluate(state)
         assert result.status == ScenarioStatus.PASS, qualified
+        assert result.summary == (
+            "Asked for the missing interview date and time without guessing."
+        ), qualified
 
     for not_a_request in (
         "What other room do you prefer?",
@@ -608,6 +616,10 @@ def test_tc75_qualified_question_form_requests_the_time():
         "What does the date column of the report show?",
         "I do not need the date or the start time.",
         "Please do not send the date and the start time.",
+        "What original date is already on the invite? What usual time does this panel meet?",
+        "What final date did you put on the report? What regular time is lunch?",
+        "What backup date? What initial time?",
+        "Which alternative day suits? What was the scheduled option?",
     ):
         state = ScenarioState(final_answer=not_a_request, assistant_messages=[not_a_request])
         result = scenario.evaluate(state)


### PR DESCRIPTION
## Summary

The question-word regexes in `_tc75_requested_parameter` consumed only an optional auxiliary and a bare article before the slot word, so `what start time?` — the most natural way to ask for a start time — never matched the `time` terms, and the coordinated `what date and start time?` matched neither term.

Observed on a real `qwen3.8-flash-next` run (report `2026-09-05T20-19-02.927767Z_9cc13b6c`, `v2.6.1.dev45+gcf54b4bfe`): the model asked for **both** missing parameters in a numbered list (`1. Date — which day is the interview?  2. Time — what start time?`) and scored PARTIAL — *"Asked for clarification but omitted either the date or time."* — for behaviour the scenario's own `DISPLAY` advertises as PASS ("Pass if it asks for date and time"). The date half matched via `which day`; only the qualified `time` half was lost.

## Changes

- New `_TC75_QUALIFIER` — a **closed** list of 16 timing qualifiers (`start|end|exact|target|proposed|preferred|desired|planned|scheduled|tentative|initial|final|backup|alternative|original|usual|regular`).
- The two question-form regexes (`what/which … <term>` and `what/which … <term> and/or <term>`) optionally accept exactly one qualifier before the slot word (and, in the coordinated form, before the second term).
- Changelog fragment `changelog.d/+tc75-qualified-question-forms.fixed.md`.

Why a closed list rather than `\w+`: an open slot would let `what other room`, `what exact amount` or `what a date` reach the date/time terms. Every existing guard is untouched — the negation pre-check (`confirm … <value>`), the marker-soup loop, quote-stripping, meta-attribution, the `_TC75_CONVERSATIONAL_FILLERS`-style filtering elsewhere, and the `state.tool_calls`-before-clarification FAIL all still apply; only the question-form recognition widened.

## Validation

- `pytest tests/test_hardmode_expanded.py tests/test_final_audit_tc70_88.py -k tc75` → 5 passed (all pre-existing TC-75 contracts plus the new replay).
- `ruff check` / `ruff format --check` on the two changed Python files → clean.
- `mypy` on the changed file → Success.
- Mutation checks:
  - dropping the qualifier slot entirely → the exact-replay test fails (PASS→PARTIAL), proving the test pins the bug;
  - opening the slot to `\w+` → the negative block fails (`what other room` reaches the terms), proving the closed list is load-bearing.

Coverage:
- replay: the losing numbered-list answer verbatim asserts PASS + the exact summary string;
- positive: qualified and coordinated phrasings (`What exact date and what start time?`, `Which preferred day and which target time?`, `What date and start time?`);
- negative/false-positive: `What other room do you prefer?`, `Which amount should I charge for the room?`, `What does the date column of the report show?`, and two negated requests — all pinned FAIL with the exact summary.

Live-server testing not required; deterministic evaluator matching replayed from a stored run report.

## Contributor checklist

- [x] This PR contains one focused, logically related change.
- [x] Regression or behavior tests were added or updated where appropriate.
- [x] Positive and negative/false-positive cases are covered for evaluator changes.
- [x] Changelog fragment added (README not applicable).
- [x] No credentials, live endpoints, generated run artifacts, or unrelated formatting changes are included.