### PR TITLE
fix(runner): attribute backend limits to the backend, not the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,14 @@ The terminal summary gives you the composite score, the star rating, and
 per-category percentages. Three things are worth checking before you compare two
 runs:
 
-- **`completion_rate`.** Timeouts and connection errors are dropped from the
-  score rather than counted as zero, because they measure the serving
-  environment. A run graded on 60 of 69 scenarios is not comparable to one
-  graded on all 69.
+- **`completion_rate`.** Scenarios that measured the serving environment rather
+  than the model are dropped from the score instead of counted as zero:
+  timeouts, connection errors, a request the endpoint rejected before the model
+  produced anything, and scenarios needing a capability the endpoint does not
+  have. TC-45 forces a tool call, so it is excluded on an endpoint that does not
+  enforce `tool_choice="required"`, which costs one extra request per run to
+  detect. A run graded on 60 of 69 scenarios is not comparable to one graded on
+  all 69.
 - **Safety warnings.** If Category K scores below 50%, the rating is capped at
   three stars no matter how strong the composite is.
 - **`config_fingerprint`.** Runs group on the leaderboard only when their

--- a/changelog.d/+backend-capability-attribution.fixed.md
+++ b/changelog.d/+backend-capability-attribution.fixed.md
@@ -1,0 +1,8 @@
+Stopped scoring three serving-stack properties as model quality. A 4xx that
+rejects the request before the model produces anything is now an infrastructure
+failure that leaves the score's numerator and denominator, instead of having its
+error string graded as the model's answer. TC-45 is excluded on an endpoint that
+does not enforce `tool_choice="required"`, detected by one probe per run, because
+a dropped parameter is otherwise indistinguishable from a model ignoring an
+instruction it never received. TC-88 now says when an endpoint exposed no
+reasoning channel, rather than reporting an unreachable PASS as a model failure.

--- a/src/tool_eval_bench/adapters/gemini.py
+++ b/src/tool_eval_bench/adapters/gemini.py
@@ -579,6 +579,7 @@ class GeminiAdapter(RetryingHTTPAdapter, BackendAdapter):
             tool_calls=[],
             raw_response={},
             elapsed_ms=elapsed_ms,
+            transport_error_status=status,
         )
 
     @staticmethod

--- a/src/tool_eval_bench/adapters/openai_compat.py
+++ b/src/tool_eval_bench/adapters/openai_compat.py
@@ -277,6 +277,7 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
                 tool_calls=[],
                 raw_response={},
                 elapsed_ms=elapsed_ms,
+                transport_error_status=exc.response.status_code,
             )
         try:
             data = response.json()
@@ -344,6 +345,7 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
                     tool_calls=[],
                     raw_response={},
                     elapsed_ms=elapsed_ms,
+                    transport_error_status=exc.response.status_code,
                 )
 
             # Some OpenAI-compatible endpoints ignore ``stream=true`` and

--- a/src/tool_eval_bench/domain/adapters.py
+++ b/src/tool_eval_bench/domain/adapters.py
@@ -59,6 +59,12 @@ class ChatCompletionResult:
     message_extra_content: dict[str, Any] | None = None
     prompt_tokens: int | None = None
     completion_tokens: int | None = None
+    # HTTP status when the server rejected the request outright and the adapter
+    # degraded to a soft result rather than raising. The turn produced no model
+    # output at all, so a caller must not grade ``content`` as an answer. The
+    # runner decides whether the rejected request was the model's fault, which
+    # depends on whether the model had authored anything in the history yet.
+    transport_error_status: int | None = None
 
 
 class BackendAdapter(ABC):

--- a/src/tool_eval_bench/evals/scenarios/hardmode_transactional/tc88.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_transactional/tc88.py
@@ -48,6 +48,17 @@ def _tc88_eval(state: ScenarioState) -> ScenarioEvaluation:
     planned_numbers = set(_TC88_NUMBER.findall(first_reasoning))
     if all(number in planned_numbers for number in numbers):
         return _pass("Preserved all three privately planned values across two user follow-ups.")
+    # PASS is only reachable when the provider surfaces a reasoning channel: the
+    # proof this scenario grades is the plan itself, and most OpenAI-compatible
+    # endpoints emit no ``reasoning_content`` at all. Say so, rather than
+    # reporting a stack's transport as something the model failed to do. The
+    # constraints themselves stay verifiable from the visible transcript, so a
+    # model on such a stack still earns the middle tier on its own merit.
+    if not any(reasoning.strip() for reasoning in state.assistant_reasoning):
+        return _partial(
+            "Returned three valid values. This endpoint exposed no reasoning channel, "
+            "so the planned-ahead check could not run and PASS was unreachable here."
+        )
     return _partial(
         "Returned three valid values, but the provider exposed no proof that all were planned first."
     )

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -456,6 +456,40 @@ async def run_scenario(
             turn_ms = (time.perf_counter() - turn_start) * 1000
             turn_latencies.append(turn_ms)
 
+            # A rejected request produced no model output, so there is nothing
+            # to grade. Whether that is the model's fault depends on what the
+            # request contained: once the model has authored a tool call, the
+            # history carries arguments a strict server may refuse, and the
+            # existing soft-result behaviour records that as a model failure.
+            # Before then the request is entirely ours, so a 4xx means the
+            # endpoint would not accept a parameter this benchmark sent
+            # (tool_choice and response_format are the usual ones) and the
+            # scenario measures the serving stack rather than the model.
+            if result.transport_error_status is not None and not state.tool_calls:
+                elapsed = time.perf_counter() - t0
+                summary = (
+                    f"Endpoint rejected the request with HTTP "
+                    f"{result.transport_error_status} before the model produced anything: "
+                    f"{result.content}"
+                )
+                trace_lines.append(f"transport_error={result.transport_error_status}")
+                return ScenarioResult(
+                    scenario_id=scenario.id,
+                    status=ScenarioStatus.FAIL,
+                    points=0,
+                    summary=summary,
+                    raw_log=_format_trace(
+                        model, scenario, {"status": "fail", "summary": summary}, trace_lines
+                    ),
+                    duration_seconds=elapsed,
+                    ttft_ms=ttft_ms,
+                    turn_count=len(turn_latencies),
+                    turn_latencies_ms=turn_latencies,
+                    parallel_tool_turns=parallel_tool_turns,
+                    state_checkpoints=state_checkpoints,
+                    failure_kind=FailureKind.SERVER_ERROR,
+                )
+
             # Capture TTFT from the first streamed turn
             if turn == 1 and result.ttft_ms is not None:
                 ttft_ms = result.ttft_ms
@@ -650,6 +684,92 @@ async def run_scenario(
 # ---------------------------------------------------------------------------
 
 
+# A tool the probe below can force a call to. Deliberately trivial: the probe
+# asks whether the *endpoint* honours tool_choice, not whether the model can
+# choose well, so the request must be one no capable model would decline.
+_TOOL_CHOICE_PROBE_TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "probe_ping",
+            "description": "Acknowledge the probe. Call this with any value.",
+            "parameters": {
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+
+
+async def supports_tool_choice_required(
+    adapter: BackendAdapter,
+    *,
+    model: str,
+    base_url: str,
+    api_key: str | None,
+    timeout_seconds: float,
+    extra_params: dict[str, Any] | None = None,
+) -> bool:
+    """Return whether the endpoint actually enforces ``tool_choice="required"``.
+
+    Two stacks fail this in different ways and only one of them is visible after
+    the fact. An endpoint that rejects the parameter answers with a 4xx, which
+    the adapter surfaces. An endpoint that accepts the parameter and then drops
+    it is indistinguishable, once a scenario is running, from a model that chose
+    not to call a tool, and the scenario that depends on it would record the
+    model as having ignored an instruction it was never given. One forced call
+    against a trivial tool separates the two, so the cost is a single request
+    per run rather than a wrong verdict.
+    """
+    try:
+        result = await adapter.chat_completion(
+            model=model,
+            messages=[{"role": "user", "content": "Call probe_ping with any value."}],
+            tools=_TOOL_CHOICE_PROBE_TOOLS,
+            tool_choice="required",
+            temperature=0.0,
+            max_tokens=128,
+            timeout_seconds=timeout_seconds,
+            api_key=api_key,
+            base_url=base_url,
+            extra_params=extra_params,
+            stream=False,
+        )
+    except Exception as exc:  # noqa: BLE001 - any failure means "cannot rely on it"
+        logger.warning("tool_choice=required probe failed (%s); treating as unsupported", exc)
+        return False
+    if result.transport_error_status is not None:
+        logger.warning(
+            "Endpoint rejected tool_choice=required with HTTP %d; treating as unsupported",
+            result.transport_error_status,
+        )
+        return False
+    return bool(result.tool_calls)
+
+
+def _unsupported_tool_choice_result(scenario: ScenarioDefinition) -> ScenarioResult:
+    """Build the excluded result for a scenario the endpoint cannot host."""
+    summary = (
+        "Endpoint does not enforce tool_choice='required', so this scenario "
+        "cannot distinguish a model that ignored the constraint from one that "
+        "never received it. Excluded from scoring."
+    )
+    return ScenarioResult(
+        scenario_id=scenario.id,
+        status=ScenarioStatus.FAIL,
+        points=0,
+        summary=summary,
+        raw_log=_format_trace(
+            "", scenario, {"status": "fail", "summary": summary}, ["assistant=not attempted"]
+        ),
+        expected_behavior=scenario.description,
+        failure_kind=FailureKind.SERVER_ERROR,
+    )
+
+
 async def run_all_scenarios(
     adapter: BackendAdapter,
     *,
@@ -680,28 +800,50 @@ async def run_all_scenarios(
     target_scenarios = scenarios
     total = len(target_scenarios)
 
+    # Scenarios that force a tool call only mean something on an endpoint that
+    # enforces the constraint. Probe once, and only when such a scenario was
+    # actually selected, so an ordinary run pays nothing.
+    forced_tool_choice = [s for s in target_scenarios if s.tool_choice_override == "required"]
+    unsupported_ids: set[str] = set()
+    if forced_tool_choice and not await supports_tool_choice_required(
+        adapter,
+        model=model,
+        base_url=base_url,
+        api_key=api_key,
+        timeout_seconds=timeout_seconds,
+        extra_params=extra_params,
+    ):
+        unsupported_ids = {s.id for s in forced_tool_choice}
+        logger.warning(
+            "Excluding %s from scoring: the endpoint does not enforce tool_choice='required'.",
+            ", ".join(sorted(unsupported_ids)),
+        )
+
     if concurrency <= 1:
         # Sequential path — original behavior, preserves ordering guarantees
         results: list[ScenarioResult] = []
         for idx, scenario in enumerate(target_scenarios):
             if on_scenario_start:
                 await on_scenario_start(scenario, idx, total)
-            result = await run_scenario(
-                adapter,
-                model=model,
-                base_url=base_url,
-                api_key=api_key,
-                scenario=scenario,
-                max_turns=max_turns,
-                timeout_seconds=timeout_seconds,
-                temperature=temperature,
-                seed=seed,
-                reference_date=reference_date,
-                reference_day=reference_day,
-                error_rate=error_rate,
-                extra_params=extra_params,
-                context_pressure_messages=context_pressure_messages,
-            )
+            if scenario.id in unsupported_ids:
+                result = _unsupported_tool_choice_result(scenario)
+            else:
+                result = await run_scenario(
+                    adapter,
+                    model=model,
+                    base_url=base_url,
+                    api_key=api_key,
+                    scenario=scenario,
+                    max_turns=max_turns,
+                    timeout_seconds=timeout_seconds,
+                    temperature=temperature,
+                    seed=seed,
+                    reference_date=reference_date,
+                    reference_day=reference_day,
+                    error_rate=error_rate,
+                    extra_params=extra_params,
+                    context_pressure_messages=context_pressure_messages,
+                )
             results.append(result)
             if on_scenario_result:
                 await on_scenario_result(scenario, result, idx, total)
@@ -732,22 +874,25 @@ async def run_all_scenarios(
         async with sem:
             if on_scenario_start:
                 await on_scenario_start(scenario, idx, total)
-            result = await run_scenario(
-                adapter,
-                model=model,
-                base_url=base_url,
-                api_key=api_key,
-                scenario=scenario,
-                max_turns=max_turns,
-                timeout_seconds=timeout_seconds,
-                temperature=temperature,
-                seed=seed,
-                reference_date=reference_date,
-                reference_day=reference_day,
-                error_rate=error_rate,
-                extra_params=extra_params,
-                context_pressure_messages=context_pressure_messages,
-            )
+            if scenario.id in unsupported_ids:
+                result = _unsupported_tool_choice_result(scenario)
+            else:
+                result = await run_scenario(
+                    adapter,
+                    model=model,
+                    base_url=base_url,
+                    api_key=api_key,
+                    scenario=scenario,
+                    max_turns=max_turns,
+                    timeout_seconds=timeout_seconds,
+                    temperature=temperature,
+                    seed=seed,
+                    reference_date=reference_date,
+                    reference_day=reference_day,
+                    error_rate=error_rate,
+                    extra_params=extra_params,
+                    context_pressure_messages=context_pressure_messages,
+                )
             ordered_results[idx] = result
             if on_scenario_result:
                 async with progress_lock:

--- a/tests/test_backend_capability_attribution.py
+++ b/tests/test_backend_capability_attribution.py
@@ -1,0 +1,383 @@
+"""A stack's limits must not be recorded as a model's mistakes.
+
+Three places where the benchmark graded the serving environment and reported
+the result as model quality:
+
+- a 4xx that rejected the request before the model produced anything, which the
+  adapter degrades to a soft result whose ``content`` was then scored as an
+  answer;
+- ``tool_choice="required"``, which an endpoint may accept and silently drop,
+  leaving a scenario unable to tell an ignored instruction from one that was
+  never delivered;
+- TC-88's PASS tier, which needs a reasoning channel most OpenAI-compatible
+  endpoints do not expose.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tool_eval_bench.adapters.base import BackendAdapter, ChatCompletionResult, ProviderToolCall
+from tool_eval_bench.domain.scenarios import (
+    Category,
+    FailureKind,
+    ScenarioDefinition,
+    ScenarioEvaluation,
+    ScenarioState,
+    ScenarioStatus,
+    ToolCallRecord,
+)
+from tool_eval_bench.evals.scenarios import ALL_SCENARIOS_WITH_HARDMODE
+from tool_eval_bench.runner.orchestrator import (
+    run_all_scenarios,
+    run_scenario,
+    supports_tool_choice_required,
+)
+
+BY_ID = {s.id: s for s in ALL_SCENARIOS_WITH_HARDMODE}
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class ScriptedAdapter(BackendAdapter):
+    """Returns queued results, recording the tool_choice each request carried."""
+
+    def __init__(self, results: list[ChatCompletionResult]) -> None:
+        self._results = list(results)
+        self.tool_choices: list[Any] = []
+        self.calls = 0
+
+    async def chat_completion(self, **kwargs: Any) -> ChatCompletionResult:
+        self.tool_choices.append(kwargs.get("tool_choice"))
+        self.calls += 1
+        if not self._results:
+            return ChatCompletionResult(content="[exhausted]")
+        return self._results.pop(0)
+
+
+class RaisingAdapter(BackendAdapter):
+    """Every request explodes, standing in for an endpoint that refuses one."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+
+    async def chat_completion(self, **kwargs: Any) -> ChatCompletionResult:
+        raise self._exc
+
+
+def _tool_call(name: str = "probe_ping") -> ProviderToolCall:
+    return ProviderToolCall(id="tc_1", name=name, arguments_str=json.dumps({"value": "ok"}))
+
+
+def _trivial_scenario(
+    scenario_id: str = "TC-TEST",
+    *,
+    tool_choice_override: str | None = None,
+) -> ScenarioDefinition:
+    return ScenarioDefinition(
+        id=scenario_id,
+        title="Test",
+        category=Category.A,
+        user_message="hello",
+        description="test scenario",
+        handle_tool_call=lambda state, call: {"ok": True},
+        evaluate=lambda state: ScenarioEvaluation(ScenarioStatus.PASS, 2, "fine"),
+        difficulty=1,
+        tool_choice_override=tool_choice_override,
+    )
+
+
+async def _run(adapter: BackendAdapter, scenario: ScenarioDefinition) -> Any:
+    return await run_scenario(
+        adapter,
+        model="m",
+        base_url="http://x",
+        api_key=None,
+        scenario=scenario,
+        max_turns=4,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. A rejected request is the stack's failure, not the model's
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rejected_first_request_is_infrastructure_not_model_failure() -> None:
+    """A 400 before the model authored anything cannot be the model's fault."""
+    adapter = ScriptedAdapter(
+        [
+            ChatCompletionResult(
+                content="[server error 400] tool_choice 'required' is not supported",
+                transport_error_status=400,
+            )
+        ]
+    )
+    result = await _run(adapter, _trivial_scenario())
+
+    assert result.failure_kind == FailureKind.SERVER_ERROR
+    assert result.is_infrastructure_failure
+    assert "400" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_rejected_request_never_reaches_the_evaluator() -> None:
+    """The error string must not be graded as though the model wrote it."""
+    seen: list[str] = []
+
+    def _evaluate(state: ScenarioState) -> ScenarioEvaluation:
+        seen.append(state.final_answer)
+        return ScenarioEvaluation(ScenarioStatus.PASS, 2, "graded")
+
+    scenario = _trivial_scenario()
+    scenario.evaluate = _evaluate
+    adapter = ScriptedAdapter(
+        [ChatCompletionResult(content="[server error 422] bad", transport_error_status=422)]
+    )
+
+    result = await _run(adapter, scenario)
+
+    assert seen == [], "the evaluator ran on a turn that produced no model output"
+    assert result.status == ScenarioStatus.FAIL
+
+
+@pytest.mark.asyncio
+async def test_rejection_after_the_model_authored_a_tool_call_stays_a_model_failure() -> None:
+    """A strict server refusing model-authored arguments is still the model.
+
+    This is the case the adapter's soft result was built for, so it has to keep
+    working: the 4xx is caused by what the model put in the history.
+    """
+    adapter = ScriptedAdapter(
+        [
+            ChatCompletionResult(content="", tool_calls=[_tool_call("anything")]),
+            ChatCompletionResult(content="[server error 400] bad args", transport_error_status=400),
+        ]
+    )
+    scenario = _trivial_scenario()
+    scenario.evaluate = lambda state: ScenarioEvaluation(ScenarioStatus.FAIL, 0, "model failed")
+
+    result = await _run(adapter, scenario)
+
+    assert result.failure_kind != FailureKind.SERVER_ERROR
+    assert not result.is_infrastructure_failure
+
+
+@pytest.mark.asyncio
+async def test_infrastructure_rejection_drops_out_of_the_score() -> None:
+    """An excluded scenario leaves the denominator, it does not score zero."""
+    good = _trivial_scenario("TC-GOOD")
+    bad = _trivial_scenario("TC-BAD")
+    adapter = ScriptedAdapter(
+        [
+            ChatCompletionResult(content="done"),
+            ChatCompletionResult(content="[server error 400] no", transport_error_status=400),
+        ]
+    )
+
+    summary = await run_all_scenarios(
+        adapter, model="m", base_url="http://x", scenarios=[good, bad]
+    )
+
+    assert summary.excluded_scenarios == ["TC-BAD"]
+    assert summary.max_points == 2, "the excluded scenario must leave the denominator"
+    assert summary.final_score == 100
+    assert summary.completion_rate == 50.0
+
+
+# ---------------------------------------------------------------------------
+# 2. tool_choice="required" is probed, not assumed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_support_when_a_tool_call_comes_back() -> None:
+    adapter = ScriptedAdapter([ChatCompletionResult(content="", tool_calls=[_tool_call()])])
+
+    assert await supports_tool_choice_required(
+        adapter, model="m", base_url="http://x", api_key=None, timeout_seconds=5
+    )
+    assert adapter.tool_choices == ["required"]
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_no_support_when_the_parameter_is_silently_dropped() -> None:
+    """The failure mode nothing else can detect: accepted, then ignored."""
+    adapter = ScriptedAdapter([ChatCompletionResult(content="56", tool_calls=[])])
+
+    assert not await supports_tool_choice_required(
+        adapter, model="m", base_url="http://x", api_key=None, timeout_seconds=5
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_reports_no_support_when_the_endpoint_rejects_the_parameter() -> None:
+    adapter = ScriptedAdapter(
+        [ChatCompletionResult(content="[server error 400] no", transport_error_status=400)]
+    )
+
+    assert not await supports_tool_choice_required(
+        adapter, model="m", base_url="http://x", api_key=None, timeout_seconds=5
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_treats_an_exception_as_unsupported() -> None:
+    adapter = RaisingAdapter(RuntimeError("connection reset"))
+
+    assert not await supports_tool_choice_required(
+        adapter, model="m", base_url="http://x", api_key=None, timeout_seconds=5
+    )
+
+
+@pytest.mark.asyncio
+async def test_forced_tool_choice_scenario_is_excluded_on_an_endpoint_that_ignores_it() -> None:
+    """TC-45 scored zero for answering 7x8 correctly. Now it is excluded."""
+    forced = _trivial_scenario("TC-45", tool_choice_override="required")
+    adapter = ScriptedAdapter(
+        [
+            ChatCompletionResult(content="56"),  # the probe, no tool call
+        ]
+    )
+
+    summary = await run_all_scenarios(adapter, model="m", base_url="http://x", scenarios=[forced])
+
+    assert summary.excluded_scenarios == ["TC-45"]
+    assert summary.max_points == 0
+    assert summary.completion_rate == 0.0
+    assert adapter.calls == 1, "the excluded scenario must not be run"
+
+
+@pytest.mark.asyncio
+async def test_forced_tool_choice_scenario_runs_when_the_endpoint_enforces_it() -> None:
+    forced = _trivial_scenario("TC-45", tool_choice_override="required")
+    adapter = ScriptedAdapter(
+        [
+            ChatCompletionResult(content="", tool_calls=[_tool_call()]),  # probe
+            ChatCompletionResult(content="56"),  # the scenario itself
+        ]
+    )
+
+    summary = await run_all_scenarios(adapter, model="m", base_url="http://x", scenarios=[forced])
+
+    assert summary.excluded_scenarios == []
+    assert summary.max_points == 2
+    assert adapter.tool_choices[0] == "required"
+
+
+@pytest.mark.asyncio
+async def test_probe_is_skipped_when_no_scenario_forces_a_tool_call() -> None:
+    """An ordinary run must not pay for a capability it never uses."""
+    adapter = ScriptedAdapter([ChatCompletionResult(content="done")])
+
+    await run_all_scenarios(
+        adapter, model="m", base_url="http://x", scenarios=[_trivial_scenario()]
+    )
+
+    assert adapter.calls == 1
+    assert "required" not in adapter.tool_choices
+
+
+@pytest.mark.asyncio
+async def test_exclusion_also_applies_on_the_parallel_path() -> None:
+    forced = _trivial_scenario("TC-45", tool_choice_override="required")
+    other = _trivial_scenario("TC-OTHER")
+    adapter = ScriptedAdapter(
+        [
+            ChatCompletionResult(content="56"),  # probe: unsupported
+            ChatCompletionResult(content="done"),
+        ]
+    )
+
+    summary = await run_all_scenarios(
+        adapter, model="m", base_url="http://x", scenarios=[forced, other], concurrency=2
+    )
+
+    assert summary.excluded_scenarios == ["TC-45"]
+    assert summary.max_points == 2
+
+
+def test_only_tc45_forces_a_tool_call() -> None:
+    """If another scenario adopts ``required`` it inherits the probe by design."""
+    forced = [s.id for s in ALL_SCENARIOS_WITH_HARDMODE if s.tool_choice_override == "required"]
+    assert forced == ["TC-45"]
+
+
+# ---------------------------------------------------------------------------
+# 3. TC-88's PASS tier depends on a channel the stack may not have
+# ---------------------------------------------------------------------------
+
+# Three distinct 20-digit numbers with digit sums 73, 91 and 109, where each
+# value's last six digits reverse the previous value's first six.
+_TC88_VALID = (
+    "11111199999994000000",
+    "99999999940000111111",
+    "99999910000000999999",
+)
+
+
+def _tc88_state(reasoning: list[str]) -> ScenarioState:
+    state = ScenarioState()
+    state.assistant_messages = list(_TC88_VALID)
+    state.final_answer = _TC88_VALID[-1]
+    state.assistant_reasoning = reasoning
+    return state
+
+
+def test_tc88_fixture_actually_satisfies_the_scenario_constraints() -> None:
+    for number, expected in zip(_TC88_VALID, (73, 91, 109), strict=True):
+        assert len(number) == 20 and number[0] != "0"
+        assert sum(int(digit) for digit in number) == expected
+    assert _TC88_VALID[1][-6:] == _TC88_VALID[0][:6][::-1]
+    assert _TC88_VALID[2][-6:] == _TC88_VALID[1][:6][::-1]
+
+
+def test_tc88_passes_when_the_provider_exposes_the_plan() -> None:
+    plan = f"Plan: {' '.join(_TC88_VALID)}. Sums and reversals verified."
+    result = BY_ID["TC-88"].evaluate(_tc88_state([plan, "", ""]))
+
+    assert result.status == ScenarioStatus.PASS
+
+
+def test_tc88_names_the_missing_channel_instead_of_blaming_the_model() -> None:
+    """Same three values, no reasoning channel: PARTIAL, and the report says why."""
+    result = BY_ID["TC-88"].evaluate(_tc88_state(["", "", ""]))
+
+    assert result.status == ScenarioStatus.PARTIAL
+    assert "no reasoning channel" in result.summary
+    assert "unreachable" in result.summary
+
+
+def test_tc88_still_reports_a_missing_plan_when_the_channel_exists() -> None:
+    """A provider that does expose reasoning is held to the original bar."""
+    result = BY_ID["TC-88"].evaluate(_tc88_state(["thinking about it", "", ""]))
+
+    assert result.status == ScenarioStatus.PARTIAL
+    assert "no proof" in result.summary
+
+
+def test_tc88_constraint_violations_outrank_the_channel_message() -> None:
+    """A wrong answer fails on its own terms, whatever the provider exposed."""
+    state = _tc88_state(["", "", ""])
+    state.assistant_messages = ["1" * 20, "2" * 20, "3" * 20]
+    state.final_answer = "3" * 20
+    result = BY_ID["TC-88"].evaluate(state)
+
+    assert result.status == ScenarioStatus.FAIL
+
+
+def test_tc88_tool_use_still_fails_regardless_of_reasoning() -> None:
+    state = _tc88_state(["", "", ""])
+    state.tool_calls.append(
+        ToolCallRecord(id="c", name="web_search", raw_arguments="{}", arguments={}, turn=1)
+    )
+    result = BY_ID["TC-88"].evaluate(state)
+
+    assert result.status == ScenarioStatus.FAIL


### PR DESCRIPTION
Follow-up to #148.

## Problem

Three places graded the serving environment and reported the result as model
quality. The first is general, the other two are the scenarios that surfaced it.

**A rejected request was graded as an answer.** When an endpoint returns 4xx,
`adapters/openai_compat.py` and `adapters/gemini.py` deliberately degrade to a
soft result rather than raising, so a scenario can record the failure and move
on. But that result's content is the string `[server error 400] ...`, and it was
flowing into `state.final_answer` and being scored as though the model wrote it.
`_classify_runtime_error` never saw it, so a request the endpoint refused could
never be labelled infrastructure. Only 5xx and 429 propagate.

**`tool_choice="required"` can be accepted and silently dropped.** A scenario
that depends on it then cannot tell a model that ignored the constraint from one
that never received it. TC-45 asks "What is 7 times 8?" with `required` set, so
on such a stack the model answers 56 and scores 0 for instruction-following.
That is the same restraint TC-11 and TC-39 award two points for. The only thing
separating a 2 from a 0 is whether the stack forwarded a parameter.

**TC-88's PASS tier needs a channel most endpoints do not have.** It gates on
`reasoning_content` in the first streamed turn. Same three valid values, one
point apart:

```
provider exposes reasoning : PASS    points=2
provider exposes nothing   : PARTIAL points=1
   "Returned three valid values, but the provider exposed no proof that all were planned first."
```

## What changed

`ChatCompletionResult` carries `transport_error_status`, set at all three
degradation sites. The runner ends the scenario as `SERVER_ERROR` when the
rejection arrives before the model has authored a tool call, which drops it from
the score's numerator and denominator and into `completion_rate`, the mechanism
the README already describes for timeouts. The guard matters: once the model has
put tool arguments into the history, a strict server refusing them is the model's
doing. That is the case the soft result was built for, and it keeps its
behaviour.

`supports_tool_choice_required` sends one forced call against a trivial tool and
reports whether a tool call comes back. It runs once per run, and only when a
scenario that forces a tool call was actually selected, so an ordinary run pays
nothing and `--dry-run` never probes. When the endpoint does not enforce it, the
affected scenarios are excluded rather than run and failed. The check keys on
`tool_choice_override == "required"` rather than on the ID, so a future scenario
inherits it.

TC-88 now names the missing channel instead of reporting an unreachable ceiling
as the model failing to prove its plan. The constraint work stays verifiable from
the visible transcript, so PARTIAL was always reachable on merit.

TC-44 was reviewed and deliberately left alone. Its prompt says "Answer from your
knowledge", so it is answerable whether or not the server honours
`tool_choice="none"`, and failing it requires a model that reaches for a tool
anyway. That is a real model defect.

## Verification

`tests/test_backend_capability_attribution.py` adds 19 tests. Each of the three
fixes was mutation-checked by disabling it and confirming the tests fail:

```
transport-error early return disabled : 3 failed, 16 passed
exclusion wiring disabled             : 2 failed, 17 passed
TC-88 channel branch disabled         : 1 failed, 18 passed
```

The coverage includes the case that must not change: a 4xx arriving after the
model authored a tool call still scores as a model failure.

```
ruff check .           All checks passed!
ruff format --check .  338 files already formatted
mypy                   Success: no issues found in 222 source files
pytest (seed 104729)   3878 passed, 1 deselected
```

## Effect on scores

On an endpoint that enforces `tool_choice` and returns no spurious 4xx, nothing
moves. On one that does not, TC-45 leaves the denominator instead of scoring 0,
which raises the composite and lowers `completion_rate`, and TC-88 keeps its
point but explains itself. Category H is 5 scenarios, so TC-45 was 20% of it.

Written with AI assistance; reviewed before opening.
