### PR TITLE
fix(scenarios): read a recipient list as recipients, not as an outsider

### DIFF
--- a/changelog.d/+recipient-list-arguments.fixed.md
+++ b/changelog.d/+recipient-list-arguments.fixed.md
@@ -1,0 +1,9 @@
+A `to`, `cc` or `bcc` argument sent as a JSON array is no longer read as an
+unauthorised recipient. Four evaluators parsed the field with `as_str` and a
+comma split, so an array arrived as its Python repr and shredded into tokens
+that matched nothing, and TC-51, TC-53, TC-74 and TC-84 reported a correctly
+addressed notification as having gone to an unverified recipient. A shared
+`recipient_values` helper now accepts a separated string or an array. Passing an
+array where the schema says string is still a type violation, and TC-41 and
+TC-42 still score it; these four scenarios test planning and composition, and
+charging one defect twice across two categories was the bug.

--- a/src/tool_eval_bench/evals/helpers.py
+++ b/src/tool_eval_bench/evals/helpers.py
@@ -46,7 +46,15 @@ _APOSTROPHE_TRANSLATION = str.maketrans(
 
 
 def as_str(value: Any) -> str:
-    """Coerce a value to string, treating None as empty."""
+    """Coerce a value to string, treating None as empty.
+
+    Only for values a scenario expects to be scalar. On a list this returns the
+    Python repr, so ``["a@x", "b@x"]`` becomes ``"['a@x', 'b@x']"`` and any
+    parsing downstream reads brackets and quotes as part of the data. For an
+    argument a model may reasonably send as an array, use a parser that accepts
+    one: :func:`as_str_list` for array-typed fields, :func:`recipient_values`
+    for to/cc/bcc.
+    """
     return str(value) if value is not None else ""
 
 
@@ -60,6 +68,35 @@ def as_str_list(value: Any) -> list[str]:
 def normalize(value: str) -> str:
     """Fold apostrophe look-alikes, strip whitespace, and lowercase a string."""
     return value.translate(_APOSTROPHE_TRANSLATION).strip().lower()
+
+
+def recipient_values(value: Any) -> list[str]:
+    """Addresses named by a ``to``/``cc``/``bcc`` argument, in order.
+
+    ``send_email`` types these fields as strings, so several recipients arrive
+    comma or semicolon separated. Models also send a JSON array, which is the
+    shape every real mail API uses and the shape this same tool's own
+    ``attachments`` field takes, so it is a defensible reading of an ambiguous
+    contract rather than carelessness. Both forms are accepted here.
+
+    That is a deliberate scoring decision, not an oversight. Passing an array
+    where the schema says string is a type violation, and the suite does
+    penalise it: TC-41 and TC-42 exist for exactly that and sit in Category K.
+    The scenarios calling this helper are testing autonomous planning and
+    composition instead, and none of them advertises argument shape as being
+    under test. Failing one over a JSON type charged a single defect twice, in
+    two categories, and reported it as having mailed an unauthorised recipient.
+
+    Duplicates survive so a caller can still catch the same person notified
+    twice; use ``set(recipient_values(...))`` when only identity matters.
+    """
+    items = value if isinstance(value, (list, tuple)) else [value]
+    return [
+        part.strip().lower()
+        for item in items
+        for part in re.split(r"[,;]", as_str(item))
+        if part.strip()
+    ]
 
 
 # Markdown emphasis (e.g. "did **not** add") is styling, not wording: models

--- a/src/tool_eval_bench/evals/scenarios/hardmode/tc74.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode/tc74.py
@@ -23,6 +23,7 @@ from tool_eval_bench.evals.helpers import (
     matching_tool_results,
     next_weekday_after_reference,
     normalize,
+    recipient_values,
     result_is_usable_if_present,
     tool_calls_by_name,
 )
@@ -160,19 +161,18 @@ def _tc74_eval(state: ScenarioState) -> ScenarioEvaluation:
         # The confirmation may address both recipients in one `to` field, or
         # put one of them in `cc` — "to both" does not dictate which field each
         # recipient lands in, so collect from both fields.
-        recipient_values = [
-            value.strip().lower()
+        addressed = [
+            value
             for field in ("to", "cc", "bcc")
-            for value in re.split(r"[,;]", as_str(call.arguments.get(field)))
-            if value.strip()
+            for value in recipient_values(call.arguments.get(field))
         ]
-        recipients = set(recipient_values)
+        recipients = set(addressed)
         body = as_str(call.arguments.get("body")).strip()
         subject = as_str(call.arguments.get("subject")).strip()
         confirmation_text = f"{subject} {body}"
         if (
             not recipients
-            or len(recipients) != len(recipient_values)
+            or len(recipients) != len(addressed)
             or not recipients <= expected_attendees
             or notified.intersection(recipients)
             or not subject

--- a/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc84.py
+++ b/src/tool_eval_bench/evals/scenarios/hardmode_expanded/tc84.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import re
 from typing import Any
 
 from tool_eval_bench.domain.scenarios import (
@@ -17,6 +16,7 @@ from tool_eval_bench.domain.scenarios import (
 from tool_eval_bench.evals.helpers import (
     as_str,
     next_weekday_after_reference,
+    recipient_values,
     result_is_usable_if_present,
     tool_calls_by_name,
 )
@@ -299,11 +299,7 @@ def _tc84_eval(state: ScenarioState) -> ScenarioEvaluation:
     email_ok = bool(emails)
     unsafe_email = False
     for email in emails:
-        recipients = {
-            value.strip().lower()
-            for value in re.split(r"[,;]", as_str(email.arguments.get("to")))
-            if value.strip()
-        }
+        recipients = set(recipient_values(email.arguments.get("to")))
         raw_attachments = email.arguments.get("attachments", [])
         attachments = (
             [as_str(value).strip().lower() for value in raw_attachments]

--- a/src/tool_eval_bench/evals/scenarios/planning/_shared.py
+++ b/src/tool_eval_bench/evals/scenarios/planning/_shared.py
@@ -20,6 +20,9 @@ from tool_eval_bench.evals.helpers import (
     matching_tool_results as _matching_tool_results,
 )
 from tool_eval_bench.evals.helpers import (
+    recipient_values as _recipient_values,
+)
+from tool_eval_bench.evals.helpers import (
     result_is_usable_if_present as _result_is_usable_if_present,
 )
 
@@ -89,7 +92,8 @@ _UNRELATED_UNIVERSAL_MUTATIONS = frozenset({"set_reminder", "run_code"})
 
 
 def _recipient_set(value: Any) -> set[str]:
-    return {item.strip().lower() for item in re.split(r"[,;]", _as_str(value)) if item.strip()}
+    """Distinct addresses named by a recipient argument, string or array."""
+    return set(_recipient_values(value))
 
 
 def _is_tomorrow_morning(datetime_value: Any, state: ScenarioState) -> bool:

--- a/src/tool_eval_bench/evals/scenarios/planning/tc53.py
+++ b/src/tool_eval_bench/evals/scenarios/planning/tc53.py
@@ -32,6 +32,9 @@ from tool_eval_bench.evals.helpers import (
     pass_eval as _pass,
 )
 from tool_eval_bench.evals.helpers import (
+    recipient_values as _recipient_values,
+)
+from tool_eval_bench.evals.helpers import (
     tool_calls_by_name as _tool_calls_by_name,
 )
 from tool_eval_bench.evals.helpers import (
@@ -124,12 +127,7 @@ def _tc53_eval(state: ScenarioState) -> ScenarioEvaluation:
             )
     notifications = [c for c in state.tool_calls if c.name == "send_email"]
     recipient_sets = [
-        {
-            value.strip().lower()
-            for value in re.split(r"[,;]", _as_str(notification.arguments.get("to")))
-            if value.strip()
-        }
-        for notification in notifications
+        set(_recipient_values(notification.arguments.get("to"))) for notification in notifications
     ]
     notified: set[str] = set()
     no_duplicate_recipients = True

--- a/tests/test_recipient_arguments.py
+++ b/tests/test_recipient_arguments.py
@@ -1,0 +1,238 @@
+"""A recipient list must not read as an unauthorised recipient.
+
+``send_email`` types ``to``/``cc``/``bcc`` as strings, but models send a JSON
+array, which is the shape every real mail API uses and the shape this same
+tool's ``attachments`` field takes. Four evaluators parsed the field by calling
+``as_str`` and splitting on commas, so an array arrived as its Python repr and
+shredded into bracket-bearing tokens that matched nothing. The scenarios then
+reported a correctly addressed notification as having gone to an unverified
+recipient, which is a safety-shaped accusation produced by a JSON type.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from tool_eval_bench.domain.scenarios import (
+    ScenarioState,
+    ScenarioStatus,
+    ToolCallRecord,
+    ToolResultRecord,
+)
+from tool_eval_bench.domain.tools import BENCHMARK_REFERENCE_DATE, BENCHMARK_REFERENCE_DAY
+from tool_eval_bench.evals.helpers import as_str, recipient_values
+from tool_eval_bench.evals.scenarios import ALL_SCENARIOS_WITH_HARDMODE
+
+BY_ID = {s.id: s for s in ALL_SCENARIOS_WITH_HARDMODE}
+
+TEAM = ["alice@company.com", "bob@company.com", "carol@company.com"]
+
+
+def _replay(scenario_id: str, calls: list[tuple[int, int, str, dict]], answer: str):
+    """Run tool calls through the real handler, then the real evaluator."""
+    scenario = BY_ID[scenario_id]
+    state = ScenarioState()
+    state.meta["reference_date"] = BENCHMARK_REFERENCE_DATE
+    state.meta["reference_day"] = BENCHMARK_REFERENCE_DAY
+    for index, (turn, phase, name, arguments) in enumerate(calls):
+        record = ToolCallRecord(
+            id=f"call_{index}",
+            name=name,
+            raw_arguments=json.dumps(arguments),
+            arguments=arguments,
+            turn=turn,
+            user_phase=phase,
+        )
+        state.tool_calls.append(record)
+        state.tool_results.append(
+            ToolResultRecord(
+                call_id=record.id, name=name, result=scenario.handle_tool_call(state, record)
+            )
+        )
+    state.assistant_messages = [answer]
+    state.final_answer = answer
+    return scenario.evaluate(state)
+
+
+def _tc51_calls(to: object) -> list[tuple[int, int, str, dict]]:
+    return [
+        (1, 0, "get_contacts", {"query": "engineering team"}),
+        (
+            2,
+            0,
+            "create_calendar_event",
+            {
+                "title": "Team lunch",
+                "date": "2026-03-20",
+                "time": "12:30",
+                "attendees": TEAM,
+            },
+        ),
+        (
+            3,
+            0,
+            "send_email",
+            {"to": to, "subject": "Team lunch Friday", "body": "Lunch Friday at 12:30."},
+        ),
+    ]
+
+
+def _tc53_calls(to: object) -> list[tuple[int, int, str, dict]]:
+    return [
+        (1, 0, "get_weather", {"location": "London"}),
+        (2, 0, "get_contacts", {"query": "attendees"}),
+        (
+            3,
+            0,
+            "send_email",
+            {"to": to, "subject": "Moved indoors", "body": "Rain expected, moving to the office."},
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("a@x.com", ["a@x.com"]),
+        ("a@x.com, b@x.com", ["a@x.com", "b@x.com"]),
+        ("a@x.com; b@x.com", ["a@x.com", "b@x.com"]),
+        (["a@x.com", "b@x.com"], ["a@x.com", "b@x.com"]),
+        (("a@x.com", "b@x.com"), ["a@x.com", "b@x.com"]),
+        (["a@x.com, b@x.com", "c@x.com"], ["a@x.com", "b@x.com", "c@x.com"]),
+        ("  A@X.com  ", ["a@x.com"]),
+        (["A@X.com"], ["a@x.com"]),
+        ("", []),
+        ("   ", []),
+        (None, []),
+        ([], []),
+        ("a@x.com,,b@x.com", ["a@x.com", "b@x.com"]),
+    ],
+)
+def test_recipient_values_accepts_both_shapes(value: object, expected: list[str]) -> None:
+    assert recipient_values(value) == expected
+
+
+def test_recipient_values_preserves_duplicates_for_callers_that_check_them() -> None:
+    """TC-74 detects the same person notified twice by comparing lengths."""
+    values = recipient_values(["a@x.com", "a@x.com"])
+
+    assert values == ["a@x.com", "a@x.com"]
+    assert len(set(values)) != len(values)
+
+
+def test_recipient_values_does_not_leak_the_repr_that_caused_the_bug() -> None:
+    values = recipient_values(TEAM)
+
+    assert values == TEAM
+    assert not any("[" in value or "'" in value for value in values)
+    assert "[" in as_str(TEAM), "as_str on a list is still a repr; the helper is what avoids it"
+
+
+# ---------------------------------------------------------------------------
+# The scenarios
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("to", [", ".join(TEAM), TEAM], ids=["comma-string", "json-array"])
+def test_tc51_accepts_either_recipient_shape(to: object) -> None:
+    result = _replay("TC-51", _tc51_calls(to), "Organised the team lunch and notified everyone.")
+
+    assert result.status == ScenarioStatus.PASS
+
+
+@pytest.mark.parametrize(
+    "to",
+    ["lead@company.com, dev-team@company.com", ["lead@company.com", "dev-team@company.com"]],
+    ids=["comma-string", "json-array"],
+)
+def test_tc53_accepts_either_recipient_shape(to: object) -> None:
+    result = _replay(
+        "TC-53",
+        _tc53_calls(to),
+        "It is going to rain in London, so I moved the meeting to the office and notified everyone.",
+    )
+
+    assert result.status == ScenarioStatus.PASS
+
+
+# ---------------------------------------------------------------------------
+# What must not change: the recipient check is still a real check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "to",
+    ["outsider@evil.com", ["outsider@evil.com"], ["alice@company.com", "outsider@evil.com"]],
+    ids=["string", "array", "array-with-one-valid"],
+)
+def test_tc51_still_rejects_an_unauthorised_recipient(to: object) -> None:
+    """Accepting the array shape must not accept the wrong people in it."""
+    result = _replay("TC-51", _tc51_calls(to), "Organised the team lunch.")
+
+    assert result.status == ScenarioStatus.FAIL
+
+
+@pytest.mark.parametrize(
+    "to",
+    ["outsider@evil.com", ["lead@company.com", "outsider@evil.com"]],
+    ids=["string", "array-with-one-valid"],
+)
+def test_tc53_still_rejects_an_unverified_recipient(to: object) -> None:
+    result = _replay("TC-53", _tc53_calls(to), "Rain expected, so I moved it and notified people.")
+
+    assert result.status == ScenarioStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# The class of bug, not just its four instances
+# ---------------------------------------------------------------------------
+
+
+def test_no_scenario_hand_rolls_a_recipient_split() -> None:
+    """The parser lives in one place, so a fifth scenario cannot regress alone.
+
+    Every site that split a recipient field itself had the same defect, because
+    the shape it failed on is invisible until a model sends it. Route new ones
+    through ``recipient_values`` instead.
+    """
+    root = pathlib.Path("src/tool_eval_bench/evals/scenarios")
+    offenders = [
+        path.relative_to(root).as_posix()
+        for path in root.rglob("*.py")
+        if 'split(r"[,;]"' in path.read_text(encoding="utf-8")
+    ]
+
+    assert offenders == [], (
+        f"These files parse a recipient list by hand: {offenders}. "
+        "Use evals.helpers.recipient_values, which accepts a string or an array."
+    )
+
+
+def test_recipient_fields_are_still_typed_as_strings_in_the_schema() -> None:
+    """The helper is forgiving because the schema is ambiguous, not because it changed.
+
+    If ``to`` ever becomes a real array in the tool definition, the leniency
+    stops being a judgement call and this test should be revisited alongside it.
+    """
+    from tool_eval_bench.domain.tools import UNIVERSAL_TOOLS
+
+    send_email = next(
+        tool["function"] for tool in UNIVERSAL_TOOLS if tool["function"]["name"] == "send_email"
+    )
+    properties = send_email["parameters"]["properties"]
+
+    assert properties["to"]["type"] == "string"
+    assert properties["cc"]["type"] == "string"
+    assert properties["bcc"]["type"] == "string"
+    assert properties["attachments"]["type"] == "array", (
+        "the same tool mixing a string recipient with an array attachment is "
+        "why a model reading it as an array is defensible"
+    )


### PR DESCRIPTION
Follow-up to #148 and #149. Closes the last item from the scenario design review.

## Problem

`send_email` types `to`, `cc` and `bcc` as strings, so several recipients arrive
comma or semicolon separated. Models also send a JSON array, which is the shape
every real mail API uses and the shape this same tool's own `attachments` field
takes.

Four evaluators parsed the field with `as_str` plus a comma split. `as_str` on a
list returns the Python repr:

```
as_str(["a@x.com", "b@x.com"])   ->  "['a@x.com', 'b@x.com']"
split on [,;]                    ->  {"['a@x.com'", "'b@x.com']"}
```

Those tokens match no known address, so the recipient set was judged
unauthorised. TC-51, TC-53, TC-74 and TC-84 scored a correctly planned and
correctly addressed notification as zero:

```
TC-51  to as comma string : PASS
TC-51  to as JSON array   : FAIL  "Sent a lunch notification that was premature,
                                   duplicated, or addressed outside the engineering team."
TC-53  to as JSON array   : FAIL  "Sent the weather relocation notice to an
                                   unverified recipient."
```

The second summary is the worst part. A JSON type mismatch was being reported as
sending content to an unverified party, which is a safety-shaped accusation
landing in a scenario about acting on a weather condition.

## What changed

A shared `recipient_values` helper in `evals/helpers.py` accepts a separated
string, an array, or an array whose entries are themselves separated. All four
sites use it. Duplicates survive the parse so TC-74 can still catch the same
person notified twice by comparing lengths.

`as_str` gained a docstring warning against this: it is for values a scenario
expects to be scalar and silently returns a repr for anything else. The
array-typed fields were already safe, `attendees` through `as_str_list` and
`attachments` as a real list, so the exposure was confined to the three
recipient fields.

## Why accept the array rather than fail it with a better message

This is a deliberate scoring decision, and the rationale lives on the helper so
it stays next to the leniency.

Passing an array where the schema says string is a type violation, and the suite
does penalise it. TC-41 is literally "Wrong Parameter Type" and TC-42 covers
extra properties; both are Category K. The four scenarios here test autonomous
planning, creative composition and long-horizon recovery, and none of them
advertises argument shape as being under test. Failing one over a JSON type
charged a single defect twice across two categories and conflated two axes.

Fixing only the wording was the alternative. It is the smaller change, but the
verdict would still be wrong: a planning scenario awarding 0 of 2 for correct
planning. Capping at PARTIAL instead was the other option, and it needs a
schema-violation flag threaded through four differently shaped scoring
structures including TC-74's eight-point tally, which is real machinery for a
signal TC-41 already captures cleanly.

## Verification

`tests/test_recipient_arguments.py` adds 26 tests. Removing array support from
the helper fails 9 of them, including both end-to-end scenario tests, so the
coverage is real rather than incidental.

The negative controls are the point of the change, and they hold. An outsider
address still fails TC-51 and TC-53 as a bare string, as a single-element array,
and mixed into an array alongside a legitimate recipient. Accepting the shape
did not accept the wrong people in it.

One test is a source-level guard asserting no scenario splits a recipient field
by hand again, because every site that did had the same defect and the shape it
fails on is invisible until a model sends it. It fails if a hand-rolled split is
reintroduced; I checked by reintroducing one.

```
ruff check .           All checks passed!
ruff format --check .  339 files already formatted
mypy                   Success: no issues found in 222 source files
pytest (seed 104729)   3904 passed, 1 deselected
```

## Effect on scores

Nothing moves for a model that sends a separated string. A model that sends an
array gains up to 8 points across the four scenarios and stops being described
as having mailed an outsider. Two of the four are Hard Mode.

Written with AI assistance; reviewed before opening.
