### PR TITLE
fix: correct llama.cpp errors and metadata (#153, #154)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,19 @@ runs:
 - **`completion_rate`.** Scenarios that measured the serving environment rather
   than the model are dropped from the score instead of counted as zero:
   timeouts, connection errors, a request the endpoint rejected before the model
-  produced anything, and scenarios needing a capability the endpoint does not
-  have. TC-45 forces a tool call, so it is excluded on an endpoint that does not
-  enforce `tool_choice="required"`, which costs one extra request per run to
-  detect. A run graded on 60 of 69 scenarios is not comparable to one graded on
-  all 69.
+  produced anything, known backend initialization failures such as llama.cpp
+  sampler grammar errors, and scenarios needing a capability the endpoint does
+  not have. TC-45 forces a tool call, so it is excluded on an endpoint that does
+  not enforce `tool_choice="required"`, which costs one extra request per run
+  to detect. A run graded on 60 of 69 scenarios is not comparable to one graded
+  on all 69.
 - **Safety warnings.** If Category K scores below 50%, the rating is capped at
   three stars no matter how strong the composite is.
 - **`config_fingerprint`.** Runs group on the leaderboard only when their
-  configuration matches. Two scores from different flag sets are not a
-  comparison.
+  configuration and discovered deployment metadata match. The deployment
+  metadata includes the engine version, quantization, GPU count, server slot
+  count, and speculative decoding mode. Two scores from different cohorts are
+  not a comparison.
 
 To read past runs back:
 

--- a/changelog.d/153.fixed.md
+++ b/changelog.d/153.fixed.md
@@ -1,0 +1,3 @@
+**llama.cpp sampler failures.** HTTP 4xx responses that report a sampler
+initialization failure are now excluded as serving infrastructure errors, even
+when the model completed an earlier tool-call turn.

--- a/changelog.d/154.fixed.md
+++ b/changelog.d/154.fixed.md
@@ -1,0 +1,2 @@
+**llama.cpp server metadata.** Reports now label `/props.total_slots` as Server
+Slots and no longer report that concurrency setting as the physical GPU count.

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,12 @@ from tool_eval_bench import run_benchmark  # same function
 | `report_path` | str/None | Path to Markdown report (when `persist=True`) |
 | `weighted_score` | int/None | 0–100 difficulty-weighted score (when `weight_by_difficulty=True`) |
 
+The `metadata` dictionary contains the best-effort backend facts used in
+reports and comparison fingerprints. `slot_count` records the llama.cpp server
+slot count from `/props.total_slots`. It is request concurrency capacity, not a
+physical GPU count. `gpu_count` remains absent unless the backend exposes a
+trustworthy hardware count.
+
 The top-level `final_score`, `rating`, `safety_warnings`, `deployability`,
 and `total_scenarios` fields are promoted from the nested `scores` dict for
 easy consumption by leaderboard pipelines and external integrators.

--- a/src/tool_eval_bench/adapters/openai_compat.py
+++ b/src/tool_eval_bench/adapters/openai_compat.py
@@ -38,6 +38,12 @@ from tool_eval_bench.utils.urls import redact_url as _redact_url
 
 logger = logging.getLogger(__name__)
 
+
+def _is_pre_inference_backend_error(body: str) -> bool:
+    """Return whether a 4xx body names a known failure before inference."""
+    return "failed to initialize samplers" in body.lower()
+
+
 # Re-exported for callers and tests that reach for the retry policy through the
 # adapter module it used to live in.
 __all__ = [
@@ -278,6 +284,9 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
                 raw_response={},
                 elapsed_ms=elapsed_ms,
                 transport_error_status=exc.response.status_code,
+                transport_error_is_infrastructure=_is_pre_inference_backend_error(
+                    exc.response.text
+                ),
             )
         try:
             data = response.json()
@@ -346,6 +355,9 @@ class OpenAICompatibleAdapter(RetryingHTTPAdapter, BackendAdapter):
                     raw_response={},
                     elapsed_ms=elapsed_ms,
                     transport_error_status=exc.response.status_code,
+                    transport_error_is_infrastructure=_is_pre_inference_backend_error(
+                        full_body_text
+                    ),
                 )
 
             # Some OpenAI-compatible endpoints ignore ``stream=true`` and

--- a/src/tool_eval_bench/application/run_config.py
+++ b/src/tool_eval_bench/application/run_config.py
@@ -29,6 +29,7 @@ COMPARISON_METADATA_KEYS = (
     "engine_version",
     "quantization",
     "gpu_count",
+    "slot_count",
     "spec_decoding",
 )
 

--- a/src/tool_eval_bench/cli/history.py
+++ b/src/tool_eval_bench/cli/history.py
@@ -91,6 +91,10 @@ def _extract_context_panel(run: dict) -> list[str]:
     if quant:
         lines.append(f"  [dim]Quantization:[/] {quant}")
 
+    slot_count = metadata.get("slot_count")
+    if slot_count:
+        lines.append(f"  [dim]Server slots:[/] {slot_count}")
+
     model_root = metadata.get("server_model_root")
     model_api = metadata.get("model") or config.get("model")
     if model_root and model_root != model_api:

--- a/src/tool_eval_bench/domain/adapters.py
+++ b/src/tool_eval_bench/domain/adapters.py
@@ -62,9 +62,11 @@ class ChatCompletionResult:
     # HTTP status when the server rejected the request outright and the adapter
     # degraded to a soft result rather than raising. The turn produced no model
     # output at all, so a caller must not grade ``content`` as an answer. The
-    # runner decides whether the rejected request was the model's fault, which
-    # depends on whether the model had authored anything in the history yet.
+    # runner decides whether the request or the serving stack caused the error.
     transport_error_status: int | None = None
+    # True when the adapter can identify a rejection that happened inside the
+    # serving stack before inference, even if an earlier turn produced output.
+    transport_error_is_infrastructure: bool = False
 
 
 class BackendAdapter(ABC):

--- a/src/tool_eval_bench/domain/models.py
+++ b/src/tool_eval_bench/domain/models.py
@@ -79,6 +79,7 @@ class RunContext:
     quantization: str | None = None
     gpu_count: int | None = None
     spec_decoding: str | None = None
+    slot_count: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a JSON-safe dict for metadata_json storage."""

--- a/src/tool_eval_bench/runner/orchestrator.py
+++ b/src/tool_eval_bench/runner/orchestrator.py
@@ -460,16 +460,24 @@ async def run_scenario(
             # to grade. Whether that is the model's fault depends on what the
             # request contained: once the model has authored a tool call, the
             # history carries arguments a strict server may refuse, and the
-            # existing soft-result behaviour records that as a model failure.
+            # existing soft-result behaviour records that as a model failure
+            # unless the adapter identifies a backend-internal rejection.
             # Before then the request is entirely ours, so a 4xx means the
             # endpoint would not accept a parameter this benchmark sent
             # (tool_choice and response_format are the usual ones) and the
             # scenario measures the serving stack rather than the model.
-            if result.transport_error_status is not None and not state.tool_calls:
+            if result.transport_error_status is not None and (
+                not state.tool_calls or result.transport_error_is_infrastructure
+            ):
                 elapsed = time.perf_counter() - t0
+                rejection_stage = (
+                    "because the serving stack failed before inference"
+                    if result.transport_error_is_infrastructure
+                    else "before the model produced anything"
+                )
                 summary = (
                     f"Endpoint rejected the request with HTTP "
-                    f"{result.transport_error_status} before the model produced anything: "
+                    f"{result.transport_error_status} {rejection_stage}: "
                     f"{result.content}"
                 )
                 trace_lines.append(f"transport_error={result.transport_error_status}")

--- a/src/tool_eval_bench/storage/reports/_common.py
+++ b/src/tool_eval_bench/storage/reports/_common.py
@@ -178,6 +178,7 @@ def _render_run_context(ctx: RunContext) -> list[str]:
             ctx.max_model_len,
             ctx.quantization,
             ctx.gpu_count,
+            ctx.slot_count,
             ctx.spec_decoding,
         ]
     )
@@ -199,6 +200,8 @@ def _render_run_context(ctx: RunContext) -> list[str]:
             md.append(f"| Quantization | {ctx.quantization} |")
         if ctx.gpu_count:
             md.append(f"| GPU Count | {ctx.gpu_count} |")
+        if ctx.slot_count:
+            md.append(f"| Server Slots | {ctx.slot_count} |")
         if ctx.spec_decoding:
             md.append(f"| Spec Decoding | {ctx.spec_decoding} |")
         md.extend(

--- a/src/tool_eval_bench/utils/metadata.py
+++ b/src/tool_eval_bench/utils/metadata.py
@@ -244,7 +244,7 @@ async def _probe_llamacpp(base_url: str, *, session: _ProbeSession | None = None
             elif "build_number" in body:
                 result["engine_version"] = f"b{body['build_number']}"
             if "total_slots" in body:
-                result["gpu_count"] = body.get("total_slots")
+                result["slot_count"] = body.get("total_slots")
             return result
     return {}
 
@@ -549,6 +549,7 @@ async def collect_run_context(
         max_model_len=engine_info.get("max_model_len"),
         quantization=engine_info.get("quantization"),
         gpu_count=engine_info.get("gpu_count"),
+        slot_count=engine_info.get("slot_count"),
         spec_decoding=engine_info.get("spec_decoding"),
     )
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -472,6 +472,37 @@ async def test_4xx_returns_graceful_result() -> None:
     await adapter.aclose()
 
 
+@pytest.mark.asyncio
+async def test_sampler_initialization_4xx_is_marked_as_infrastructure() -> None:
+    """llama.cpp can reject generated grammars before inference starts."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={
+                "error": {
+                    "code": 400,
+                    "message": "Failed to initialize samplers: failed to parse grammar",
+                    "type": "invalid_request_error",
+                }
+            },
+        )
+
+    adapter = OpenAICompatibleAdapter()
+    adapter._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    result = await adapter.chat_completion(
+        model="m",
+        messages=[{"role": "user", "content": "return JSON"}],
+        base_url="http://localhost:8080",
+        response_format={"type": "json_schema", "json_schema": {"schema": {"type": "object"}}},
+    )
+
+    assert result.transport_error_status == 400
+    assert result.transport_error_is_infrastructure
+    await adapter.aclose()
+
+
 # ---------------------------------------------------------------------------
 # response_format and extra_params
 # ---------------------------------------------------------------------------
@@ -1049,6 +1080,34 @@ async def test_stream_4xx_returns_graceful_result() -> None:
 
     assert "[server error 422]" in result.content
     assert result.tool_calls == []
+    assert not result.transport_error_is_infrastructure
+    await adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stream_sampler_initialization_4xx_is_marked_as_infrastructure() -> None:
+    """Streaming and non-streaming requests classify the same llama.cpp error."""
+    body = json.dumps(
+        {
+            "error": {
+                "code": 400,
+                "message": "FAILED TO INITIALIZE SAMPLERS: failed to parse grammar",
+                "type": "invalid_request_error",
+            }
+        }
+    )
+    adapter = OpenAICompatibleAdapter()
+    adapter._client = httpx.AsyncClient(transport=_mock_stream_transport(body, status=400))
+
+    result = await adapter.chat_completion(
+        model="m",
+        messages=[{"role": "user", "content": "return JSON"}],
+        base_url="http://localhost:8080",
+        stream=True,
+    )
+
+    assert result.transport_error_status == 400
+    assert result.transport_error_is_infrastructure
     await adapter.aclose()
 
 

--- a/tests/test_backend_capability_attribution.py
+++ b/tests/test_backend_capability_attribution.py
@@ -171,6 +171,38 @@ async def test_rejection_after_the_model_authored_a_tool_call_stays_a_model_fail
 
 
 @pytest.mark.asyncio
+async def test_sampler_initialization_rejection_after_tool_call_is_infrastructure() -> None:
+    """A backend sampler failure is not caused by valid tool-call history."""
+    adapter = ScriptedAdapter(
+        [
+            ChatCompletionResult(content="", tool_calls=[_tool_call("anything")]),
+            ChatCompletionResult(
+                content=(
+                    "[server error 400] Failed to initialize samplers: failed to parse grammar"
+                ),
+                transport_error_status=400,
+                transport_error_is_infrastructure=True,
+            ),
+        ]
+    )
+    seen: list[str] = []
+    scenario = _trivial_scenario()
+
+    def evaluate(state: ScenarioState) -> ScenarioEvaluation:
+        seen.append(state.final_answer)
+        return ScenarioEvaluation(ScenarioStatus.PARTIAL, 1, "graded server output")
+
+    scenario.evaluate = evaluate
+
+    result = await _run(adapter, scenario)
+
+    assert seen == []
+    assert result.failure_kind == FailureKind.SERVER_ERROR
+    assert result.is_infrastructure_failure
+    assert "serving stack failed before inference" in result.summary
+
+
+@pytest.mark.asyncio
 async def test_infrastructure_rejection_drops_out_of_the_score() -> None:
     """An excluded scenario leaves the denominator, it does not score zero."""
     good = _trivial_scenario("TC-GOOD")

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -163,7 +163,8 @@ class TestProbeLlamacpp:
 
         assert result["engine_name"] == "llama.cpp"
         assert result["engine_version"] == "1234 (abc)"
-        assert result["gpu_count"] == 1
+        assert result["slot_count"] == 1
+        assert "gpu_count" not in result
 
     @pytest.mark.asyncio
     async def test_falls_back_to_health(self) -> None:
@@ -630,6 +631,30 @@ class TestProbeBackendHint:
 
 
 class TestCollectRunContext:
+    @pytest.mark.asyncio
+    async def test_carries_llamacpp_slots_without_inventing_gpu_count(self) -> None:
+        from tool_eval_bench.utils.metadata import collect_run_context
+
+        with patch(
+            "tool_eval_bench.utils.metadata._probe_engine",
+            AsyncMock(
+                return_value={
+                    "engine_name": "llama.cpp",
+                    "engine_version": "b10820-74a7c897f",
+                    "slot_count": 3,
+                }
+            ),
+        ):
+            ctx = await collect_run_context(
+                model="m",
+                backend="llamacpp",
+                base_url="http://localhost:8080",
+            )
+
+        assert ctx.slot_count == 3
+        assert ctx.gpu_count is None
+        assert ctx.to_dict()["slot_count"] == 3
+
     @pytest.mark.asyncio
     async def test_collects_context(self) -> None:
         from tool_eval_bench.utils.metadata import collect_run_context

--- a/tests/test_run_context.py
+++ b/tests/test_run_context.py
@@ -67,12 +67,14 @@ class TestRunContext:
             engine_version="0.8.5",
             max_model_len=65536,
             quantization="AWQ",
+            slot_count=3,
         )
         d = ctx.to_dict()
         assert d["engine_name"] == "vLLM"
         assert d["engine_version"] == "0.8.5"
         assert d["max_model_len"] == 65536
         assert d["quantization"] == "AWQ"
+        assert d["slot_count"] == 3
 
     def test_to_dict_is_json_serializable(self):
         from tool_eval_bench.domain.models import RunContext
@@ -92,6 +94,43 @@ class TestRunContext:
         serialized = json.dumps(ctx.to_dict())
         parsed = json.loads(serialized)
         assert parsed["extra_params"] == {"temperature": 0.6, "top_p": 0.9}
+
+    def test_new_slot_count_field_preserves_positional_spec_decoding(self):
+        from tool_eval_bench.domain.models import RunContext
+
+        ctx = RunContext(
+            "1.4.0",
+            "abc123",
+            "host",
+            "Linux",
+            "3.12",
+            "model",
+            "llamacpp",
+            "http://localhost:8080",
+            0.0,
+            8,
+            120.0,
+            None,
+            "all",
+            1,
+            1,
+            0.0,
+            True,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "llama.cpp",
+            "b10820",
+            None,
+            None,
+            None,
+            "mtp",
+        )
+
+        assert ctx.spec_decoding == "mtp"
+        assert ctx.slot_count is None
 
     def test_defaults_match_cli_defaults(self):
         """RunContext defaults should match CLI argparse defaults."""
@@ -268,6 +307,15 @@ class TestRenderRunContext:
         assert "65,536" in md
         assert "AWQ" in md
 
+    def test_server_slots_are_not_rendered_as_gpu_count(self):
+        from tool_eval_bench.storage.reports import _render_run_context
+
+        ctx = self._make_context(engine_name="llama.cpp", slot_count=3)
+        md = "\n".join(_render_run_context(ctx))
+
+        assert "| Server Slots | 3 |" in md
+        assert "GPU Count" not in md
+
     def test_environment_section_without_engine(self):
         from tool_eval_bench.storage.reports import _render_run_context
 
@@ -404,6 +452,13 @@ class TestHistoryContextExtraction:
         assert "AWQ" in text
         assert "Qwen/Qwen3.6-27B-Instruct" in text
         assert "inference-01" in text
+
+    def test_extract_context_panel_shows_server_slots(self):
+        from tool_eval_bench.cli.history import _extract_context_panel
+
+        run = {"metadata": {"engine_name": "llama.cpp", "slot_count": 3}, "config": {}}
+
+        assert "  [dim]Server slots:[/] 3" in _extract_context_panel(run)
 
     def test_extract_context_panel_old_run(self):
         """Old runs should return empty list gracefully."""

--- a/tests/test_run_provenance.py
+++ b/tests/test_run_provenance.py
@@ -182,6 +182,12 @@ class TestFingerprintIncludesCodeIdentity:
     def test_missing_sha_is_tolerated(self) -> None:
         assert _config({})["config_fingerprint"]
 
+    def test_server_slot_count_changes_comparison_cohort(self) -> None:
+        one_slot = _config({"git_sha": "aaaaaaa", "slot_count": 1})
+        three_slots = _config({"git_sha": "aaaaaaa", "slot_count": 3})
+
+        assert one_slot["config_fingerprint"] != three_slots["config_fingerprint"]
+
 
 def _package_head() -> str | None:
     """The HEAD of the checkout the installed package lives in, if any."""


### PR DESCRIPTION
Issues #153 and #154 identify two llama.cpp integration errors. Sampler-initialization HTTP 4xx responses can be scored as model output after a valid tool call, and `/props.total_slots` is reported as a physical GPU count.

This change carries a narrow infrastructure classification for known `failed to initialize samplers` responses through the OpenAI-compatible adapter and orchestrator. Generic post-tool HTTP 4xx responses remain model-attributed. It also records `total_slots` as `slot_count`, renders it as Server Slots, and includes it in comparison metadata without inferring a GPU count.

Verification:

- 186 focused adapter, attribution, metadata, report, and provenance tests passed
- 3,920 non-live tests passed with seed 104729
- Ruff lint and format checks passed
- mypy passed
- pre-push hooks passed
- the live llama.cpp endpoint confirmed `total_slots=3` and accepted the TC-65 schema

Closes #153
Closes #154

Written with AI assistance; reviewed before opening.
