### PR TITLE
fix(perf): reject zero throughput cells (#152)

### DIFF
--- a/changelog.d/152.fixed.md
+++ b/changelog.d/152.fixed.md
@@ -1,0 +1,3 @@
+**Throughput matrix failures.** `bench --perf-only` now rejects all-zero cells instead of
+publishing them as successful measurements. Partial reports keep completed cells, identify failed
+cells and exit with a nonzero status so unattended runs cannot publish invalid results.

--- a/src/tool_eval_bench/cli/dispatch.py
+++ b/src/tool_eval_bench/cli/dispatch.py
@@ -354,7 +354,7 @@ def _run_throughput_mode(target: _Target) -> tuple[list, bool]:
     )
 
     if not args.perf_only:
-        return throughput_samples, False
+        return [sample for sample in throughput_samples if not sample.error], False
 
     from tool_eval_bench.utils.ids import build_run_id
 
@@ -374,18 +374,26 @@ def _run_throughput_mode(target: _Target) -> tuple[list, bool]:
         throughput_samples,
         run_context=target.run_context,
     )
+    failed_count = sum(bool(sample.error) for sample in throughput_samples)
+    successful_count = len(throughput_samples) - failed_count
+    scores = {"samples": len(throughput_samples)}
+    if failed_count:
+        scores.update({"successful": successful_count, "failed": failed_count})
     _persist_plugin_run(
         {
             "run_id": run_id,
             "run_type": "perf",
-            "status": "completed",
+            "status": "failed" if failed_count else "completed",
             "config": run_config,
-            "scores": {"samples": len(throughput_samples)},
+            "scores": scores,
             "metadata": _metadata_for_storage(target.run_context),
             "report_path": str(report_path),
         }
     )
     console.print(f"\n  [dim]Report saved to {report_path}[/]\n")
+    if failed_count:
+        console.print(f"[bold red]Throughput benchmark failed in {failed_count} cell(s).[/]")
+        sys.exit(1)
     return throughput_samples, True
 
 

--- a/src/tool_eval_bench/cli/perf.py
+++ b/src/tool_eval_bench/cli/perf.py
@@ -221,7 +221,6 @@ def run_llama_benchy(
             def on_progress(event: dict[str, Any]) -> None:
                 event_type = event.get("type", "")
                 if event_type == "bench_complete":
-                    progress.update(task, completed=total_runs, description="[green]✓ Complete")
                     return
                 tracker.handle(event)
                 if event_type == "request_start":
@@ -247,7 +246,9 @@ def run_llama_benchy(
                 on_progress=on_progress,
             )
 
-            progress.update(task, completed=total_runs, description="[green]✓ Complete")
+            failed_samples = [sample for sample in benchy_result.samples if sample.error]
+            description = "[red]✗ Incomplete" if failed_samples else "[green]✓ Complete"
+            progress.update(task, completed=total_runs, description=description)
 
     try:
         asyncio.run(_run())
@@ -313,5 +314,11 @@ def run_llama_benchy(
             "[bold]https://github.com/eugr/llama-benchy[/] for methodology.[/]"
         )
 
+    failed_samples = [s for s in benchy_result.samples if s.error]
+    if failed_samples:
+        console.print("\n[bold red]Failed measurements:[/]")
+        for sample in failed_samples:
+            console.print(f"  [red]•[/] {sample.error}")
+
     console.print()
-    return ok_samples
+    return benchy_result.samples

--- a/src/tool_eval_bench/runner/llama_benchy.py
+++ b/src/tool_eval_bench/runner/llama_benchy.py
@@ -340,6 +340,32 @@ def _stat_mean(stat: dict[str, Any]) -> float:
     return 0.0
 
 
+def _sample_cell_key(sample: ThroughputSample) -> tuple[int, int, int, int]:
+    """Return the matrix coordinates shared by results and progress events."""
+    return (sample.pp_tokens, sample.tg_tokens, sample.depth, sample.concurrency)
+
+
+def _progress_cell_key(event: dict[str, Any]) -> tuple[int, int, int, int]:
+    """Return one progress event's matrix coordinates."""
+    return (
+        int(event.get("prompt_size", 0)),
+        int(event.get("response_size", 0)),
+        int(event.get("context_size", 0)),
+        int(event.get("concurrency", 1)),
+    )
+
+
+def _invalid_sample_error(sample: ThroughputSample, errors: list[str]) -> str | None:
+    """Describe an all-zero cell, using llama-benchy's request error when present."""
+    if any(value > 0 for value in (sample.pp_tps, sample.tg_tps, sample.ttft_ms, sample.total_ms)):
+        return None
+    detail = "; ".join(dict.fromkeys(errors)) or "no usable throughput metrics"
+    return (
+        f"pp{sample.label_pp} tg{sample.tg_tokens} @ d{sample.label_depth} "
+        f"c{sample.concurrency}: {detail}"
+    )
+
+
 def parse_json_output(data: dict[str, Any]) -> LlamaBenchyResult:
     """Parse a complete llama-benchy JSON output into a LlamaBenchyResult."""
     result = LlamaBenchyResult(
@@ -462,6 +488,8 @@ async def run_llama_benchy(
         # stdout and regular output to stderr.  Read both concurrently to avoid
         # pipe-buffer deadlock.
         output_lines: list[str] = []
+        request_cells: dict[int, tuple[int, int, int, int]] = {}
+        cell_errors: dict[tuple[int, int, int, int], list[str]] = {}
         # Known noisy lines from transformers/HF Hub we suppress from display
         _SUPPRESS = (
             "PyTorch was not found",
@@ -493,6 +521,15 @@ async def run_llama_benchy(
                     if line:
                         output_lines.append(line)
                     continue
+                event_type = event.get("type")
+                request_id = event.get("request_id")
+                if event_type == "request_start" and request_id is not None:
+                    request_cells[int(request_id)] = _progress_cell_key(event)
+                elif event_type == "request_end" and request_id is not None:
+                    cell = request_cells.pop(int(request_id), None)
+                    error = event.get("error")
+                    if cell is not None and isinstance(error, str) and error:
+                        cell_errors.setdefault(cell, []).append(error)
                 if on_progress:
                     on_progress(event)
 
@@ -567,6 +604,11 @@ async def run_llama_benchy(
 
         raw_data = json.loads(output_path.read_text(encoding="utf-8"))
         result = parse_json_output(raw_data)
+        for sample in result.samples:
+            sample.error = _invalid_sample_error(
+                sample,
+                cell_errors.get(_sample_cell_key(sample), []),
+            )
         if not result.samples:
             raise RuntimeError(
                 "llama-benchy produced no benchmark samples. "

--- a/tests/test_dispatch_coverage.py
+++ b/tests/test_dispatch_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from rich.console import Console
@@ -261,11 +262,12 @@ def test_dispatch_main_skip_and_perf_only_routes(
     dispatch.main()
     assert context_calls[-1]["label"] == "startup A"
 
+    successful_runs: list[dict] = []
     monkeypatch.setattr(dispatch, "_run_llama_benchy", lambda *a, **k: [_sample()])
     monkeypatch.setattr(
         reports.MarkdownReporter, "write_throughput_report", lambda *a, **k: tmp_path / "p.md"
     )
-    monkeypatch.setattr(dispatch, "_persist_plugin_run", lambda value: None)
+    monkeypatch.setattr(dispatch, "_persist_plugin_run", successful_runs.append)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -282,6 +284,63 @@ def test_dispatch_main_skip_and_perf_only_routes(
         ],
     )
     dispatch.main()
+    assert successful_runs[-1]["status"] == "completed"
+    assert successful_runs[-1]["scores"] == {"samples": 1}
+
+    perf_samples = [_sample(), _sample(error="backend unavailable")]
+    written_samples: list = []
+    persisted_runs: list[dict] = []
+    monkeypatch.setattr(dispatch, "_run_llama_benchy", lambda *a, **k: perf_samples)
+    monkeypatch.setattr(
+        reports.MarkdownReporter,
+        "write_throughput_report",
+        lambda self, run_id, model, samples, **kwargs: (
+            written_samples.extend(samples) or tmp_path / "p.md"
+        ),
+    )
+    monkeypatch.setattr(dispatch, "_persist_plugin_run", persisted_runs.append)
+    with pytest.raises(SystemExit) as exc:
+        dispatch.main()
+
+    assert exc.value.code == 1
+    assert written_samples == perf_samples
+    assert persisted_runs[-1]["status"] == "failed"
+    assert persisted_runs[-1]["scores"] == {"samples": 2, "successful": 1, "failed": 1}
+
+
+def test_regular_perf_keeps_only_successful_samples(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Failed cells must not change the existing combined-run input contract."""
+    from tool_eval_bench.cli import dispatch
+
+    good = _sample()
+    failed = _sample(error="backend unavailable")
+    monkeypatch.setattr(dispatch, "_run_llama_benchy", lambda *a, **k: [good, failed])
+    target = SimpleNamespace(
+        args=SimpleNamespace(
+            perf=True,
+            perf_only=False,
+            benchy_args=None,
+            pp=2048,
+            tg=128,
+            depth="0",
+            concurrency="1",
+            benchy_runs=1,
+            benchy_latency_mode="generation",
+            no_warmup=True,
+            tokenizer=None,
+        ),
+        console=Console(),
+        model="model",
+        display_name="Model",
+        base_url="http://test/v1",
+        api_key=None,
+        backend="llamacpp",
+    )
+
+    samples, finished = dispatch._run_throughput_mode(target)
+
+    assert samples == [good]
+    assert finished is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_llama_benchy.py
+++ b/tests/test_llama_benchy.py
@@ -808,6 +808,75 @@ class TestRunLlamaBenchy:
         with pytest.raises(RuntimeError, match="no usable throughput metrics"):
             await run_llama_benchy("http://localhost:8888/v1", "test-model")
 
+    async def test_partial_null_metrics_preserve_request_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One successful cell must not hide a failed cell in the same matrix."""
+        from tool_eval_bench.runner.llama_benchy import run_llama_benchy
+
+        monkeypatch.setattr(
+            "tool_eval_bench.runner.llama_benchy.shutil.which",
+            lambda name: "/usr/bin/llama-benchy" if name == "llama-benchy" else None,
+        )
+        output_file_ref = _capture_output_file(monkeypatch)
+        failed_entry = {
+            "concurrency": 2,
+            "context_size": 161792,
+            "prompt_size": 2048,
+            "response_size": 512,
+            "pp_throughput": None,
+            "tg_throughput": None,
+            "pp_req_throughput": None,
+            "tg_req_throughput": None,
+            "e2e_ttft": None,
+            "est_ppt": None,
+        }
+        unstarted_entry = {**failed_entry, "concurrency": 3}
+        progress_events = [
+            {
+                "type": "request_start",
+                "request_id": 7,
+                "prompt_size": 2048,
+                "response_size": 512,
+                "context_size": 161792,
+                "concurrency": 2,
+                "run_index": 0,
+            },
+            {
+                "type": "request_end",
+                "request_id": 7,
+                "total_tokens": 0,
+                "prompt_tokens": 0,
+                "decode_seconds": 0.0,
+                "error": "Cannot connect to host after backend exited",
+            },
+            {"type": "bench_complete", "status": "ok"},
+        ]
+
+        async def mock_create(*args: object, **kwargs: object) -> _MockProcess:
+            return _MockProcess(
+                stdout_lines=[f"{json.dumps(event)}\n" for event in progress_events],
+                output_file=output_file_ref[0],
+                write_json={
+                    "benchmarks": [SAMPLE_BENCHMARK_ENTRY, failed_entry, unstarted_entry],
+                },
+            )
+
+        monkeypatch.setattr(
+            "tool_eval_bench.runner.llama_benchy.asyncio.create_subprocess_exec",
+            mock_create,
+        )
+
+        result = await run_llama_benchy("http://localhost:8888/v1", "test-model")
+
+        assert result.samples[0].error is None
+        assert result.samples[1].error == (
+            "pp2048 tg512 @ d161792 c2: Cannot connect to host after backend exited"
+        )
+        assert result.samples[2].error == (
+            "pp2048 tg512 @ d161792 c3: no usable throughput metrics"
+        )
+
     async def test_on_output_receives_stderr_lines(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """on_output callback should receive every stderr line."""
         from tool_eval_bench.runner.llama_benchy import run_llama_benchy

--- a/tests/test_reporting_and_perf_coverage.py
+++ b/tests/test_reporting_and_perf_coverage.py
@@ -238,8 +238,12 @@ def test_llama_benchy_cli_success_and_unavailable(monkeypatch: pytest.MonkeyPatc
         runs=1,
     )
 
-    assert result == [ok]
-    assert "llama-benchy 1.2.3" in console.export_text()
+    assert result == [ok, failed]
+    output = console.export_text()
+    assert "llama-benchy 1.2.3" in output
+    assert "Incomplete" in output
+    assert "\u2713 Complete" not in output
+    assert "failed" in output
 
 
 def test_spec_bench_cli_renders_metrics_and_persists(


### PR DESCRIPTION
Issue #152 reports that `bench --perf-only` treats all-zero llama-benchy cells as successful measurements. A mixed matrix can therefore print Complete, persist a completed run, and exit 0 after the backend has died.

This change marks cells invalid only when prompt throughput, generation throughput, TTFT, and total time are all zero. It correlates llama-benchy progress events so reports retain the original request error when available, preserves successful cells in partial reports, and makes failed perf-only runs persist as failed and exit 1. Combined `--perf` runs continue to pass only successful throughput samples downstream.

Verification:

- 150 focused perf and reporting tests passed
- 3,914 non-live tests passed with seed 104729
- llama-benchy branch coverage passed at 96.88 percent
- Ruff lint and format checks passed
- mypy passed
- pre-push hooks passed

Closes #152

Written with AI assistance; reviewed before opening.
