### PR TITLE
ci: enforce contributor pull request policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,4 @@
-# Default owner for everything in this repository.
-*       @SeraphimSerapis
+# Keep the enforcement mechanism itself under maintainer review. Other pull
+# requests can merge without a mandatory approval once their checks pass.
+/.github/workflows/contributor-policy.yml @SeraphimSerapis
+/scripts/check_contribution.py @SeraphimSerapis

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,23 @@
-## Summary
+## Problem
 
-<!-- What problem does this change solve? Link the relevant issue, if one exists. -->
+<!-- Link the issue or provide a minimal reproduction and expected behavior. -->
 
-## Changes
+## Change
 
-<!-- Summarize the implementation and any user-facing or scoring impact. -->
+<!-- Explain the implementation and any user-facing or scoring impact. -->
 
-## Validation
+## Regression coverage
 
-<!-- List focused tests and the broader checks you ran. If a check is not applicable, say why. -->
+<!-- Name the tests that fail without this change. Include negative or false-positive cases. -->
 
-- [ ] Focused tests pass.
-- [ ] `.venv/bin/ruff check .` passes.
-- [ ] `.venv/bin/ruff format --check .` passes.
-- [ ] `.venv/bin/mypy` passes.
-- [ ] Required pytest suite passes.
-- [ ] Live-server testing is not required, or the test endpoint and scope are described.
+## Changelog and documentation
+
+<!-- Link the new changelog.d/ fragment and documentation changes, or explain why neither applies. -->
 
 ## Contributor checklist
 
 - [ ] This PR contains one focused, logically related change.
-- [ ] Regression or behavior tests were added or updated where appropriate.
-- [ ] Positive and negative/false-positive cases are covered for evaluator changes.
-- [ ] `README.md` and/or `CHANGELOG.md` is updated when applicable.
+- [ ] Regression tests were added or a maintainer applied `tests-not-needed`.
+- [ ] A `changelog.d/` fragment was added or a maintainer applied `skip-changelog`.
+- [ ] Fork PRs enable **Allow edits from maintainers**.
 - [ ] No credentials, live endpoints, generated run artifacts, or unrelated formatting changes are included.

--- a/.github/workflows/contributor-policy.yml
+++ b/.github/workflows/contributor-policy.yml
@@ -1,0 +1,31 @@
+name: Contributor policy
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited, ready_for_review, labeled, unlabeled]
+
+# Pull requests are untrusted. This job gets read-only access and no secrets.
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  contributor-policy:
+    name: contributor-policy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check contribution requirements
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: >
+          python scripts/check_contribution.py
+          --base-sha "$BASE_SHA"
+          --head-sha "$HEAD_SHA"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,34 @@ TOOL_EVAL_CANARY_BASE_URL=http://host:port/v1 \
   .venv/bin/python -m pytest -m live tests/test_live_canary.py
 ```
 
+## Pull request policy
+
+The `contributor-policy` check rejects mechanical omissions before maintainer
+review:
+
+- Production Python changes need a corresponding change under `tests/`.
+- Runtime and packaging changes need a new, nonempty `changelog.d/` fragment.
+- `CHANGELOG.md` must not be edited directly because towncrier generates it.
+- Pull requests from forks must enable **Allow edits from maintainers**.
+
+Documentation-only and test-only changes do not need a changelog fragment.
+When tests or a changelog entry genuinely do not apply, ask a maintainer to add
+the `tests-not-needed` or `skip-changelog` label. Contributors should explain
+the exception in the pull request instead of adding the labels themselves.
+
+On a user-owned fork, **Allow edits from maintainers** lets people with push
+access to this repository commit to the pull request branch. If the fork has
+GitHub Actions workflows, GitHub labels this option **Allow edits and access to
+secrets by maintainers** because it can also expose the fork's Actions secrets
+and other branches. Review GitHub's
+[fork permission documentation](https://docs.github.com/en/pull-requests/how-tos/work-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
+before enabling it.
+
+Draft pull requests are welcome for early discussion. Maintainer review begins
+after the pull request is marked ready, the policy check passes, and CI is
+green. Maintainers may push a small correction when that is cheaper than a
+review round, but contributors remain responsible for a complete submission.
+
 ## What a good contribution looks like
 
 Prefer one focused change per pull request. A strong contribution generally:
@@ -252,6 +280,7 @@ Before submitting a pull request:
 - [ ] No secrets, live endpoints, generated reports, or unrelated changes are
       included.
 - [ ] The PR description lists the validation performed.
+- [ ] Fork PRs enable **Allow edits from maintainers**.
 
 Thank you for contributing improvements that make model and tool-use evaluation
 more trustworthy.

--- a/scripts/check_contribution.py
+++ b/scripts/check_contribution.py
@@ -1,0 +1,223 @@
+"""Enforce mechanical pull-request contribution requirements."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+CHANGELOG_TYPES = ("added", "changed", "fixed", "removed", "security")
+FRAGMENT_NAME = re.compile(
+    rf"^(?:[0-9]+|\+[a-z0-9][a-z0-9-]*)\.(?:{'|'.join(CHANGELOG_TYPES)})\.md$"
+)
+RUNTIME_FILES = {
+    ".env.example",
+    "Dockerfile",
+    "compose.yaml",
+    "docker-compose.yml",
+    "pyproject.toml",
+    "uv.lock",
+}
+
+
+def _pull_request(event: dict[str, Any]) -> dict[str, Any]:
+    pull_request = event.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise ValueError("event does not contain a pull_request object")
+    return pull_request
+
+
+def _labels(pull_request: dict[str, Any]) -> set[str]:
+    labels = pull_request.get("labels", [])
+    return {
+        label["name"]
+        for label in labels
+        if isinstance(label, dict) and isinstance(label.get("name"), str)
+    }
+
+
+def _repo_name(ref: object) -> str | None:
+    if not isinstance(ref, dict):
+        return None
+    repo = ref.get("repo")
+    if not isinstance(repo, dict):
+        return None
+    name = repo.get("full_name")
+    return name if isinstance(name, str) else None
+
+
+def _is_runtime_file(path: str) -> bool:
+    return path.startswith("src/") or path in RUNTIME_FILES
+
+
+def _is_production_python(path: str) -> bool:
+    return path.startswith("src/") and path.endswith(".py")
+
+
+def _is_test_file(path: str) -> bool:
+    return path.startswith("tests/")
+
+
+def _added_fragments(added_files: set[str]) -> list[str]:
+    return sorted(
+        path
+        for path in added_files
+        if path.startswith("changelog.d/") and path != "changelog.d/README.md"
+    )
+
+
+def evaluate_policy(
+    *,
+    event: dict[str, Any],
+    changed_files: set[str],
+    added_files: set[str],
+    fragment_contents: dict[str, str | None],
+) -> list[str]:
+    """Return actionable policy failures for one pull request."""
+    pull_request = _pull_request(event)
+    labels = _labels(pull_request)
+    errors: list[str] = []
+
+    head_repo = _repo_name(pull_request.get("head"))
+    base_repo = _repo_name(pull_request.get("base"))
+    if head_repo and base_repo and head_repo != base_repo:
+        if not pull_request.get("maintainer_can_modify", False):
+            errors.append(
+                "Fork pull requests must enable 'Allow edits from maintainers'. Enable it in "
+                "the pull request sidebar, then rerun this check."
+            )
+
+    if "tests-not-needed" not in labels:
+        production_changed = any(_is_production_python(path) for path in changed_files)
+        tests_changed = any(_is_test_file(path) for path in changed_files)
+        if production_changed and not tests_changed:
+            errors.append(
+                "Production Python changed without a tests/** change. Add regression coverage "
+                "or ask a maintainer to apply the tests-not-needed label."
+            )
+
+    if "skip-changelog" not in labels:
+        if "CHANGELOG.md" in changed_files:
+            errors.append(
+                "CHANGELOG.md is generated. Revert that edit and add a changelog.d/ fragment "
+                "instead."
+            )
+
+        fragments = _added_fragments(added_files)
+        for path in fragments:
+            name = Path(path).name
+            if not FRAGMENT_NAME.fullmatch(name):
+                errors.append(
+                    f"Invalid changelog fragment name: {path}. Use "
+                    "<issue-or-PR-number>.<type>.md or +<slug>.<type>.md."
+                )
+                continue
+            content = fragment_contents.get(path)
+            if content is None or not content.strip():
+                errors.append(f"Changelog fragment is empty: {path}.")
+
+        runtime_changed = any(_is_runtime_file(path) for path in changed_files)
+        valid_fragments = [path for path in fragments if FRAGMENT_NAME.fullmatch(Path(path).name)]
+        if runtime_changed and not valid_fragments:
+            errors.append(
+                "Runtime or packaging files changed without a changelog fragment. Add "
+                "changelog.d/<issue-or-+slug>.<type>.md or ask a maintainer to apply the "
+                "skip-changelog label."
+            )
+
+    return errors
+
+
+def _git_files(root: Path, base_sha: str, head_sha: str, *, diff_filter: str) -> set[str]:
+    # Git receives separate arguments and never invokes a shell. The commit IDs
+    # and paths may come from the PR event, but they cannot become commands.
+    result = subprocess.run(  # noqa: S603
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "-z",
+            f"--diff-filter={diff_filter}",
+            f"{base_sha}...{head_sha}",
+            "--",
+        ],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    return {path.decode("utf-8") for path in result.stdout.split(b"\0") if path}
+
+
+def _git_file_text(root: Path, head_sha: str, path: str) -> str | None:
+    result = subprocess.run(  # noqa: S603
+        ["git", "show", f"{head_sha}:{path}"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        return result.stdout.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def _sha(pull_request: dict[str, Any], side: str) -> str:
+    ref = pull_request.get(side)
+    if not isinstance(ref, dict) or not isinstance(ref.get("sha"), str):
+        raise ValueError(f"pull_request.{side}.sha is missing")
+    return ref["sha"]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--event-path",
+        type=Path,
+        default=Path(os.environ.get("GITHUB_EVENT_PATH", "")),
+        help="GitHub pull_request event JSON",
+    )
+    parser.add_argument("--base-sha", help="Override the event base commit")
+    parser.add_argument("--head-sha", help="Override the event head commit")
+    parser.add_argument("--root", type=Path, default=Path.cwd(), help="Repository root")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if not args.event_path.is_file():
+        raise SystemExit("--event-path must name a pull_request event JSON file")
+
+    event = json.loads(args.event_path.read_text(encoding="utf-8"))
+    pull_request = _pull_request(event)
+    base_sha = args.base_sha or _sha(pull_request, "base")
+    head_sha = args.head_sha or _sha(pull_request, "head")
+    root = args.root.resolve()
+    changed_files = _git_files(root, base_sha, head_sha, diff_filter="ACDMR")
+    added_files = _git_files(root, base_sha, head_sha, diff_filter="A")
+    fragments = _added_fragments(added_files)
+    errors = evaluate_policy(
+        event=event,
+        changed_files=changed_files,
+        added_files=added_files,
+        fragment_contents={path: _git_file_text(root, head_sha, path) for path in fragments},
+    )
+
+    if errors:
+        print("Contributor policy failed:")
+        for error in errors:
+            print(f"  - {error}")
+        print("See CONTRIBUTING.md#pull-request-policy for details.")
+        return 1
+
+    print("Contributor policy passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_contribution_policy.py
+++ b/tests/test_contribution_policy.py
@@ -1,0 +1,149 @@
+"""Tests for the pull-request contribution policy."""
+
+from __future__ import annotations
+
+from scripts.check_contribution import evaluate_policy
+
+
+def _event(
+    *,
+    fork: bool = False,
+    maintainer_can_modify: bool = True,
+    labels: tuple[str, ...] = (),
+) -> dict:
+    head_repo = "contributor/tool-eval-bench" if fork else "owner/tool-eval-bench"
+    return {
+        "pull_request": {
+            "maintainer_can_modify": maintainer_can_modify,
+            "head": {"repo": {"full_name": head_repo}},
+            "base": {"repo": {"full_name": "owner/tool-eval-bench"}},
+            "labels": [{"name": label} for label in labels],
+        }
+    }
+
+
+def _fragment(name: str = "123.fixed.md") -> str:
+    return f"changelog.d/{name}"
+
+
+def test_source_change_requires_test_and_changelog() -> None:
+    errors = evaluate_policy(
+        event=_event(),
+        changed_files={"src/tool_eval_bench/runner/service.py"},
+        added_files=set(),
+        fragment_contents={},
+    )
+
+    assert errors == [
+        "Production Python changed without a tests/** change. Add regression coverage or ask "
+        "a maintainer to apply the tests-not-needed label.",
+        "Runtime or packaging files changed without a changelog fragment. Add "
+        "changelog.d/<issue-or-+slug>.<type>.md or ask a maintainer to apply the "
+        "skip-changelog label.",
+    ]
+
+
+def test_source_change_with_required_artifacts_passes() -> None:
+    fragment = _fragment()
+
+    errors = evaluate_policy(
+        event=_event(),
+        changed_files={
+            "src/tool_eval_bench/runner/service.py",
+            "tests/test_service.py",
+            fragment,
+        },
+        added_files={fragment},
+        fragment_contents={fragment: "Fixed it.\n"},
+    )
+
+    assert errors == []
+
+
+def test_changelog_fragment_must_be_new_valid_and_nonempty() -> None:
+    invalid = _fragment("notes.md")
+    empty = _fragment("124.fixed.md")
+
+    errors = evaluate_policy(
+        event=_event(),
+        changed_files={invalid, empty},
+        added_files={invalid, empty},
+        fragment_contents={invalid: "Notes.\n", empty: " \n"},
+    )
+
+    assert errors == [
+        "Changelog fragment is empty: changelog.d/124.fixed.md.",
+        "Invalid changelog fragment name: changelog.d/notes.md. Use "
+        "<issue-or-PR-number>.<type>.md or +<slug>.<type>.md.",
+    ]
+
+
+def test_generated_changelog_edit_is_rejected() -> None:
+    errors = evaluate_policy(
+        event=_event(),
+        changed_files={"CHANGELOG.md"},
+        added_files=set(),
+        fragment_contents={},
+    )
+
+    assert errors == [
+        "CHANGELOG.md is generated. Revert that edit and add a changelog.d/ fragment instead."
+    ]
+
+
+def test_maintainer_labels_allow_deliberate_exceptions() -> None:
+    errors = evaluate_policy(
+        event=_event(labels=("tests-not-needed", "skip-changelog")),
+        changed_files={"src/tool_eval_bench/domain/models.py", "CHANGELOG.md"},
+        added_files=set(),
+        fragment_contents={},
+    )
+
+    assert errors == []
+
+
+def test_fork_pull_request_requires_maintainer_edits() -> None:
+    errors = evaluate_policy(
+        event=_event(fork=True, maintainer_can_modify=False),
+        changed_files={"docs/example.md"},
+        added_files=set(),
+        fragment_contents={},
+    )
+
+    assert errors == [
+        "Fork pull requests must enable 'Allow edits from maintainers'. Enable it in the pull "
+        "request sidebar, then rerun this check."
+    ]
+
+
+def test_fork_with_maintainer_edits_and_same_repo_branch_pass() -> None:
+    fork_errors = evaluate_policy(
+        event=_event(fork=True, maintainer_can_modify=True),
+        changed_files={"docs/example.md"},
+        added_files=set(),
+        fragment_contents={},
+    )
+    same_repo_errors = evaluate_policy(
+        event=_event(fork=False, maintainer_can_modify=False),
+        changed_files={"docs/example.md"},
+        added_files=set(),
+        fragment_contents={},
+    )
+
+    assert fork_errors == []
+    assert same_repo_errors == []
+
+
+def test_packaging_change_requires_changelog_but_not_python_test() -> None:
+    errors = evaluate_policy(
+        event=_event(),
+        changed_files={"pyproject.toml"},
+        added_files=set(),
+        fragment_contents={},
+    )
+
+    assert errors == [
+        "Runtime or packaging files changed without a changelog fragment. Add "
+        "changelog.d/<issue-or-+slug>.<type>.md or ask a maintainer to apply the "
+        "skip-changelog label."
+    ]


### PR DESCRIPTION
## Problem

Contributor pull requests can reach maintainer review without regression tests, a changelog fragment, or permission for maintainers to make small corrections. The resulting cleanup is repetitive and avoidable.

## Change

- add a read-only contributor policy check for tests, changelog fragments, generated changelog edits, and fork edit permission
- document the two maintainer-controlled exception labels
- simplify the pull request template around evidence instead of duplicating CI
- require owner review only when the policy workflow or checker itself changes

## Regression coverage

Eight focused tests cover compliant changes, missing tests, missing or malformed fragments, direct CHANGELOG.md edits, label exceptions, packaging-only changes, and fork permissions.

The full local quality bar passed: Ruff check and format, mypy, pre-commit, and 3,930 tests with one deselected.

## Changelog and documentation

CONTRIBUTING.md documents the policy, exception labels, and GitHub fork-secret caveat. No package changelog fragment is included because this changes repository contribution process, not shipped package behavior.

Written with AI assistance; reviewed before opening.