### PR TITLE
fix: keep contributor-policy check working after squash-merge

### DIFF
--- a/.github/workflows/contributor-policy.yml
+++ b/.github/workflows/contributor-policy.yml
@@ -21,6 +21,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Fetch pull-request head
+        # refs/pull/N/head survives branch deletion, so the head SHA stays
+        # fetchable even for runs that start after the PR was merged.
+        run: git fetch --no-tags --no-recurse-submodules origin "+refs/pull/${{ github.event.pull_request.number }}/head"
+
       - name: Check contribution requirements
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/changelog.d/+contributor-policy-fetch.fixed.md
+++ b/changelog.d/+contributor-policy-fetch.fixed.md
@@ -1,0 +1,1 @@
+Fixed the contributor-policy check failing on runs that start after the PR branch was deleted: the workflow now fetches `refs/pull/<number>/head`, closed pull requests skip the check, and missing commits report git's error instead of a traceback.

--- a/scripts/check_contribution.py
+++ b/scripts/check_contribution.py
@@ -135,20 +135,28 @@ def evaluate_policy(
 def _git_files(root: Path, base_sha: str, head_sha: str, *, diff_filter: str) -> set[str]:
     # Git receives separate arguments and never invokes a shell. The commit IDs
     # and paths may come from the PR event, but they cannot become commands.
-    result = subprocess.run(  # noqa: S603
-        [
-            "git",
-            "diff",
-            "--name-only",
-            "-z",
-            f"--diff-filter={diff_filter}",
-            f"{base_sha}...{head_sha}",
-            "--",
-        ],
-        cwd=root,
-        check=True,
-        capture_output=True,
-    )
+    try:
+        result = subprocess.run(  # noqa: S603
+            [
+                "git",
+                "diff",
+                "--name-only",
+                "-z",
+                f"--diff-filter={diff_filter}",
+                f"{base_sha}...{head_sha}",
+                "--",
+            ],
+            cwd=root,
+            check=True,
+            capture_output=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or b"").decode("utf-8", "replace").strip()
+        raise SystemExit(
+            f"Cannot diff {base_sha}...{head_sha}: {detail or 'git diff failed'}. "
+            "Fetch the pull-request commits first "
+            "(git fetch origin '+refs/pull/<number>/head') and rerun."
+        ) from exc
     return {path.decode("utf-8") for path in result.stdout.split(b"\0") if path}
 
 
@@ -195,6 +203,9 @@ def main(argv: list[str] | None = None) -> int:
 
     event = json.loads(args.event_path.read_text(encoding="utf-8"))
     pull_request = _pull_request(event)
+    if pull_request.get("state", "open") != "open":
+        print("Pull request is closed; contributor policy check skipped.")
+        return 0
     base_sha = args.base_sha or _sha(pull_request, "base")
     head_sha = args.head_sha or _sha(pull_request, "head")
     root = args.root.resolve()

--- a/tests/test_contribution_policy.py
+++ b/tests/test_contribution_policy.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from scripts.check_contribution import evaluate_policy
+import json
+import subprocess
+
+import pytest
+
+from scripts.check_contribution import _git_files, evaluate_policy, main
 
 
 def _event(
@@ -147,3 +152,21 @@ def test_packaging_change_requires_changelog_but_not_python_test() -> None:
         "changelog.d/<issue-or-+slug>.<type>.md or ask a maintainer to apply the "
         "skip-changelog label."
     ]
+
+
+def test_closed_pull_request_skips_diff(tmp_path, capsys) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"state": "closed", "labels": []}}),
+        encoding="utf-8",
+    )
+
+    assert main(["--event-path", str(event_path), "--root", str(tmp_path)]) == 0
+    assert "skipped" in capsys.readouterr().out
+
+
+def test_git_files_missing_sha_reports_git_error(tmp_path) -> None:
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+
+    with pytest.raises(SystemExit, match="Cannot diff"):
+        _git_files(tmp_path, "0" * 40, "1" * 40, diff_filter="ACDMR")


### PR DESCRIPTION
Fetch refs/pull/<number>/head so the head SHA is diffable even after the branch is deleted. Closed pull requests skip the check, and missing commits now report git's error instead of a traceback.

## Problem

<!-- Link the issue or provide a minimal reproduction and expected behavior. -->

## Change

<!-- Explain the implementation and any user-facing or scoring impact. -->

## Regression coverage

<!-- Name the tests that fail without this change. Include negative or false-positive cases. -->

## Changelog and documentation

<!-- Link the new changelog.d/ fragment and documentation changes, or explain why neither applies. -->

## Contributor checklist

- [ ] This PR contains one focused, logically related change.
- [ ] Regression tests were added or a maintainer applied `tests-not-needed`.
- [ ] A `changelog.d/` fragment was added or a maintainer applied `skip-changelog`.
- [ ] Fork PRs enable **Allow edits from maintainers**.
- [ ] No credentials, live endpoints, generated run artifacts, or unrelated formatting changes are included.
