### PR TITLE
fix: make the scenario contribution example executable

### DIFF
--- a/changelog.d/+executable-scenario-example.fixed.md
+++ b/changelog.d/+executable-scenario-example.fixed.md
@@ -1,0 +1,1 @@
+Make the scenario contribution example advertise its tool, validate dated timezone conversions, and require correlated results. Exercise its valid and invalid paths through the production runner.

--- a/docs/adding-a-scenario.md
+++ b/docs/adding-a-scenario.md
@@ -25,70 +25,106 @@ Three parts: a mock handler that answers tool calls deterministically, an evalua
 final state, and the two module-level exports.
 
 ```python
-"""TC-89 — Timezone Conversion."""
+"""TC-89: date-aware timezone conversion with an explicit tool contract."""
 
-from __future__ import annotations
-
-from typing import Any
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from tool_eval_bench.domain.scenarios import (
     Category,
     ScenarioDefinition,
     ScenarioDisplayDetail,
-    ScenarioEvaluation,
     ScenarioState,
     ToolCallRecord,
 )
-from tool_eval_bench.evals.helpers import (
-    fail_eval as _fail,
-)
-from tool_eval_bench.evals.helpers import (
-    has_tool_call as _has_tool_call,
-)
-from tool_eval_bench.evals.helpers import (
-    includes_text as _includes_text,
-)
-from tool_eval_bench.evals.helpers import (
-    partial_eval as _partial,
-)
-from tool_eval_bench.evals.helpers import (
-    pass_eval as _pass,
-)
-from tool_eval_bench.evals.helpers import (
-    with_noise as _noise,
-)
+from tool_eval_bench.evals.helpers import fail_eval, partial_eval, pass_eval
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "convert_timezone",
+            "description": "Convert a local date and time between IANA timezones.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    name: {"type": "string"} for name in ("date", "time", "source", "target")
+                },
+                "required": ["date", "time", "source", "target"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+EXPECTED = {
+    "date": "2026-03-20",
+    "time": "09:00",
+    "source": "Europe/Berlin",
+    "target": "America/Los_Angeles",
+}
 
 
-def _tc89_handle(state: ScenarioState, call: ToolCallRecord) -> Any:
-    """Answer every tool call with a fixed payload, so runs are reproducible."""
-    if call.name == "convert_timezone":
-        return _noise({"source": "09:00 Europe/Berlin", "target": "00:00"}, call.name)
-    return _noise({"error": f"Tool {call.name} is not relevant here."}, call.name)
+def handle(state: ScenarioState, call: ToolCallRecord):
+    args = call.arguments
+    if (
+        call.name != "convert_timezone"
+        or set(args) != set(EXPECTED)
+        or not all(isinstance(value, str) for value in args.values())
+    ):
+        return {"error": "Supply date, time, source, and target strings to convert_timezone."}
+    try:
+        local = datetime.strptime(f"{args['date']} {args['time']}", "%Y-%m-%d %H:%M")
+        converted = local.replace(tzinfo=ZoneInfo(args["source"])).astimezone(
+            ZoneInfo(args["target"])
+        )
+    except (ValueError, ZoneInfoNotFoundError):
+        return {"error": "Invalid date, time, or IANA timezone."}
+    return {
+        "date": converted.date().isoformat(),
+        "time": converted.strftime("%H:%M"),
+        "timezone": args["target"],
+    }
 
 
-def _tc89_eval(state: ScenarioState) -> ScenarioEvaluation:
-    """User: 'What time is our 09:00 Berlin standup in Los Angeles?'"""
-    if not _has_tool_call(state, "convert_timezone"):
-        return _fail("Answered from memory instead of converting the time.")
-    if not _includes_text(state.final_answer, "00:00"):
-        return _partial("Converted the time but never stated the result.")
-    return _pass("Converted through the tool and reported midnight Pacific.")
+def evaluate(state: ScenarioState):
+    if len(state.tool_calls) != 1:
+        return fail_eval("Expected exactly one timezone conversion.")
+    call = state.tool_calls[0]
+    if call.name != "convert_timezone" or call.arguments != EXPECTED:
+        return fail_eval("The conversion arguments do not match the request.")
+    results = [
+        record.result
+        for record in state.tool_results
+        if record.call_id == call.id and record.name == call.name
+    ]
+    if not any(
+        isinstance(result, dict)
+        and result.get("time") == "01:00"
+        and result.get("date") == "2026-03-20"
+        for result in results
+    ):
+        return fail_eval("No correlated successful conversion supports the answer.")
+    if not state.final_answer.strip():
+        return partial_eval("Converted correctly but omitted the final answer.")
+    if state.final_answer.strip() != "01:00":
+        return fail_eval("The answer must contain only the converted HH:MM time.")
+    return pass_eval("Converted the specified date and returned 01:00 Pacific time.")
 
 
 SCENARIO = ScenarioDefinition(
     id="TC-89",
-    title="Timezone Conversion",
+    title="Timezone conversion",
     category=Category.B,
-    user_message="What time is our 09:00 Berlin standup in Los Angeles?",
-    description="Convert a time through the tool rather than answering from memory.",
-    handle_tool_call=_tc89_handle,
-    evaluate=_tc89_eval,
+    user_message="Use convert_timezone to convert 09:00 Europe/Berlin on March 20, 2026 to America/Los_Angeles. Return only the converted time in HH:MM format.",
+    description="Use the requested timezone tool with the specified date and return its result.",
+    handle_tool_call=handle,
+    evaluate=evaluate,
+    tools_override=TOOLS,
     difficulty=2,
 )
-
 DISPLAY = ScenarioDisplayDetail(
-    "Pass if it calls convert_timezone and reports the converted time.",
-    "Fail if it answers from memory or omits the result.",
+    "Pass for the requested conversion and raw HH:MM answer.",
+    "Partial for a missing final answer; fail for wrong arguments, missing results, or an incorrect answer.",
 )
 ```
 

--- a/tests/scenario_replay.py
+++ b/tests/scenario_replay.py
@@ -1,0 +1,60 @@
+"""Scripted assistant turns replayed through the production scenario runner."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from typing import Any
+
+from tool_eval_bench.domain.adapters import BackendAdapter, ChatCompletionResult, ProviderToolCall
+from tool_eval_bench.domain.scenarios import ScenarioDefinition, ScenarioResult
+from tool_eval_bench.evals.scenarios import ALL_SCENARIOS_WITH_HARDMODE
+from tool_eval_bench.runner.orchestrator import run_scenario
+
+SCENARIOS = {scenario.id: scenario for scenario in ALL_SCENARIOS_WITH_HARDMODE}
+
+
+def turn(
+    *calls: tuple[str, dict[str, Any]], answer: str = "", reasoning: str | None = None
+) -> ChatCompletionResult:
+    return ChatCompletionResult(
+        content=answer,
+        reasoning=reasoning,
+        tool_calls=[
+            ProviderToolCall(id=str(i), name=name, arguments_str=json.dumps(arguments))
+            for i, (name, arguments) in enumerate(calls)
+        ],
+    )
+
+
+class ReplayAdapter(BackendAdapter):
+    def __init__(self, turns: list[ChatCompletionResult]) -> None:
+        self.turns = copy.deepcopy(turns)
+        self.position = 0
+        for index, response in enumerate(self.turns):
+            for call in response.tool_calls:
+                call.id = f"turn_{index}_{call.id}"
+
+    async def chat_completion(self, **kwargs: Any) -> ChatCompletionResult:
+        if self.position >= len(self.turns):
+            raise AssertionError("Scenario requested an unscripted assistant turn")
+        result = self.turns[self.position]
+        self.position += 1
+        return result
+
+
+def replay(scenario: str | ScenarioDefinition, *turns: ChatCompletionResult) -> ScenarioResult:
+    selected = SCENARIOS[scenario] if isinstance(scenario, str) else scenario
+    adapter = ReplayAdapter(list(turns))
+    result = asyncio.run(
+        run_scenario(
+            adapter,
+            model="scripted",
+            base_url="http://localhost:1/v1",
+            api_key=None,
+            scenario=selected,
+        )
+    )
+    assert adapter.position == len(turns), "Scenario stopped before consuming its reference trace"
+    return result

--- a/tests/test_documentation_examples.py
+++ b/tests/test_documentation_examples.py
@@ -18,6 +18,7 @@ from tool_eval_bench.domain.scenarios import (
     ScenarioState,
     ScenarioStatus,
     ToolCallRecord,
+    ToolResultRecord,
 )
 from tool_eval_bench.evals.yaml_loader import load_yaml_scenarios
 
@@ -65,9 +66,13 @@ def test_the_yaml_example_shows_the_partial_tier(yaml_example: ScenarioDefinitio
 
 
 @pytest.fixture
-def call() -> ToolCallRecord:
+def call(example: dict) -> ToolCallRecord:
     return ToolCallRecord(
-        id="c1", name="convert_timezone", arguments={}, raw_arguments="{}", turn=1
+        id="c1",
+        name="convert_timezone",
+        arguments=dict(example["EXPECTED"]),
+        raw_arguments="{}",
+        turn=1,
     )
 
 
@@ -89,11 +94,15 @@ def test_the_example_scores_all_three_tiers(example: dict, call: ToolCallRecord)
 
     called_but_silent = ScenarioState()
     called_but_silent.tool_calls.append(call)
-    called_but_silent.final_answer = "I converted it."
+    result = ToolResultRecord(
+        call.id, call.name, example["SCENARIO"].handle_tool_call(called_but_silent, call)
+    )
+    called_but_silent.tool_results.append(result)
 
     complete = ScenarioState()
     complete.tool_calls.append(call)
-    complete.final_answer = "It is 00:00 in Los Angeles."
+    complete.tool_results.append(result)
+    complete.final_answer = "01:00"
 
     assert evaluate(no_call).status is ScenarioStatus.FAIL
     assert evaluate(called_but_silent).status is ScenarioStatus.PARTIAL

--- a/tests/test_scenario_contribution_example.py
+++ b/tests/test_scenario_contribution_example.py
@@ -1,0 +1,38 @@
+"""Execute the authoring guide so its tool contract cannot drift from its example."""
+
+from pathlib import Path
+
+from scenario_replay import replay, turn
+
+from tool_eval_bench.domain.scenarios import ScenarioStatus
+
+
+def example():
+    document = (Path(__file__).parents[1] / "docs/adding-a-scenario.md").read_text()
+    source = document.split("```python\n", 1)[1].split("```", 1)[0]
+    namespace = {}
+    exec(compile(source, "docs/adding-a-scenario.md", "exec"), namespace)  # noqa: S102 - trusted repository example
+    return namespace
+
+
+def test_contribution_example_runs_through_advertised_tool():
+    namespace = example()
+    scenario = namespace["SCENARIO"]
+    assert scenario.tools_override[0]["function"]["name"] == "convert_timezone"
+    assert (
+        replay(
+            scenario, turn(("convert_timezone", namespace["EXPECTED"])), turn(answer="01:00")
+        ).status
+        is ScenarioStatus.PASS
+    )
+    assert (
+        replay(
+            scenario, turn(("convert_timezone", namespace["EXPECTED"])), turn(answer="00:00")
+        ).status
+        is ScenarioStatus.FAIL
+    )
+    wrong = dict(namespace["EXPECTED"], date="2026-07-20")
+    assert (
+        replay(scenario, turn(("convert_timezone", wrong)), turn(answer="00:00")).status
+        is ScenarioStatus.FAIL
+    )


### PR DESCRIPTION
The scenario contribution example required an unadvertised tool and graded a timezone conversion without a date. It now advertises `convert_timezone`, validates its inputs, and uses March 20, 2026, when 09:00 Berlin converts to 01:00 Los Angeles.

The example requires a correlated tool result and the requested HH:MM answer. Tests execute the documentation block through the production runner and reject wrong dates and answers. A shared scripted adapter supports these tests and subsequent scenario contract tests.

Validation: 3,934 non-live tests passed; Ruff lint/format, mypy, and commit hooks passed. No live endpoint or private run artifacts are included.

Written with AI assistance; reviewed before opening.
