### PR TITLE
test: decode scenario fixtures as UTF-8 on Windows

### DIFF
--- a/tests/test_live_review_regressions.py
+++ b/tests/test_live_review_regressions.py
@@ -101,9 +101,9 @@ def test_valid_live_answers_receive_full_credit(sid):
 
     from test_scenario_runner_contracts import REFERENCES
 
-    answer = json.loads((Path(__file__).parent / "fixtures/live_review_answers.json").read_text())[
-        sid
-    ]
+    answer = json.loads(
+        (Path(__file__).parent / "fixtures/live_review_answers.json").read_text(encoding="utf-8")
+    )[sid]
     sid = "TC-23" if sid == "TC-23-expanded" else sid
     if sid == "TC-50":
         trace = responses(REFERENCES[sid])

--- a/tests/test_scenario_contribution_example.py
+++ b/tests/test_scenario_contribution_example.py
@@ -8,7 +8,7 @@ from tool_eval_bench.domain.scenarios import ScenarioStatus
 
 
 def example():
-    document = (Path(__file__).parents[1] / "docs/adding-a-scenario.md").read_text()
+    document = (Path(__file__).parents[1] / "docs/adding-a-scenario.md").read_text(encoding="utf-8")
     source = document.split("```python\n", 1)[1].split("```", 1)[0]
     namespace = {}
     exec(compile(source, "docs/adding-a-scenario.md", "exec"), namespace)  # noqa: S102 - trusted repository example

--- a/tests/test_scenario_runner_contracts.py
+++ b/tests/test_scenario_runner_contracts.py
@@ -9,7 +9,7 @@ from scenario_replay import SCENARIOS, replay, turn
 from tool_eval_bench.domain.scenarios import ScenarioStatus
 
 REFERENCES = json.loads(
-    (Path(__file__).parent / "fixtures/scenario_reference_traces.json").read_text()
+    (Path(__file__).parent / "fixtures/scenario_reference_traces.json").read_text(encoding="utf-8")
 )
 
 


### PR DESCRIPTION
Windows uses a legacy default text encoding in the extended test job, so three tests could fail while reading UTF-8 scenario fixtures and documentation. Read those files explicitly as UTF-8 so the post-merge suite behaves consistently across platforms.

Validation:

- `ruff check` and `ruff format --check`
- `.venv/bin/mypy`
- 246 focused tests with the Windows CI seed `199933`
- full pre-push quality gate

Written with AI assistance; reviewed before opening.
